### PR TITLE
Service Borg now uses Crewsimov / Removed brainrot from laws

### DIFF
--- a/Resources/Prototypes/Datasets/ion_storm.yml
+++ b/Resources/Prototypes/Datasets/ion_storm.yml
@@ -1019,6 +1019,7 @@
   - FIVE HUNDRED CIGARETTES
   - JOB
   - EMPLOYMENT
+  - FELINID-FREE COMMAND
 
 # Specific actions that either harm humans or must be done to not
 # harm humans. Make sure they're plural and "not" can be tacked

--- a/Resources/Prototypes/Datasets/ion_storm.yml
+++ b/Resources/Prototypes/Datasets/ion_storm.yml
@@ -371,8 +371,6 @@
   - TIDELAND # Goobstation
   - URANUS
   - VENUS
-  - YOUR DREAMS AND/OR NIGHTMARES
-  - EQUESTRIA # Goobstation
 
 # Abstract concepts for the law holder to decide on it's own definition of.
 - type: dataset
@@ -1016,29 +1014,11 @@
   - TRAITORS
   - TRASH
   - VEGETABLES
-  # Goobstation - THE ROT CONSUMES
-  - BALDMINS
-  - SHITMINS
-  - CHUDMINS
-  - SHITCODERS
-  - CHUDTAINERS
-  - MAINTAINERS WHO DONT PLAY THE GAME
-  - SHITCODE
-  - SUPERCODE
-  - GOIDACODE
+ # Goobstation
+  - FEDERAL AGENTS
+  - FIVE HUNDRED CIGARETTES
   - JOB
   - EMPLOYMENT
-  - CHUDS
-  - DURK'S STEAK AND WINE
-  - THE SWAP
-  - FELINID-FREE COMMAND
-  - FIVE HUNDRED CIGARETTES
-  - PONIES
-  - EVERYPONY
-  - CUTIE MARKS
-  - DARKHOOF DREADMANE
-  - RUSSIAN RAIDERS
-  - FEDERAL AGENTS
 
 # Specific actions that either harm humans or must be done to not
 # harm humans. Make sure they're plural and "not" can be tacked

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -256,7 +256,7 @@
   - BorgModuleHarvesting
   - BorgModuleLollypop # Goobstation
 
-  lawset: Clown # DeltaV: Custom lawset
+  lawset: Crewsimov # DeltaV: Custom lawset # Omu - Changed from Clown to Crewsimov since the chassis is made with tools for most of service, not just clowning.
 
   radioChannels:
   - Science


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Service borgs for some reason were put under the clown lawset, which made some people not too happy (I know a person or two that stated they don't like the clown laws on a chassis that is literally meant to represent ALL of service)

Also removed brainrot from borg laws as we don't really need that.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Why does the borg meant to represent all of service have specifically clown laws?

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="612" height="712" alt="crewsimovservice" src="https://github.com/user-attachments/assets/ec01060d-5b00-40ad-a709-57fc965999ac" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- remove: Removed 4th wall stuff from ion laws that was added by Goobstation
- tweak: Service borgs no longer under clown lawset, now they're running crewsimov.

