### PR TITLE
Remove Other Rule Entries

### DIFF
--- a/Resources/Prototypes/Guidebook/rules.yml
+++ b/Resources/Prototypes/Guidebook/rules.yml
@@ -18,9 +18,11 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+
 - type: guideEntry # Default for forks and stuff. Should not be listed anywhere if the server is using a custom ruleset.
   id: DefaultRuleset
   name: guide-entry-rules
+  ruleEntry: true # Omu - removes from guidebook without removing it entirely.
   priority: 60
   text: "/ServerInfo/Guidebook/ServerRules/DefaultRules.xml"
   children:

--- a/Resources/Prototypes/_Goobstation/Guidebook/rules.yml
+++ b/Resources/Prototypes/_Goobstation/Guidebook/rules.yml
@@ -8,5 +8,6 @@
 - type: guideEntry
   id: NRPRuleset
   name: guide-entry-rules-nrp
+  ruleEntry: true # Omu - removes from guidebook without removing it entirely.
   priority: 60
   text: "/ServerInfo/Guidebook/ServerRules/NRPRules.xml"

--- a/Resources/Prototypes/_Omu/Guidebook/rules.yml
+++ b/Resources/Prototypes/_Omu/Guidebook/rules.yml
@@ -1,9 +1,10 @@
 - type: guideEntry
   id: OmuRuleset
   name: guide-entry-rules
-  ruleEntry: true
   priority: 1
   text: "/ServerInfo/_Omu/Guidebook/ServerRules/OmuRules.xml"
+  children:
+  - Conditions
 
 ## Core Rules
 - type: guideEntry


### PR DESCRIPTION
## About the PR
This just adds `ruleEntry: true` to the prototypes for the guidebook entries. Since they are not locked as the default ruleset, they will not show up due to this parameter.

## Why / Balance
Need I explain why?

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
Not player facing.