### PR TITLE
Avoid Discord Webhook character limit for Station Reports

### DIFF
--- a/Content.Goobstation.Server/StationReport/StationReportDiscordIntergrationSystem.cs
+++ b/Content.Goobstation.Server/StationReport/StationReportDiscordIntergrationSystem.cs
@@ -85,9 +85,7 @@ public sealed class StationReportDiscordIntergrationSystem : EntitySystem
                 // 1) Prefer a newline
                 var splitAt = text.LastIndexOf('\n', end - 1, take);
                 if (splitAt >= start)
-                {
                     end = splitAt + 1; // include the newline
-                }
                 else
                 {
                     // 2) Prefer sentence boundary (". ", "! ", "? ", "… ")
@@ -104,17 +102,13 @@ public sealed class StationReportDiscordIntergrationSystem : EntitySystem
                     }
     
                     if (bestBoundary >= start)
-                    {
                         end = bestBoundary;
-                    }
                     else
                     {
                         // 3) Fall back to last whitespace
                         var lastSpace = text.LastIndexOf(' ', end - 1, take);
                         if (lastSpace >= start)
-                        {
                             end = lastSpace + 1;
-                        }
                         // 4) Otherwise, hard cut at end (avoid infinite loop)
                     }
                 }
@@ -130,7 +124,16 @@ public sealed class StationReportDiscordIntergrationSystem : EntitySystem
     {
         if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(_webhookUrl))
             return;
-    
+        //var payload = new { content = message };
+        //var json = System.Text.Json.JsonSerializer.Serialize(payload);
+        //var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        //try
+        //{
+        //    var response = await client.PostAsync(_webhookUrl, content);
+        //    response.EnsureSuccessStatusCode();
+        //}
+        //catch (Exception)
         foreach (var chunk in SplitDiscordMessage(message, DiscordSoftLimit)) // Omu - avoid hitting the Discord character limit of 200 by splitting up the payload
         {
             var payload = new { content = chunk };

--- a/Content.Goobstation.Server/StationReport/StationReportDiscordIntergrationSystem.cs
+++ b/Content.Goobstation.Server/StationReport/StationReportDiscordIntergrationSystem.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text.RegularExpressions;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -16,6 +17,7 @@ public sealed class StationReportDiscordIntergrationSystem : EntitySystem
     //thank you Timfa for writing this code
     private static readonly HttpClient client = new();
     [Dependency] private readonly IConfigurationManager _cfg = default!;
+    private const int DiscordSoftLimit = 1800; // Omu - keep headroom under 2000
 
     private string? _webhookUrl;
 
@@ -65,23 +67,88 @@ public sealed class StationReportDiscordIntergrationSystem : EntitySystem
         _ = SendMessageAsync(report);
     }
 
+    // Omu - Split Discord messages to avoid hitting the character limit
+    private static IEnumerable<string> SplitDiscordMessage(string text, int chunkSize)
+    {
+        if (string.IsNullOrEmpty(text))
+            yield break;
+    
+        var start = 0;
+        while (start < text.Length)
+        {
+            var remaining = text.Length - start;
+            var take = Math.Min(chunkSize, remaining);
+            var end = start + take;
+    
+            if (end < text.Length)
+            {
+                // 1) Prefer a newline
+                var splitAt = text.LastIndexOf('\n', end - 1, take);
+                if (splitAt >= start)
+                {
+                    end = splitAt + 1; // include the newline
+                }
+                else
+                {
+                    // 2) Prefer sentence boundary (". ", "! ", "? ", "… ")
+                    var bestBoundary = -1;
+                    static int LastIndexOfSpan(string s, string token, int endExclusive, int searchLen)
+                        => s.LastIndexOf(token, endExclusive - 1, searchLen, StringComparison.Ordinal);
+    
+                    var candidates = new[] { ". ", "! ", "? ", "… " };
+                    foreach (var token in candidates)
+                    {
+                        var idx = LastIndexOfSpan(text, token, end, take);
+                        if (idx >= start)
+                            bestBoundary = Math.Max(bestBoundary, idx + token.Length);
+                    }
+    
+                    if (bestBoundary >= start)
+                    {
+                        end = bestBoundary;
+                    }
+                    else
+                    {
+                        // 3) Fall back to last whitespace
+                        var lastSpace = text.LastIndexOf(' ', end - 1, take);
+                        if (lastSpace >= start)
+                        {
+                            end = lastSpace + 1;
+                        }
+                        // 4) Otherwise, hard cut at end (avoid infinite loop)
+                    }
+                }
+            }
+    
+            var chunk = text.Substring(start, end - start);
+            yield return chunk;
+            start = end;
+        }
+    }
+    
     private async Task SendMessageAsync(string message)
     {
         if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(_webhookUrl))
             return;
-
-        var payload = new { content = message };
-        var json = System.Text.Json.JsonSerializer.Serialize(payload);
-        var content = new StringContent(json, Encoding.UTF8, "application/json");
-
-        try
+    
+        foreach (var chunk in SplitDiscordMessage(message, DiscordSoftLimit)) // Omu - avoid hitting the Discord character limit of 200 by splitting up the payload
         {
-            var response = await client.PostAsync(_webhookUrl, content);
-            response.EnsureSuccessStatusCode();
-        }
-        catch (Exception)
-        {
-
+            var payload = new { content = chunk };
+            var json = System.Text.Json.JsonSerializer.Serialize(payload);
+            using var content = new StringContent(json, Encoding.UTF8, "application/json");
+    
+            try
+            {
+                using var response = await client.PostAsync(_webhookUrl, content);
+                response.EnsureSuccessStatusCode();
+            }
+            catch (Exception)
+            {
+                // Optionally log
+            }
+    
+            // Pause ~0.5s between posts (except after the last one) to ease up on a rate limit
+            await Task.Delay(500);
         }
     }
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Split up the Station Report sent to a Discord Webhook so it won't hit the 2000 character limit and break, allowing for longer reports to be submitted.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The Discord limit is at a hard 2000 characters, while the station report supports up to 10000. Handling this limit in Discord is preferable over limiting the report length in-game.
## Technical details
<!-- Summary of code changes for easier review. -->
The code will first take the message and split it up in chunks of around 1800 characters. It will initially try to split on a linebreak, and if none are found within a chunk on a sentence ender. If that's not possible either, we split on spaces, and if even that fails, we hard cut the sentence.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Nothing player-facing changes within the game.
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
The station report sent through the Discord Webhook is first passed through another funtion to split it up in chunks, and will then send all chunks one-by-one.
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed station reports over 2000 characters being blocked by Discord and not showing up in the reports channel.
