### PR TITLE
Allow traits to not increment MaxTraits

### DIFF
--- a/Content.Client/Lobby/LobbyUIController.cs
+++ b/Content.Client/Lobby/LobbyUIController.cs
@@ -305,7 +305,9 @@ public sealed class LobbyUIController : UIController, IOnStateEntered<LobbyState
         {
             var trait = _prototypeManager.Index(traitProto);
             traitPoints -= trait.GlobalCost;
-            numTraits++;
+
+            if (trait.CountsTowardsMaxTraits)
+                numTraits++;
 
             // if the saved profile will have unmet requirements, take note of it
             if (!_requirements.CheckTraitRequirements(trait, EditedProfile, out var unmetRequirements))

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -759,8 +759,10 @@ namespace Content.Client.Lobby.UI
                 if (selector.Preference)
                 {
                     selectionCount += trait.Cost;
-                    _selectedTraitCount++;
                     _selectedTraitPointCount -= trait.GlobalCost;
+
+                    if (trait.CountsTowardsMaxTraits)
+                        _selectedTraitCount++;
                 }
 
                 // Make sure that the player meets the requirements to select this trait. If they don't the trait is locked.
@@ -783,14 +785,18 @@ namespace Content.Client.Lobby.UI
                     (_selectedTraitCount < _maxTraits || _maxTraits <= 0)) // make sure the player isn't selecting more traits than they're allowed
                     {
                         Profile = Profile?.WithTraitPreference(trait.ID, _prototypeManager);
-                        _selectedTraitCount++;
                         _selectedTraitPointCount -= trait.GlobalCost;
+
+                        if (trait.CountsTowardsMaxTraits)
+                            _selectedTraitCount++;
                     }
                     else
                     {
                         Profile = Profile?.WithoutTraitPreference(trait.ID, _prototypeManager);
-                        _selectedTraitCount--;
                         _selectedTraitPointCount += trait.GlobalCost;
+
+                        if (trait.CountsTowardsMaxTraits)
+                            _selectedTraitCount--;
                     }
 
                     SetDirty();

--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -351,8 +351,10 @@ namespace Content.Server.GameTicking
             foreach (var traitProtoId in character.TraitPreferences)
             {
                 var traitProto = _prototypeManager.Index(traitProtoId);
-                numSelectedTraits++;
                 traitPoints -= traitProto.GlobalCost;
+
+                if (traitProto.CountsTowardsMaxTraits)
+                    numSelectedTraits++;
 
                 // if the trait exists, and the character is not allowed to have it
                 if (traitProto != null &&

--- a/Content.Shared/Traits/TraitPrototype.cs
+++ b/Content.Shared/Traits/TraitPrototype.cs
@@ -103,6 +103,13 @@ public sealed partial class TraitPrototype : IPrototype
     public int GlobalCost = 0;
 
     /// <summary>
+    ///     Whether this trait will increment MaxTraits or not. 
+    ///     Useful for small traits, such as accents, which don't affect gameplay all that much and should be selectable at no cost.
+    /// </summary>
+    [DataField]
+    public bool CountsTowardsMaxTraits = true;
+
+    /// <summary>
     ///     Functions which should be called when this trait is added to a player.
     /// </summary>
     [DataField(serverOnly: true)]

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -23,6 +23,7 @@
     - type: MothAccent
     - type: ReplacementAccent
       accent: dwarf
+  countsTowardsMaxTraits: false # Omustation - Don't count accents towards max traits
 
 # 1 Cost
 
@@ -34,6 +35,7 @@
   cost: 1
   components:
   - type: SouthernAccent
+  countsTowardsMaxTraits: false # Omustation - Don't count accents towards max traits
 
 - type: trait
   id: PirateAccent
@@ -43,6 +45,7 @@
   cost: 1
   components:
   - type: PirateAccent
+  countsTowardsMaxTraits: false # Omustation - Don't count accents towards max traits
 
 - type: trait
   id: CowboyAccent
@@ -53,6 +56,7 @@
   components:
   - type: ReplacementAccent
     accent: cowboy
+  countsTowardsMaxTraits: false # Omustation - Don't count accents towards max traits
 
 - type: trait
   id: GermanAccent
@@ -62,6 +66,7 @@
   cost: 1
   components:
   - type: GermanAccent
+  countsTowardsMaxTraits: false # Omustation - Don't count accents towards max traits
 
 - type: trait
   id: ItalianAccent
@@ -72,6 +77,7 @@
   components:
   - type: ReplacementAccent
     accent: italian
+  countsTowardsMaxTraits: false # Omustation - Don't count accents towards max traits
 
 - type: trait
   id: FrenchAccent
@@ -81,6 +87,7 @@
   cost: 1
   components:
   - type: FrenchAccent
+  countsTowardsMaxTraits: false # Omustation - Don't count accents towards max traits
 
 - type: trait
   id: SpanishAccent
@@ -90,6 +97,7 @@
   cost: 1
   components:
   - type: SpanishAccent
+  countsTowardsMaxTraits: false # Omustation - Don't count accents towards max traits
 
 - type: trait
   id: Liar
@@ -100,6 +108,7 @@
   components:
   - type: ReplacementAccent
     accent: liar
+  countsTowardsMaxTraits: false # Omustation - Don't count accents towards max traits
 
 # 2 Cost
 
@@ -115,6 +124,7 @@
     fourRandomProb: 0
     threeRandomProb: 0
     cutRandomProb: 0
+  countsTowardsMaxTraits: false # Omustation - Don't count accents towards max traits
 
 - type: trait
   id: FrontalLisp
@@ -124,3 +134,4 @@
   cost: 2
   components:
   - type: FrontalLisp
+  countsTowardsMaxTraits: false # Omustation - Don't count accents towards max traits

--- a/Resources/Prototypes/_EinsteinEngines/Traits/languages.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Traits/languages.yml
@@ -11,6 +11,12 @@
   - type: ForeignerTrait
     cantUnderstand: false
     baseTranslator: TranslatorForeigner
+  countsTowardsMaxTraits: false # Omustation - Don't count languages towards max traits
+  requirements: # Omustation - Don't allow forigner and forigner light to be used at the same time
+    - !type:TraitsRequirement
+      traits:
+        - Foreigner
+      inverted: true
 
 - type: trait
   id: Foreigner
@@ -21,6 +27,7 @@
   components:
   - type: ForeignerTrait
     baseTranslator: TranslatorForeigner
+  countsTowardsMaxTraits: false # Omustation - Don't count languages towards max traits
 
 - type: trait
   id: SignLanguage
@@ -30,6 +37,7 @@
   cost: 1
   components:
   - type: LanguageSpeaker
+  countsTowardsMaxTraits: false # Omustation - Don't count languages towards max traits
   languagesSpoken:
     - Sign
   languagesUnderstood:
@@ -44,6 +52,7 @@
   cost: 1
   components:
   - type: LanguageSpeaker
+  countsTowardsMaxTraits: false # Omustation - Don't count languages towards max traits
   languagesSpoken:
     - SolCommon
   languagesUnderstood:
@@ -57,6 +66,7 @@
   cost: 1
   components:
   - type: LanguageSpeaker
+  countsTowardsMaxTraits: false # Omustation - Don't count languages towards max traits
   languagesSpoken:
     - Tradeband
   languagesUnderstood:
@@ -70,6 +80,7 @@
   cost: 1
   components:
   - type: LanguageSpeaker
+  countsTowardsMaxTraits: false # Omustation - Don't count languages towards max traits
   languagesSpoken:
     - Freespeak
   languagesUnderstood:
@@ -83,6 +94,7 @@
   cost: 1
   components:
   - type: LanguageSpeaker
+  countsTowardsMaxTraits: false # Omustation - Don't count languages towards max traits
   languagesSpoken:
     - Elyran
   languagesUnderstood:
@@ -110,6 +122,7 @@
   cost: 1
   components:
   - type: LanguageSpeaker
+  countsTowardsMaxTraits: false # Omustation - Don't count languages towards max traits
   languagesSpoken:
     - NovuNederic
   languagesUnderstood:

--- a/Resources/Prototypes/_Goobstation/Traits/speech.yml
+++ b/Resources/Prototypes/_Goobstation/Traits/speech.yml
@@ -21,6 +21,7 @@
   components:
   - type: ReplacementAccent
     accent: dementia
+  countsTowardsMaxTraits: false # Omustation - Don't count accents towards max traits
 
 - type: trait
   id: ScottishAccent
@@ -31,6 +32,7 @@
   components:
   - type: ReplacementAccent
     accent: scottish
+  countsTowardsMaxTraits: false # Omustation - Don't count accents towards max traits
 
 - type: trait
   id: Bogan
@@ -41,6 +43,7 @@
   components:
   - type: ReplacementAccent
     accent: bogan
+  countsTowardsMaxTraits: false # Omustation - Don't count accents towards max traits
 
 - type: trait
   id: MedievalAccent
@@ -50,6 +53,7 @@
   cost: 1
   components:
   - type: MedievalAccent
+  countsTowardsMaxTraits: false # Omustation - Don't count accents towards max traits
 
 - type: trait
   id: british
@@ -60,3 +64,4 @@
   components:
   - type: ReplacementAccent
     accent: british
+  countsTowardsMaxTraits: false # Omustation - Don't count accents towards max traits

--- a/Resources/Prototypes/_NF/Traits/speech.yml
+++ b/Resources/Prototypes/_NF/Traits/speech.yml
@@ -8,5 +8,6 @@
   cost: 1
   components:
     - type: StreetpunkAccent
+  countsTowardsMaxTraits: false # Omustation - Don't count accents towards max traits
 
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->
<!--- LICENSE: AGPL -->

## About the PR
This PR gives traits the option not to increment the player's max trait count.

## Why / Balance
Traits such as accents don't affect gameplay all that much, so penalizing the player for taking them is unnecessary.
Also the foreigner trait can no longer be selected alongside foreigner light.

## Technical details
A field has been added to the traits prototype. Some logic has been updated. YAML prototypes have been updated.

## Media
<i> The game says that the player has selected 0/14 traits, in spite of some languages being selected. Trying to save foreigner light with foreigner results in a "confirm save" popup and prevents the player from joining the shift. </i>
<img width="630" height="347" alt="image" src="https://github.com/user-attachments/assets/7e6f881d-ed90-438a-a10e-9e21c3d26e03" />

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.