### PR TITLE
[HOTFIX] Added missing Cough Up Chitzite action

### DIFF
--- a/Resources/Prototypes/_DV/Actions/types.yml
+++ b/Resources/Prototypes/_DV/Actions/types.yml
@@ -65,6 +65,6 @@
     icon:
       sprite: _DV/Objects/Specific/Species/chitinid.rsi
       state: chitzite
-    useDelay: 300
+    useDelay: 120
   - type: InstantAction
     event: !type:CoughItemActionEvent

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
@@ -136,6 +136,10 @@
     understands:
     - TauCetiBasic
     - Moffic
+  - type: ItemCougher  # OmuStation
+    item: Chitzite # OmuStation
+    action: ActionChitzite # OmuStation
+    coughPopup: chitzite-cough # OmuStation - Durk fully implements a bounty challenge ( IMPOSSIBLE )
 
 - type: entity
   parent: BaseSpeciesDummy


### PR DESCRIPTION
Also reduces the action delay from 5 minutes to 2.

<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Added missing PukeChitzite action to Chitinids

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fix :3  
Besides that, the cooldown thing. The individual is only able to self-cleanse 30 points of rad damage before a danger rocks needs puking. 5 minutes between pukes is a ridiculous time to wait for what is essentially re-activating a headlining feature.

## Technical details
<!-- Summary of code changes for easier review. -->
`Resources/Prototypes/_DV/Actions/types.yml` edit of cooldown here, bottom of the file under `ActionChitzite`
`Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml` Chitinid composition found here, added the missing action component to the bottom.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed Chitinids not being able to puke up their Chitzite. Have fun throwing angry rocks!