### PR TITLE
Comments out Barratry

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -72,7 +72,7 @@
 #  - Train # Goobstation - all my friends hate train
   - FlandHighPop
   - OasisHighPop
-# - Barratry # Goobstation - Re-add barratry # Omustation - HEAVEN BRINGS FORTH INUMERABLE THINGS TO NUTURE MAN. MAN HAS NOTHING GOOD WITH WHICH TO RECOMPENSE HEAVEN. BARRATRY. BARRATRY. BARRATRY. BARRATRY. BARRATRY. BARRATRY. BARRATRY.
+# - Barratry # Omu - Trimming map pool.
   - Kettle # Goobstation - Re-add kettle (before it was gemini!)
   - Submarine # goobstation - kill yourse
   - Leonid # Goobstation - for goob by goob

--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -72,7 +72,7 @@
 #  - Train # Goobstation - all my friends hate train
   - FlandHighPop
   - OasisHighPop
-  - Barratry # Goobstation - Re-add barratry
+# - Barratry # Goobstation - Re-add barratry # Omustation - HEAVEN BRINGS FORTH INUMERABLE THINGS TO NUTURE MAN. MAN HAS NOTHING GOOD WITH WHICH TO RECOMPENSE HEAVEN. BARRATRY. BARRATRY. BARRATRY. BARRATRY. BARRATRY. BARRATRY. BARRATRY.
   - Kettle # Goobstation - Re-add kettle (before it was gemini!)
   - Submarine # goobstation - kill yourse
   - Leonid # Goobstation - for goob by goob


### PR DESCRIPTION
## About the PR
Comments Barratry out of (what I believe to be) the map pool.

## Why / Balance
Barratry is a shithole. Despite it being right after the playtest, everyone immediately left because it was Barratry.

## Technical details
Single line change in `Resources/Prototypes/Maps/Pools/default.yml` which comments out barratry, and should hopefully keep it out of the map pool.

## Media
Not sure how I would test this, but if you want me to and tell me how I gladly will.

## Requirements

## Breaking changes
No idea.

**Changelog**
:cl:
- remove: Deleted Barratry from the map pool.
