### PR TITLE
Fix secretplus failing to start

### DIFF
--- a/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusSystem.cs
+++ b/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusSystem.cs
@@ -239,7 +239,7 @@ public sealed class SecretPlusSystem : GameRuleSystem<SecretPlusComponent>
         var primaryWeightList = _prototypeManager.Index(scheduler.Comp.PrimaryAntagsWeightTable);
         var weightList = _prototypeManager.Index(scheduler.Comp.RoundStartAntagsWeightTable);
 
-        var count = GetTotalPlayerCount(_playerManager.Sessions);
+        var count = GameTicker.ReadyPlayerCount(); //GetTotalPlayerCount(_playerManager.Sessions); // Omu, this should only check for players that are ready.
 
         LogMessage($"Trying to run roundstart rules, total player count: {count}", false);
 


### PR DESCRIPTION
## About the PR
Made it so secretplus checks for players ready, instead of server pop.

## Why / Balance
Caused most rounds to fail to start.

## Technical details
Copied code from SecretClassic

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed SecretPlus failing to select antags properly