### PR TITLE
Fix > escaping going wrong

### DIFF
--- a/Content.Goobstation.Server/StationReport/StationReportDiscordIntergrationSystem.cs
+++ b/Content.Goobstation.Server/StationReport/StationReportDiscordIntergrationSystem.cs
@@ -45,7 +45,7 @@ public sealed class StationReportDiscordIntergrationSystem : EntitySystem
         new(@"\[/?bold\]", @"**"),
         new(@"\[/?italic\]", @"_"),
         new(@"\[/?mono\]", @"__"),
-        new(@">", @""),
+        // new(@">", @""), // Omu, was causing issues with > escaping in the Discord markdown block
         new(@"\[h1\]", @""), // Omu, make head be replaced with empty, was # 
         new(@"\[h2\]", @""), // Omu, make head be replaced with empty, was ## 
         new(@"\[h3\]", @""), // Omu, make head be replaced with empty, was ###


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Comment out > replacemetns, as it was causing issues now that it's escaped earlier in the code.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It would first replace > with \>, and then replace it again, leaving only a \ that messed up formatting coming after
## Technical details
<!-- Summary of code changes for easier review. -->
I added `//`

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] I'm really cool
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed double replacement of a > character in Station Reports in Discord, causing the markdown to be messed up
