### PR TITLE
Make terminus Oni only, allow it to pry doors again

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/Entities/Objects/Weapons/Melee/terminus.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Objects/Weapons/Melee/terminus.yml
@@ -15,7 +15,7 @@
   id: Terminus
   description: An advanced melee weapon crafted specifically for an oni. It is also capable of firing a spread of disabler shots from its tip.
   components:
-  - type: RestrictedMelee
+  - type: RestrictedMelee # Omu, its made for Oni, so only Oni can use it.
     whitelist:
       tags:
         - Oni
@@ -58,3 +58,9 @@
     - 0,0,4,2
   - type: DisarmMalus
     malus: 0.75
+  - type: Tool # Omu, it should be able to pry doors, it used to on EE, and it should be able to here as well.
+    qualities:
+      - Prying
+    useSound:
+      path: /Audio/Items/crowbar.ogg
+  - type: Prying

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Objects/Weapons/Melee/terminus.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Objects/Weapons/Melee/terminus.yml
@@ -15,6 +15,10 @@
   id: Terminus
   description: An advanced melee weapon crafted specifically for an oni. It is also capable of firing a spread of disabler shots from its tip.
   components:
+  - type: RestrictedMelee
+    whitelist:
+      tags:
+        - Oni
   - type: Sprite
     sprite: _EinsteinEngines/Objects/Weapons/Melee/terminus.rsi
     state: icon

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Objects/Weapons/Melee/terminus.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Objects/Weapons/Melee/terminus.yml
@@ -64,3 +64,5 @@
     useSound:
       path: /Audio/Items/crowbar.ogg
   - type: Prying
+  - type: UseDelay # Omu, this means the crowbar function has a cooldown
+    delay: 0.9


### PR DESCRIPTION
## About the PR
Made it so that the terminus is exclusive to Oni, (its an Oni weapon), allowed it to pry doors (It had this function on EE, it's pretty much a giant axe, and gives some more use to it)

## Why / Balance
It's a weapon designed for Oni, it used to be Oni only, so it shall be Oni only again.

## Technical details
Added RestrictedMelee back, added prying to it.

## Media
<img width="612" height="205" alt="image" src="https://github.com/user-attachments/assets/688df3ef-cf68-48de-a392-8eeb2384b765" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Terminus is back to being Oni only.
- tweak: Terminus can now function as a crowbar again
