### PR TITLE
Make Cosmic Blank ability have a hidden do-after

### DIFF
--- a/Content.Server/_DV/CosmicCult/Abilities/CosmicBlankSystem.cs
+++ b/Content.Server/_DV/CosmicCult/Abilities/CosmicBlankSystem.cs
@@ -70,7 +70,7 @@ public sealed class CosmicBlankSystem : EntitySystem
         var doargs = new DoAfterArgs(EntityManager, uid, uid.Comp.CosmicBlankDelay, new EventCosmicBlankDoAfter(), uid, args.Target)
         {
             DistanceThreshold = 1.5f,
-            Hidden = false,
+            Hidden = true, // Omu, was false, this ability allows coscult to get some more stealthy converts early on, and doesnt have that much use in later stages, it should be a hidden do-after.
             BreakOnDamage = true,
             BreakOnMove = true,
             BreakOnDropItem = true,


### PR DESCRIPTION
## About the PR
Made the cosmic blank ability (the one that puts you into a wisp), have a hidden do-after, as it serves little to no purpose in combat, but allows for less meta-gamed converts with a hidden do-after.

## Why / Balance
Saw people metagame the do-after one to many times.

## Technical details
Change a false to a true

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Cosmic blank now has a hidden do-after.
