### PR TITLE
Fixes the station having the CC whitelist added to it.

### DIFF
--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -102,6 +102,7 @@ using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using Content.Shared.DeviceNetwork.Components;
+using Content.Shared._Omu.Shuttles.Components; // Omu, allow CC shuttles to FTL to CC
 
 namespace Content.Server.Shuttles.Systems;
 
@@ -623,7 +624,7 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
             QueueDel(grid);
             return;
         }
-
+        _ = EnsureComp<MapCentcommComponent>(map); // Omu, add marker component to CC
         if (!Exists(grid))
         {
             Log.Error($"Failed to set up centcomm grid!");

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -277,7 +277,8 @@ public sealed partial class ShuttleSystem
             return false;
 
         component = EnsureComp<FTLDestinationComponent>(mapUid);
-        component.Whitelist = CCWhitelist; // Omu, allow CC shuttles to FTL to CC
+        if (HasComp<MapCentcommComponent>(mapUid)) // Omu, CC whitelist should only be added to CC
+            component.Whitelist = CCWhitelist; // Omu, allow CC shuttles to FTL to CC
         if (component.Enabled == enabled && component.RequireCoordinateDisk == requireDisk && component.BeaconsOnly == beaconsOnly)
             return true;
         

--- a/Content.Shared/_Omu/Shuttles/Components/MapCentCommComponent.cs
+++ b/Content.Shared/_Omu/Shuttles/Components/MapCentCommComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Omu.Shuttles.Components;
+
+/// <summary>
+/// Marker component for the CentComm map.
+/// Used for CentComm's FTL whitelist.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class MapCentcommComponent : Component;


### PR DESCRIPTION
## About the PR
Added a comp for CC's map, ensured that the map gets this comp, checks for this comp in addftldestination, if it's found it adds the CC whitelist.

## Why / Balance
Bugfix good.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed stations having the CC shuttle whitelist added to them.
