### PR TITLE
Fix flashes

### DIFF
--- a/Content.Server/Flash/FlashSystem.cs
+++ b/Content.Server/Flash/FlashSystem.cs
@@ -238,8 +238,8 @@ namespace Content.Server.Flash
                 if (used == null)
                     return;
 
-                _popup.PopupEntity(Loc.GetString("flash-component-user-head-rev",
-                        ("victim", Identity.Entity(target, EntityManager))), target);
+               // _popup.PopupEntity(Loc.GetString("flash-component-user-head-rev", // Omu, this shouldn't be enabled, as it is shown in a different system instead
+               //         ("victim", Identity.Entity(target, EntityManager))), target);
             }  // funkystation end
         }
 


### PR DESCRIPTION
## About the PR
Fixes it showing the headrev popup when you flash something regardless of if you are actualy a headrev.

## Why / Balance
It shows this in another system, having it here breaks the point of it (it shows regardless of if the user is a headrev or not)

## Technical details
Comments out the lines that shouldn't be there.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed flashes showing the headrev popup when it is not the headrev using them.
