### PR TITLE
Fixed sunglasses erroneously toggling photophobia

### DIFF
--- a/Content.Client/_Omu/Traits/PhotophobiaSystem.cs
+++ b/Content.Client/_Omu/Traits/PhotophobiaSystem.cs
@@ -1,7 +1,8 @@
+using Content.Client._Omu.Eye;
 using Content.Shared._Omu.Traits;
 using Content.Shared.Flash.Components;
+using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
-using Content.Client._Omu.Eye;
 using Robust.Client.Graphics;
 using Robust.Client.Player;
 using Robust.Shared.Player;
@@ -64,9 +65,7 @@ public sealed class PhotophobiaSystem : SharedPhotophobiaSystem
     private void OnPhotophobiaShutdown(Entity<PhotophobiaComponent> ent, ref ComponentShutdown args)
     {
         if (_player.LocalEntity == ent.Owner)
-        {
             _overlayMan.RemoveOverlay(_overlay);
-        }
     }
 
     /// <summary>
@@ -74,7 +73,8 @@ public sealed class PhotophobiaSystem : SharedPhotophobiaSystem
     /// </summary>
     private void OnSunglassesEquipped(Entity<FlashImmunityComponent> ent, ref GotEquippedEvent args)
     {
-        _overlayMan.RemoveOverlay(_overlay);
+        if (_player.LocalEntity == args.Equipee && args.SlotFlags != SlotFlags.POCKET)
+            _overlayMan.RemoveOverlay(_overlay);
     }
 
     /// <summary>
@@ -82,7 +82,8 @@ public sealed class PhotophobiaSystem : SharedPhotophobiaSystem
     /// </summary>
     private void OnSunglassesUnequipped(Entity<FlashImmunityComponent> ent, ref GotUnequippedEvent args)
     {
-        _overlayMan.AddOverlay(_overlay);
+        if (_player.LocalEntity == args.Equipee && args.SlotFlags != SlotFlags.POCKET)
+            _overlayMan.AddOverlay(_overlay);
     }
 
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!--- LICENSE: AGPL -->
## About the PR
Other players within PVS who equipped and unequipped their sunglasses would toggle photophobia for the local player, regardless of whether they had the photophobia trait. This resulted in two issues:
- One is that almost every client would be refreshing the photophobia shader constantly, which invokes a TryComp on the local player for a photophobia component, which would result in some (very very minor) undue lag on players without photophobia.
- The other is that players with a photophobia component would have photophobia toggled by other players taking their glasses on and off.

This PR also fixes another bug:
- Sunglasses placed into a pocket would count as "worn" for the sake of photophobia.

## Why / Balance
Bugfix.

## Technical details
Added two `If` statements, did some slight cleanup to the system (removed a set of brackets and put the using directives in alphabetical order)

## Media
not needed.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
