### PR TITLE
Fix revs

### DIFF
--- a/Content.Server/Flash/FlashSystem.cs
+++ b/Content.Server/Flash/FlashSystem.cs
@@ -230,7 +230,6 @@ namespace Content.Server.Flash
 
             if (melee || revFlash)  // funkystation start
             {
-                var ev = new AfterFlashedEvent(target, user, used);
 
                 if (user == null)
                     return;
@@ -238,9 +237,10 @@ namespace Content.Server.Flash
                 if (used == null)
                     return;
 
-               // _popup.PopupEntity(Loc.GetString("flash-component-user-head-rev", // Omu, this shouldn't be enabled, as it is shown in a different system instead
-               //         ("victim", Identity.Entity(target, EntityManager))), target);
-            }  // funkystation end
+                var ev = new AfterFlashedEvent(target, user, used);
+                RaiseLocalEvent(user.Value, ref ev);
+                RaiseLocalEvent(used.Value, ref ev);
+            } // funkystation end
         }
 
         public override void FlashArea(Entity<FlashComponent?> source, EntityUid? user, float range, float duration, float slowTo = 0.8f, bool displayPopup = false, float probability = 1f, SoundSpecifier? sound = null)


### PR DESCRIPTION
## About the PR
Made it so revs can actually convert, since it was raising the event in the wrong order

## Why / Balance
Bugfix

## Technical details
Copied the code from latest on Funky

## Media
<img width="275" height="213" alt="image" src="https://github.com/user-attachments/assets/5888e2c3-e68e-4140-9b75-520e1d3caa6d" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed revs being unable to convert