### PR TITLE
Add pressure protection check to slime water damage

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -177,7 +177,7 @@
           types:
             Heat: 0.1
         conditions:
-        - !type:HasComponentOnEquipmentCondition
+        - !type:HasComponentOnEquipmentCondition # omu edit - make suits protect slimes from water damage
           components:
           - type: PressureProtection
           invert: true
@@ -187,7 +187,7 @@
         messages: [ "slime-hurt-by-water-popup" ]
         probability: 0.25
         conditions:
-        - !type:HasComponentOnEquipmentCondition
+        - !type:HasComponentOnEquipmentCondition # omu edit - make suits protect slimes from water damage
           components:
           - type: PressureProtection
           invert: true


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->
## About the PR
Makes slimes no longer take damage from water if they have pressure protection.

## Why / Balance
This allows slimes to have the silly interaction without being gimped in combat. It also makes sense that the water can't touch them through an airtight space suit.

## Media
https://github.com/user-attachments/assets/d1a827b3-c7ca-4a02-9cf3-5cda06f66fc5

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Slimes no longer take damage from water through spacesuits
