### PR TITLE
Remove shrapnel from syndie uplink, raise price in nukeops uplink

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -654,20 +654,20 @@
       - NukeOpsUplink
 
 
-- type: listing
-  id: UplinkGrenadeShrapnel
-  name: uplink-shrapnel-grenade-name
-  description: uplink-shrapnel-grenade-desc
-  productEntity: GrenadeShrapnel
-  cost:
-    Telecrystal: 8 # goob
-  categories:
-  - UplinkExplosives
-  conditions: # Goob, two times cheaper for nukies
-  - !type:StoreWhitelistCondition
-    blacklist:
-      tags:
-      - NukeOpsUplink
+#- type: listing # Omu, This thing 3 shots deathsquad, this should not be in the uplink.
+#  id: UplinkGrenadeShrapnel
+#  name: uplink-shrapnel-grenade-name
+#  description: uplink-shrapnel-grenade-desc
+#  productEntity: GrenadeShrapnel
+#  cost:
+#    Telecrystal: 8 # goob
+#  categories:
+#  - UplinkExplosives
+#  conditions: # Goob, two times cheaper for nukies
+#  - !type:StoreWhitelistCondition
+#    blacklist:
+#      tags:
+#      - NukeOpsUplink
 
 
 - type: listing

--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -273,7 +273,7 @@
   description: uplink-shrapnel-grenade-desc
   productEntity: GrenadeShrapnel
   cost:
-    Telecrystal: 4
+    Telecrystal: 20 # Omu, raise price from 4 to 20, this grenade 3 shots deathsquad, it should not be 4tc.
   categories:
   - UplinkExplosives
   conditions:


### PR DESCRIPTION
## About the PR
Removed the shrapnel grenade from syndie uplink, raised its price from 4tc to 20tc in nukeops uplink, as this grenade will one-shot any normal person, and lifeline a deathsquad in 3 shots.

## Why / Balance
Shrapnel grenade acted as the grenade of instant death, and was absurdly cheap, so this makes it so that syndies have to actually use lathes and make their own shrapnel grenades, rather than having a dirt cheap grenade that instantly kills people.

## Technical details
Comments it out from the standard uplink, raises price on the nukie listing.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- remove: Removed the shrapnel grenade from syndie uplink.
- tweak: Changed the price of the shrapnel grenade from 4tc to 20tc in the nukie uplink
