### PR TITLE
Salvage Change

### DIFF
--- a/Content.Server/_Lavaland/Pressure/PressureDamageChangeComponent.cs
+++ b/Content.Server/_Lavaland/Pressure/PressureDamageChangeComponent.cs
@@ -31,7 +31,7 @@ public sealed partial class PressureDamageChangeComponent : Component
     public bool Enabled = true;
 
     [DataField]
-    public float LowerBound = Atmospherics.OneAtmosphere * 0.2f;
+    public float LowerBound = Atmospherics.OneAtmosphere * 0.0f;
 
     [DataField]
     public float UpperBound = Atmospherics.OneAtmosphere * 0.5f;

--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -165,21 +165,21 @@
           - ChunkDebrisSmall
           - ChunkDebrisSmall
           - ChunkDebris
-        # goob - no vgroid
-        #vgroid: !type:DungeonSpawnGroup
-        #  minimumDistance: 300
-        #  maximumDistance: 350
-        #  nameDataset: NamesBorer
-        #  stationGrid: false
-        #  addComponents:
-        # - type: Gravity
-        #    enabled: true
-        #    inherent: true
-        #  - type: IFF
-        #    flags: HideLabel
-        #    color: "#d67e27"
-        #  protos:
-        #  - VGRoid
+
+        vgroid: !type:DungeonSpawnGroup #OMU change, Re-adds VGroid, Yippee!
+          minimumDistance: 300
+          maximumDistance: 350
+          nameDataset: NamesBorer
+          stationGrid: false
+          addComponents:
+         - type: Gravity
+            enabled: true
+            inherent: true
+          - type: IFF
+            flags: HideLabel
+            color: "#d67e27"
+          protos:
+          - VGRoid
 
 - type: entity
   id: BaseStationCentcomm


### PR DESCRIPTION
[<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Re-adds the VGroid and allows PKA to work in space

## Why / Balance
Lets salvage work in space without being useless and gives them back the VGroid

## Technical details
Un-comments VGroid and sets minimum pressure for PKA to 0.0

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

