### PR TITLE
modified shadowkin damage vulnerabilities

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Damage/modifier_sets.yml
@@ -24,17 +24,17 @@
     Ion: 0.8
   ignoreArmorPierceFlags: All
 
-# begin Omu - shadowkin take less brute and heat now, but take 40% more radiation
 - type: damageModifierSet
   id: Shadowkin
   coefficients:
+# begin Omu - shadowkin take less brute and heat now, but take 40% more radiation
     Blunt: 1.15
     Slash: 1.15
     Piercing: 1.15
     Asphyxiation: 0.50
     Radiation: 1.4
+    # end Omu
   ignoreArmorPierceFlags: All # Goobstation
-# end Omu
 
 - type: damageModifierSet
   id: Plasmaman


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
shadowkin now take 10% less brute (all types) than before and no longer have burn vulnerability, however they now also have a 40% radiation vulnerability
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
shadowkin are now somewhat more survivable, although flashes still drop them
## Technical details
<!-- Summary of code changes for easier review. -->
damage values changed, all yaml
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
hit the urist with each of the items (other than hypo and bottle) + 1 unit unstable mutagen (hypospray/bottle)
<img width="464" height="448" alt="image" src="https://github.com/user-attachments/assets/620b33e7-9b54-4315-8b3b-150e0f0955b0" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: shadowkin brute damage has been reduced from 25% to 15%, burn 40% vulnerability has been replaced with radiation
