### PR TITLE
Allow AI turret controls to set a proper whitelist

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/turret_controls.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/turret_controls.yml
@@ -187,12 +187,12 @@
     exemptAccessLevels:
     - BasicSilicon
     - Borg
-  - type: DeployableTurretController
-    accessGroups:
-    - Silicon
-    accessLevels:
-    - BasicSilicon
-    - Borg
+#  - type: DeployableTurretController # Omu, commenting this out means that the turret control can change its whitelist to allow other jobs.
+#    accessGroups:
+#    - Silicon
+#    accessLevels:
+#    - BasicSilicon
+#    - Borg
 
 - type: entity
   parent: WeaponEnergyTurretStationControlPanelBase


### PR DESCRIPTION
## About the PR
Someone made it so that the turret control could only whitelist borg access?, this makes it so that it can whitelist other access, but still defaults to silicon only.

## Why / Balance
Allows AI to clearly define who they want near their core.

## Technical details
Comments out some yml

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Allowed AI to set whitelists on their turrets properly.
