### PR TITLE
Fix harpy emotes

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/harpy.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/harpy.yml
@@ -159,7 +159,7 @@
   - type: Speech
     speechSounds: Harpy
     speechVerb: Harpy
-    allowedEmotes: ['Chirp', 'Trill', 'Warble', 'Wurble', 'Mars']
+    allowedEmotes: ['Chirp', 'Trill', 'Warble', 'Wurble', 'Mars', 'Chitter', 'Squeak', 'Flap']
   - type: Vocal
     sounds:
       Male: SoundsHarpyMale

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/harpy.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/harpy.yml
@@ -159,7 +159,7 @@
   - type: Speech
     speechSounds: Harpy
     speechVerb: Harpy
-    allowedEmotes: ['Chirp', 'Trill', 'Warble', 'Wurble', 'Mars', 'Chitter', 'Squeak', 'Flap']
+    allowedEmotes: ['Chirp', 'Trill', 'Warble', 'Wurble', 'Mars', 'Chitter', 'Squeak', 'Flap'] # Omu (Chitter, Squeak, Flap)
   - type: Vocal
     sounds:
       Male: SoundsHarpyMale

--- a/Resources/Prototypes/_DV/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/_DV/Voice/speech_emote_sounds.yml
@@ -465,3 +465,4 @@
       path: /Audio/_Goobstation/Voice/gulpexotic.ogg
     Surprised: # Goob
       path: /Audio/_Goobstation/Voice/surprised.ogg
+

--- a/Resources/Prototypes/_DV/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/_DV/Voice/speech_emote_sounds.yml
@@ -121,6 +121,8 @@
       collection: IPCWhirrs
     Hew: # Omu, give harpy more emotes
       collection: Hew
+    Flap: # Omu, give harpy more emotes
+      path: /Audio/_Goobstation/Voice/Moth/moth_flap.ogg
 
 - type: emoteSounds
   id: SoundsHarpyMale
@@ -225,6 +227,8 @@
       collection: IPCWhirrs
     Hew: # Omu, give harpy more emotes
       collection: Hew
+    Flap: # Omu, give harpy more emotes
+      path: /Audio/_Goobstation/Voice/Moth/moth_flap.ogg
 
 - type: emoteSounds
   id: FemaleVulpkanin


### PR DESCRIPTION
## About the PR
I forgot to add the emotes to allowedemotes for harpy.
Allows harpy to Chitter, Squeak, Flap

## Why / Balance
Harpy were meant to have chitter and squeak anyway, they have wings so why not give them flap as well.

## Technical details
Adds Chitter, Squeak, Flap, to allowedemotes for harpy.

## Media
<img width="136" height="68" alt="image" src="https://github.com/user-attachments/assets/a5819c0f-dcc1-4b31-b76d-8a95f1cfcda2" />
<img width="219" height="65" alt="image" src="https://github.com/user-attachments/assets/8ad4e1bb-fdb6-44a9-a024-9dd42f9819b2" />
<img width="116" height="81" alt="image" src="https://github.com/user-attachments/assets/058512e4-d3ca-4721-8e0e-6cd8a5d3ae2f" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add:  Harpy can now Chitter, Squeak, and Flap
