### PR TITLE
Set Up OmuStation Changelog

### DIFF
--- a/Content.Client/Changelog/ChangelogManager.cs
+++ b/Content.Client/Changelog/ChangelogManager.cs
@@ -35,7 +35,7 @@ namespace Content.Client.Changelog
         [Dependency] private readonly IConfigurationManager _configManager = default!;
 
         private const string SawmillName = "changelog";
-        public const string MainChangelogName = "Gooblog";
+        public const string MainChangelogName = "Omulog";
 
         private ISawmill _sawmill = default!;
 

--- a/Resources/Changelog/OmuChangelog.yml
+++ b/Resources/Changelog/OmuChangelog.yml
@@ -1,0 +1,9 @@
+Name: Omulog
+Order: -2
+Entries:
+- author: CerberusWolfie
+  changes:
+    - type: Add
+      message: REEE
+  id: 1
+  time: '2025-08-25T22:06:13.0000000+00:00'

--- a/Resources/Changelog/OmuChangelog.yml
+++ b/Resources/Changelog/OmuChangelog.yml
@@ -1,9 +1,53 @@
 Name: Omulog
 Order: -2
 Entries:
-- author: CerberusWolfie
+- author: Diggy0
   changes:
     - type: Add
-      message: REEE
+      message: Cyberpunk accent added to the accents section in traits.
   id: 1
   time: '2025-08-25T22:06:13.0000000+00:00'
+- author: CliveOcelot
+  changes:
+    - type: Add
+      message: More Xenoborg content from upstream!
+    - type: Tweak
+      message: Felinids return.
+    - type: Fix
+      message: Fixed modsuit helmet's lights, you can see again.
+    - type: Fix
+      message: Fixed CC modsuits not being insulated.
+  id: 2
+  time: '2025-08-25T22:06:14.0000000+00:00'
+- author: ShieldAcrados
+  changes:
+    - type: Add
+      message: Added a new Central Command Shuttle! The CC-557 "Angel"!
+    - type: Add
+      message: Added a new Central Command Intern role, stamp, lanyard, and fax machine!
+    - type: Tweak
+      message: You can now use Lanyards as IDs!
+  id: 3
+  time: '2025-08-25T22:06:15.0000000+00:00'
+- author: dootythefrooty
+  changes:
+    - type: Remove
+      message: Removed Assistant Malus, be free!
+  id: 4
+  time: '2025-08-25T22:06:16.0000000+00:00'
+- author: Cygnis
+  changes:
+    - type: Add
+      message: Added the VC-8 revolver for the Captain.
+    - type: Add
+      message: Added a new revolver for Security Duty Weapon selector.
+    - type: Tweak
+      message: Made the VC-8 not the most OP thing in the universe.
+  id: 5
+  time: '2025-08-25T22:06:17.0000000+00:00'
+- author: Appenzaller
+  changes:
+    - type: Tweak
+      message: Added sec key to BSO's headset.
+  id: 6
+  time: '2025-08-25T22:06:18.0000000+00:00'

--- a/Resources/Locale/en-US/_Omu/changelog/changelog-window.ftl
+++ b/Resources/Locale/en-US/_Omu/changelog/changelog-window.ftl
@@ -1,0 +1,1 @@
+changelog-tab-title-Omulog = Omu

--- a/Tools/changelog/changelog.js
+++ b/Tools/changelog/changelog.js
@@ -156,7 +156,7 @@ function writeChangelog(entry) {
     // Write updated changelogs file
     fs.writeFileSync(
         `../../${process.env.CHANGELOG_DIR}`,
-        "Name: Gooblog\nOrder: -1\nEntries:\n" + // IF YOU ARE A FORK, CHANGE THIS!!!!!!!!!!!!
+        "Name: Omulog\nOrder: -2\nEntries:\n" + // IF YOU ARE A FORK, CHANGE THIS!!!!!!!!!!!!
             yaml.dump(data.Entries, { indent: 2 }).replace(/^---/, "")
     );
 }


### PR DESCRIPTION
## About the PR
This adds the Omu tab to the changelog for this station's changes. It also sets it up as the default for the workflow, so it should work and run everything we want now.

## Why / Balance
Changelogs updating automatically is cool and better. Also this is just an immediate version of #2.

## Technical details
Makes some changes for it, yada yada, makes a separate changelog.

## Media
<img width="455" height="705" alt="image" src="https://github.com/user-attachments/assets/0f81a88c-d878-4254-9642-e2b3dd0f299b" />

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Might break changelog.

**Changelog**
:cl:
- add: Added a changelog!