### PR TITLE
Replace HEAD tags with empty in station reports

### DIFF
--- a/Content.Goobstation.Server/StationReport/StationReportDiscordIntergrationSystem.cs
+++ b/Content.Goobstation.Server/StationReport/StationReportDiscordIntergrationSystem.cs
@@ -38,15 +38,15 @@ public sealed class StationReportDiscordIntergrationSystem : EntitySystem
         new(@"\[/?italic\]", @"_"),
         new(@"\[/?mono\]", @"__"),
         new(@">", @""),
-        new(@"\[h1\]", @"# "),
-        new(@"\[h2\]", @"## "),
-        new(@"\[h3\]", @"### "),
-        new(@"\[h4\]", @"-# "),
+        new(@"\[h1\]", @""), // Omu, make head be replaced with empty, was # 
+        new(@"\[h2\]", @""), // Omu, make head be replaced with empty, was ## 
+        new(@"\[h3\]", @""), // Omu, make head be replaced with empty, was ###
+        new(@"\[h4\]", @""), // Omu, make head be replaced with empty, was -# 
         new(@"\[/h[0-9]\]", @""),
-        new(@"\[head=1\]", @"# "),
-        new(@"\[head=2\]", @"## "),
-        new(@"\[head=3\]", @"### "),
-        new(@"\[head=4\]", @"-# "),
+        new(@"\[head=1\]", @""), // Omu, make head be replaced with empty, was # 
+        new(@"\[head=2\]", @""), // Omu, make head be replaced with empty, was ## 
+        new(@"\[head=3\]", @""), // Omu, make head be replaced with empty, was ### 
+        new(@"\[head=4\]", @""), // Omu, make head be replaced with empty, was -# 
         new(@"\[/head\]", @""),
         new(@"\[/?color(=[#0-9a-zA-Z]+)?\]", @"")
     };


### PR DESCRIPTION
## About the PR
Replace [head] tags with empty in station reports, as discord only supports head formating at the start of a line.

## Why / Balance
Fen said it was a good idea, I agree with them.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Station Report now removes any [head] tags, instead of sending an incorrectly formated message to discord.
