### PR TITLE
Admeme: TemuViro,

### DIFF
--- a/Content.Client/Drunk/DrunkOverlay.cs
+++ b/Content.Client/Drunk/DrunkOverlay.cs
@@ -35,8 +35,9 @@ public sealed class DrunkOverlay : Overlay
 
     public float CurrentBoozePower = 0.0f;
 
-    private const float VisualThreshold = 10.0f;
-    private const float PowerDivisor = 250.0f;
+    // Visual effect parameters
+    private const float VisualThreshold = 0f; // Start showing effect immediately at any strength
+    private const float PowerDivisor = 100.0f; // Scale to 0-1 range for the shader
 
     private float _visualScale = 0;
 

--- a/Content.Goobstation.Server/_Omu/AdminEvents/TemuViro/TemuViroSystem.cs
+++ b/Content.Goobstation.Server/_Omu/AdminEvents/TemuViro/TemuViroSystem.cs
@@ -1,0 +1,90 @@
+using Content.Goobstation.Shared._Omu.AdminEvents.TemuViro;
+using Content.Goobstation.Shared._Omu.AdminEvents.TemuViro.Components;
+using Content.Shared.Administration.Logs;
+using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.Database;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Popups;
+using Robust.Shared.Timing;
+using Content.Server.Medical;
+using Content.Shared.Mobs.Systems;
+
+namespace Content.Goobstation.Server._Omu.AdminEvents.TemuViro;
+
+public sealed class TemuViroSystem : SharedTemuViroSystem
+{
+    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+    [Dependency] private readonly ISharedAdminLogManager _adminLogManager = default!;
+    [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
+    [Dependency] private readonly VomitSystem _vomitSystem = default!;
+
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<TemuViroComponent, SolutionContainerChangedEvent>(OnSolutionChanged);
+        SubscribeLocalEvent<TemuViroComponent, MapInitEvent>(OnMapInit);
+    }
+
+    private void OnMapInit(EntityUid uid, TemuViroComponent component, MapInitEvent args)
+    {
+        // Admin Logging
+        _adminLogManager.Add(LogType.AdminMessage,
+            LogImpact.Extreme,
+            $"{ToPrettyString(uid)} has been infected with Temu Virus");
+    }
+
+    #region Solution Container Events / Cure Handling (When injected)
+    private void OnSolutionChanged(Entity<TemuViroComponent> entity, ref SolutionContainerChangedEvent args)
+    {
+        var (uid, component) = entity;
+
+        // Ensure the entity is not cured
+        if (entity.Comp.IsCured)
+            return;
+
+        // Only process if this is NOT a change to the bloodstream
+        if (args.SolutionId == "bloodstream")
+            return;
+
+        // Get the solution from the event args
+        var solution = args.Solution;
+        if (solution is null)
+            return;
+
+        // Get the current amount of cure chemical in the solution
+        var currentAmount = solution.GetTotalPrototypeQuantity(component.CureChemical);
+        // Process the cure chemical if present
+        if (currentAmount > 0)
+            ProcessCureChemical(uid, component.CureChemical, (float)currentAmount, component);
+    }
+
+    public void ProcessCureChemical(EntityUid uid, string reagentId, float amount, TemuViroComponent? component = null)
+    {
+        if (!Resolve(uid, ref component) || component.IsCured)
+            return;
+
+        // Increase cure progress
+        component.CureProgress += amount;
+        // Check if cured
+        if (component.CureProgress >= component.CureAmountNeeded)
+        {
+            component.IsCured = true;
+
+            // Admin Log
+            _adminLogManager.Add(LogType.AdminMessage,
+                LogImpact.Medium,
+                $"{ToPrettyString(uid)} has been cured of Temu Virus");
+
+            // Show popup after 5 seconds
+            Timer.Spawn(TimeSpan.FromSeconds(5), () =>
+            {
+                if (EntityManager.EntityExists(uid))
+                {
+                    _popupSystem.PopupEntity("You feel better.", uid, PopupType.Medium);
+                }
+            });
+        }
+    }
+    #endregion
+}

--- a/Content.Goobstation.Server/_Omu/AdminEvents/TemuViro/TemuViroSystem.cs
+++ b/Content.Goobstation.Server/_Omu/AdminEvents/TemuViro/TemuViroSystem.cs
@@ -69,20 +69,18 @@ public sealed class TemuViroSystem : SharedTemuViroSystem
         // Check if cured
         if (component.CureProgress >= component.CureAmountNeeded)
         {
-            component.IsCured = true;
-
-            // Admin Log
-            _adminLogManager.Add(LogType.AdminMessage,
-                LogImpact.Medium,
-                $"{ToPrettyString(uid)} has been cured of Temu Virus");
-
             // Show popup after 5 seconds
             Timer.Spawn(TimeSpan.FromSeconds(5), () =>
             {
-                if (EntityManager.EntityExists(uid))
-                {
-                    _popupSystem.PopupEntity("You feel better.", uid, PopupType.Medium);
-                }
+                if (!EntityManager.EntityExists(uid))
+                    return;
+                // Admin Log
+                _adminLogManager.Add(LogType.AdminMessage,
+                    LogImpact.Medium,
+                    $"{ToPrettyString(uid)} has been cured of Temu Virus");
+
+                component.IsCured = true;
+                _popupSystem.PopupEntity("You feel better.", uid, PopupType.Medium);
             });
         }
     }

--- a/Content.Goobstation.Server/_Omu/AdminEvents/TemuViro/TemuViroSystem.cs
+++ b/Content.Goobstation.Server/_Omu/AdminEvents/TemuViro/TemuViroSystem.cs
@@ -1,5 +1,6 @@
 using Content.Goobstation.Shared._Omu.AdminEvents.TemuViro;
 using Content.Goobstation.Shared._Omu.AdminEvents.TemuViro.Components;
+using Content.Goobstation.Shared._Omu.AdminEvents.TemuViro.Events;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Database;
@@ -24,6 +25,7 @@ public sealed class TemuViroSystem : SharedTemuViroSystem
         base.Initialize();
         SubscribeLocalEvent<TemuViroComponent, SolutionContainerChangedEvent>(OnSolutionChanged);
         SubscribeLocalEvent<TemuViroComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<TemuViroComponent, OnVomitEvent>(OnVomit);
     }
 
     private void OnMapInit(EntityUid uid, TemuViroComponent component, MapInitEvent args)
@@ -70,19 +72,36 @@ public sealed class TemuViroSystem : SharedTemuViroSystem
         if (component.CureProgress >= component.CureAmountNeeded)
         {
             // Show popup after 5 seconds
-            Timer.Spawn(TimeSpan.FromSeconds(5), () =>
-            {
-                if (!EntityManager.EntityExists(uid))
-                    return;
-                // Admin Log
-                _adminLogManager.Add(LogType.AdminMessage,
-                    LogImpact.Medium,
-                    $"{ToPrettyString(uid)} has been cured of Temu Virus");
+            Timer.Spawn(TimeSpan.FromSeconds(5),
+                () =>
+                {
+                    if (!EntityManager.EntityExists(uid))
+                        return;
+                    // Admin Log
+                    _adminLogManager.Add(LogType.AdminMessage,
+                        LogImpact.Medium,
+                        $"{ToPrettyString(uid)} has been cured of Temu Virus");
 
-                component.IsCured = true;
-                _popupSystem.PopupEntity("You feel better.", uid, PopupType.Medium);
-            });
+                    component.IsCured = true;
+                    _popupSystem.PopupEntity("You feel better.", uid, PopupType.Medium);
+                });
         }
+    }
+    #endregion
+
+    #region Vomit
+    private void OnVomit(Entity<TemuViroComponent> entity, ref OnVomitEvent args)
+    {
+        var target = GetEntity(args.Entity);
+        
+        if (!TryComp<TemuViroComponent>(target, out var comp) || 
+            comp.IsCured || 
+            !_mobStateSystem.IsAlive(target))
+        {
+            return;
+        }
+
+        _vomitSystem.Vomit(target, 5f, 1f);
     }
     #endregion
 }

--- a/Content.Goobstation.Server/_Omu/AdminEvents/TemuViro/TemuViroSystem.cs
+++ b/Content.Goobstation.Server/_Omu/AdminEvents/TemuViro/TemuViroSystem.cs
@@ -18,6 +18,8 @@ public sealed class TemuViroSystem : SharedTemuViroSystem
     [Dependency] private readonly ISharedAdminLogManager _adminLogManager = default!;
     [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
     [Dependency] private readonly VomitSystem _vomitSystem = default!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+
 
 
     public override void Initialize()
@@ -71,20 +73,29 @@ public sealed class TemuViroSystem : SharedTemuViroSystem
         // Check if cured
         if (component.CureProgress >= component.CureAmountNeeded)
         {
-            // Show popup after 5 seconds
-            Timer.Spawn(TimeSpan.FromSeconds(5),
-                () =>
-                {
-                    if (!EntityManager.EntityExists(uid))
-                        return;
-                    // Admin Log
-                    _adminLogManager.Add(LogType.AdminMessage,
-                        LogImpact.Medium,
-                        $"{ToPrettyString(uid)} has been cured of Temu Virus");
+            if (!EntityManager.EntityExists(uid))
+                return;
 
-                    component.IsCured = true;
-                    _popupSystem.PopupEntity("You feel better.", uid, PopupType.Medium);
-                });
+            // Admin Log
+            _adminLogManager.Add(LogType.AdminMessage,
+                LogImpact.Medium,
+                $"{ToPrettyString(uid)} has been cured of Temu Virus");
+
+            component.IsCured = true;
+
+            // Send OnCuredEvent to Shared
+            if (component.OnCuredTime == TimeSpan.Zero)
+            {
+                component.OnCuredTime = _gameTiming.CurTime + TimeSpan.FromSeconds(5f);
+                return;
+            }
+
+            if (component.OnCuredTime <= _gameTiming.CurTime)
+            {
+                var netEntity = GetNetEntity(uid);
+                var ev = new OnCuredEvent(netEntity, true);
+                RaiseLocalEvent(uid, ref ev);
+            }
         }
     }
     #endregion
@@ -93,9 +104,9 @@ public sealed class TemuViroSystem : SharedTemuViroSystem
     private void OnVomit(Entity<TemuViroComponent> entity, ref OnVomitEvent args)
     {
         var target = GetEntity(args.Entity);
-        
-        if (!TryComp<TemuViroComponent>(target, out var comp) || 
-            comp.IsCured || 
+
+        if (!TryComp<TemuViroComponent>(target, out var comp) ||
+            comp.IsCured ||
             !_mobStateSystem.IsAlive(target))
         {
             return;

--- a/Content.Goobstation.Shared/_Omu/AdminEvents/TemuViro/Components/TemuViroComponent.cs
+++ b/Content.Goobstation.Shared/_Omu/AdminEvents/TemuViro/Components/TemuViroComponent.cs
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2025 RichardBlonski <48651647+RichardBlonski@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Robust.Shared.Serialization;
+
+namespace Content.Goobstation.Shared._Omu.AdminEvents.TemuViro.Components;
+[RegisterComponent, Serializable, NetSerializable, AutoGenerateComponentState]
+
+public sealed partial class TemuViroComponent : Component
+{
+    /// <summary>
+    /// The ID of the chemical that cures this condition.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadOnly)]
+    public string CureChemical = "CE235"; // Custom Chem
+
+    /// <summary>
+    /// The minimum time at which the status effect can be applied to the player.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadOnly)]
+    public TimeSpan MinEffectTime = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// The maximum time at which the status effect can be applied to the player.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadOnly)]
+    public TimeSpan MaxEffectTime = TimeSpan.FromSeconds(5);
+    /// <summary>
+    /// The actual calculated time when the effect will be applied.
+    /// This is set when the component is added to an entity.
+    /// </summary>
+    [DataField]
+    public TimeSpan EffectTime { get; set; }
+
+    /// <summary>
+    /// Current amount of poison damage accumulated.
+    /// </summary>
+    [DataField]
+    public float PoisonDamage { get; set; }
+
+    /// <summary>
+    /// Maximum amount of poison damage that can be accumulated.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float MaxPoisonDamage { get; set; } = 50f;
+
+    /// <summary>
+    /// Minimum poison damage applied per vomiting event.
+    /// </summary>
+    [DataField]
+    public int MinPoisonDamagePerEffect { get; set; } = 1;
+
+    /// <summary>
+    /// Maximum poison damage applied per vomiting event.
+    /// </summary>
+    [DataField]
+    public int MaxPoisonDamagePerEffect { get; set; } = 5;
+
+    /// <summary>
+    /// Maximum drunkenness intensity at max poison damage.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadOnly)]
+    public float MaxDrunkenness = 5f;
+
+    /// <summary>
+    /// Current drunkenness effect value.
+    /// </summary>
+    [ViewVariables]
+    public float CurrentDrunkenness => Math.Clamp(
+        PoisonDamage / MaxPoisonDamage * MaxDrunkenness,
+        0f,
+        MaxDrunkenness
+    );
+
+
+
+    #region Networked stuff
+    /// <summary>
+    /// Percentage chance (0-100) for the effect to trigger each interval
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public double RandomChance { get; set; }
+
+    /// <summary>
+    /// Current progress towards being cured.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float CureProgress { get; set; }
+
+    /// <summary>
+    /// Total amount of cure chemical needed to be cured.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadOnly), AutoNetworkedField]
+    public float CureAmountNeeded { get; set; } = 5;
+
+    /// <summary>
+    /// Whether the condition has been cured.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadOnly), AutoNetworkedField]
+    public bool IsCured { get; set; }
+    #endregion
+}

--- a/Content.Goobstation.Shared/_Omu/AdminEvents/TemuViro/Components/TemuViroComponent.cs
+++ b/Content.Goobstation.Shared/_Omu/AdminEvents/TemuViro/Components/TemuViroComponent.cs
@@ -26,12 +26,6 @@ public sealed partial class TemuViroComponent : Component
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadOnly)]
     public TimeSpan MaxEffectTime = TimeSpan.FromSeconds(5);
-    /// <summary>
-    /// The actual calculated time when the effect will be applied.
-    /// This is set when the component is added to an entity.
-    /// </summary>
-    [DataField]
-    public TimeSpan EffectTime { get; set; }
 
     /// <summary>
     /// Current amount of poison damage accumulated.
@@ -73,7 +67,7 @@ public sealed partial class TemuViroComponent : Component
     /// <summary>
     /// Total amount of cure chemical needed to be cured.
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadOnly), AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public float CureAmountNeeded { get; set; } = 5;
 
     /// <summary>
@@ -81,5 +75,24 @@ public sealed partial class TemuViroComponent : Component
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadOnly), AutoNetworkedField]
     public bool IsCured { get; set; }
+
+    #endregion
+
+    #region Timers
+    // Vomit _gameTiming.CurTime
+    [DataField]
+    public TimeSpan NextVomitTime { get; set; }
+
+    // Cured _gameTiming.CurTime
+    [DataField]
+    public TimeSpan OnCuredTime { get; set; }
+
+    /// <summary>
+    /// The actual calculated time when the effect will be applied.
+    /// This is set when the component is added to an entity.
+    /// </summary>
+    [DataField]
+    public TimeSpan EffectTime { get; set; }
+
     #endregion
 }

--- a/Content.Goobstation.Shared/_Omu/AdminEvents/TemuViro/Components/TemuViroComponent.cs
+++ b/Content.Goobstation.Shared/_Omu/AdminEvents/TemuViro/Components/TemuViroComponent.cs
@@ -2,10 +2,10 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-using Robust.Shared.Serialization;
+using Robust.Shared.GameStates;
 
 namespace Content.Goobstation.Shared._Omu.AdminEvents.TemuViro.Components;
-[RegisterComponent, Serializable, NetSerializable, AutoGenerateComponentState]
+[RegisterComponent, AutoGenerateComponentState, NetworkedComponent]
 
 public sealed partial class TemuViroComponent : Component
 {
@@ -56,24 +56,6 @@ public sealed partial class TemuViroComponent : Component
     /// </summary>
     [DataField]
     public int MaxPoisonDamagePerEffect { get; set; } = 5;
-
-    /// <summary>
-    /// Maximum drunkenness intensity at max poison damage.
-    /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadOnly)]
-    public float MaxDrunkenness = 5f;
-
-    /// <summary>
-    /// Current drunkenness effect value.
-    /// </summary>
-    [ViewVariables]
-    public float CurrentDrunkenness => Math.Clamp(
-        PoisonDamage / MaxPoisonDamage * MaxDrunkenness,
-        0f,
-        MaxDrunkenness
-    );
-
-
 
     #region Networked stuff
     /// <summary>

--- a/Content.Goobstation.Shared/_Omu/AdminEvents/TemuViro/Events/TemuViroEvents.cs
+++ b/Content.Goobstation.Shared/_Omu/AdminEvents/TemuViro/Events/TemuViroEvents.cs
@@ -5,3 +5,7 @@ namespace Content.Goobstation.Shared._Omu.AdminEvents.TemuViro.Events;
 
 [ByRefEvent]
 public readonly record struct OnVomitEvent(NetEntity Entity);
+
+[ByRefEvent]
+public readonly record struct OnCuredEvent(NetEntity Entity, bool ShowPopup = false);
+

--- a/Content.Goobstation.Shared/_Omu/AdminEvents/TemuViro/Events/TemuViroEvents.cs
+++ b/Content.Goobstation.Shared/_Omu/AdminEvents/TemuViro/Events/TemuViroEvents.cs
@@ -1,0 +1,7 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Goobstation.Shared._Omu.AdminEvents.TemuViro.Events;
+
+
+[ByRefEvent]
+public readonly record struct OnVomitEvent(NetEntity Entity);

--- a/Content.Goobstation.Shared/_Omu/AdminEvents/TemuViro/TemuViroSystem.cs
+++ b/Content.Goobstation.Shared/_Omu/AdminEvents/TemuViro/TemuViroSystem.cs
@@ -2,7 +2,10 @@ using Content.Goobstation.Shared._Omu.AdminEvents.TemuViro.Components;
 using Content.Goobstation.Shared._Omu.AdminEvents.TemuViro.Events;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
+using Content.Shared.Drunk;
 using Content.Shared.Popups;
+using Content.Shared.StatusEffect;
+using Content.Shared.StatusEffectNew.Components;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
@@ -15,11 +18,13 @@ public abstract class SharedTemuViroSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
+    [Dependency] private readonly SharedDrunkSystem _drunkSystem = default!;
 
     public override void Initialize()
     {
         base.Initialize();
         SubscribeLocalEvent<TemuViroComponent, ComponentStartup>(OnStartup);
+        SubscribeLocalEvent<TemuViroComponent, OnCuredEvent>(OnCured);
     }
 
     private void OnStartup(EntityUid uid, TemuViroComponent component, ComponentStartup args)
@@ -49,7 +54,6 @@ public abstract class SharedTemuViroSystem : EntitySystem
         {
             if (comp.IsCured)
                 continue;
-
             if (_gameTiming.CurTime < comp.EffectTime)
                 continue;
 
@@ -61,19 +65,28 @@ public abstract class SharedTemuViroSystem : EntitySystem
                 ApplyPoisonDamage(uid, comp);
                 _popupSystem.PopupEntity("You feel nauseous", uid, PopupType.MediumCaution);
 
+                // Drunk
+                ApplyDrunkEffect(uid, comp);
+
                 // Vomit
-                var netEntity = GetNetEntity(uid);
-                var vomitEvent = new OnVomitEvent(netEntity);
-                Timer.Spawn(TimeSpan.FromSeconds(5),
-                    () =>
+                if (comp.NextVomitTime == TimeSpan.Zero)
+                {
+                    comp.NextVomitTime = _gameTiming.CurTime + TimeSpan.FromSeconds(5f);
+                    return;
+                }
+                    if (_gameTiming.CurTime >= comp.NextVomitTime)
                     {
+                        var netEntity = GetNetEntity(uid);
+                        var vomitEvent = new OnVomitEvent(netEntity);
                         RaiseLocalEvent(uid, ref vomitEvent);
-                    });
+                        comp.NextVomitTime = TimeSpan.Zero;
+                    }
             }
             SetNextEffectTime(uid, comp);
         }
     }
 
+    #region Poision
     private void ApplyPoisonDamage(EntityUid uid, TemuViroComponent comp)
     {
         if (comp.PoisonDamage >= comp.MaxPoisonDamage)
@@ -89,4 +102,26 @@ public abstract class SharedTemuViroSystem : EntitySystem
             comp.PoisonDamage += damage;
         }
     }
+    #endregion
+
+    #region Drunk
+    private void ApplyDrunkEffect(EntityUid uid, TemuViroComponent comp)
+    {
+        TryComp<StatusEffectsComponent>(uid, out var status);
+
+        // Calculate drunk strength based on poison damage (0-45 damage maps to 0-100 strength)
+        float drunkStrength = Math.Clamp(comp.PoisonDamage / 45f * 100f, 0f, 100f);
+        _drunkSystem.SetDrunkeness(uid, drunkStrength, status);
+    }
+
+    #endregion
+
+    #region Cured Event
+    // This gets called by the server when we have set Cured to true
+    // This avoid thread timeout issues
+    private void OnCured(EntityUid uid, TemuViroComponent comp, OnCuredEvent args)
+    {
+        _popupSystem.PopupEntity("You feel better.", uid, PopupType.Medium);
+    }
+    #endregion
 }

--- a/Content.Goobstation.Shared/_Omu/AdminEvents/TemuViro/TemuViroSystem.cs
+++ b/Content.Goobstation.Shared/_Omu/AdminEvents/TemuViro/TemuViroSystem.cs
@@ -1,0 +1,80 @@
+using Content.Goobstation.Shared._Omu.AdminEvents.TemuViro.Components;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Prototypes;
+using Content.Shared.Popups;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
+
+
+namespace Content.Goobstation.Shared._Omu.AdminEvents.TemuViro;
+
+public abstract class SharedTemuViroSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+    [Dependency] private readonly DamageableSystem _damageable = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<TemuViroComponent, ComponentStartup>(OnStartup);
+    }
+
+    private void OnStartup(EntityUid uid, TemuViroComponent component, ComponentStartup args)
+    {
+        if (component.EffectTime == TimeSpan.Zero)
+        {
+            SetNextEffectTime(uid, component);
+        }
+    }
+
+    private void SetNextEffectTime(EntityUid uid, TemuViroComponent component)
+    {
+        component.EffectTime = _gameTiming.CurTime + TimeSpan.FromSeconds(
+            Random.Shared.Next(
+                (int)component.MinEffectTime.TotalSeconds,
+                (int)component.MaxEffectTime.TotalSeconds + 1
+            )
+        );
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<TemuViroComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (comp.IsCured)
+                continue;
+
+            if (_gameTiming.CurTime < comp.EffectTime)
+                continue;
+
+            // Check if effect should trigger based on RandomChance
+            comp.RandomChance = Random.Shared.NextDouble();
+            if (comp.RandomChance < 50f)
+            {
+                ApplyPoisonDamage(uid, comp);
+            }
+            SetNextEffectTime(uid, comp);
+        }
+    }
+
+    private void ApplyPoisonDamage(EntityUid uid, TemuViroComponent comp)
+    {
+        if (comp.PoisonDamage >= comp.MaxPoisonDamage)
+            return;
+
+        var damage = Random.Shared.Next(comp.MinPoisonDamagePerEffect, comp.MaxPoisonDamagePerEffect + 1);
+        damage = (int)Math.Min(damage, comp.MaxPoisonDamage - comp.PoisonDamage);
+
+        if (damage > 0 && _prototypeManager.TryIndex<DamageTypePrototype>("Poison", out var damageType))
+        {
+            var damageSpecifier = new DamageSpecifier(damageType, damage);
+            _damageable.TryChangeDamage(uid, damageSpecifier);
+            comp.PoisonDamage += damage;
+        }
+    }
+}

--- a/Content.Goobstation.Shared/_Omu/AdminEvents/TemuViro/TemuViroSystem.cs
+++ b/Content.Goobstation.Shared/_Omu/AdminEvents/TemuViro/TemuViroSystem.cs
@@ -56,7 +56,9 @@ public abstract class SharedTemuViroSystem : EntitySystem
             comp.RandomChance = Random.Shared.NextDouble();
             if (comp.RandomChance < 50f)
             {
+                // Apply effects & Popup
                 ApplyPoisonDamage(uid, comp);
+                _popupSystem.PopupEntity("You feel nauseous", uid, PopupType.Medium);
             }
             SetNextEffectTime(uid, comp);
         }

--- a/Content.Goobstation.Shared/_Omu/AdminEvents/TemuViro/TemuViroSystem.cs
+++ b/Content.Goobstation.Shared/_Omu/AdminEvents/TemuViro/TemuViroSystem.cs
@@ -1,4 +1,5 @@
 using Content.Goobstation.Shared._Omu.AdminEvents.TemuViro.Components;
+using Content.Goobstation.Shared._Omu.AdminEvents.TemuViro.Events;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.Popups;
@@ -58,7 +59,16 @@ public abstract class SharedTemuViroSystem : EntitySystem
             {
                 // Apply effects & Popup
                 ApplyPoisonDamage(uid, comp);
-                _popupSystem.PopupEntity("You feel nauseous", uid, PopupType.Medium);
+                _popupSystem.PopupEntity("You feel nauseous", uid, PopupType.MediumCaution);
+
+                // Vomit
+                var netEntity = GetNetEntity(uid);
+                var vomitEvent = new OnVomitEvent(netEntity);
+                Timer.Spawn(TimeSpan.FromSeconds(5),
+                    () =>
+                    {
+                        RaiseLocalEvent(uid, ref vomitEvent);
+                    });
             }
             SetNextEffectTime(uid, comp);
         }

--- a/Content.Shared/Drunk/DrunkComponent.cs
+++ b/Content.Shared/Drunk/DrunkComponent.cs
@@ -7,8 +7,16 @@
 // SPDX-License-Identifier: MIT
 
 using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared.Drunk;
 
-[RegisterComponent, NetworkedComponent]
-public sealed partial class DrunkComponent : Component { }
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class DrunkComponent : Component
+{
+    /// <summary>
+    /// Direct strength of the drunk effect (0-100)
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
+    public float Strength { get; set; } = 0f;
+}

--- a/Content.Shared/Drunk/DrunkSystem.cs
+++ b/Content.Shared/Drunk/DrunkSystem.cs
@@ -28,8 +28,8 @@ public abstract class SharedDrunkSystem : EntitySystem
 
     [Dependency] private readonly StatusEffectsSystem _statusEffectsSystem = default!;
     [Dependency] private readonly SharedSlurredSystem _slurredSystem = default!;
-    [Dependency] private readonly IGameTiming _timing = default!; // Goob - needed to calculate remaining status time. 
-    [Dependency] private readonly IConfigurationManager _cfg = default!; // Goob - used to get the CVar setting. 
+    [Dependency] private readonly IGameTiming _timing = default!; // Goob - needed to calculate remaining status time.
+    [Dependency] private readonly IConfigurationManager _cfg = default!; // Goob - used to get the CVar setting.
 
     public void TryApplyDrunkenness(EntityUid uid, float boozePower, bool applySlur = true,
         StatusEffectsComponent? status = null)
@@ -76,4 +76,43 @@ public abstract class SharedDrunkSystem : EntitySystem
         _statusEffectsSystem.TryRemoveTime(uid, DrunkKey, TimeSpan.FromSeconds(timeRemoved));
     }
 
+    /// <summary>
+    /// Directly sets the drunk effect strength
+    /// </summary>
+    /// <param name="uid">The entity to apply the effect to</param>
+    /// <param name="strength">The strength of the drunk effect (0-100). Set to 0 to remove the effect.</param>
+    public void SetDrunkeness(EntityUid uid, float strength, StatusEffectsComponent? status = null)
+    {
+        if (!Resolve(uid, ref status, false))
+            return;
+
+        if (strength <= 0)
+        {
+            // Remove the effect if strength is 0 or negative
+            _statusEffectsSystem.TryRemoveStatusEffect(uid, DrunkKey);
+            return;
+        }
+
+        // Add or update the status effect with the component
+        if (_statusEffectsSystem.TryAddStatusEffect<DrunkComponent>(
+            uid,
+            DrunkKey,
+            TimeSpan.FromMinutes(500f), // Duration is irrelevant as we control the effect through the component
+            true,
+            status))
+        {
+            // If we successfully added the status effect, get the component and set the strength
+            if (TryComp<DrunkComponent>(uid, out var drunkComponent))
+            {
+                drunkComponent.Strength = strength;
+                Dirty(uid, drunkComponent);
+            }
+        }
+        // If the effect already exists, update its strength
+        else if (TryComp<DrunkComponent>(uid, out var existingDrunk))
+        {
+            existingDrunk.Strength = strength;
+            Dirty(uid, existingDrunk);
+        }
+    }
 }

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1816,3 +1816,20 @@
       - !type:AdjustReagent
         reagent: MindbreakerToxin
         amount: -3.0
+
+# Omu - Admeme, TemuViro
+- type: reagent
+  id: CE235
+  name: CE-235
+  group: Medicine
+  desc: Central Command told us to try this, will this work? we don't know.
+  physicalDesc: A thick, white and sticky liquid that smells like burned glue.
+  flavor: glue
+  color: "#BAD3E8"
+  metabolisms:
+    Medicine:
+      effects:
+      - !type:GenericStatusEffect
+        key: CE235Cure
+        component: TemuViroComponent
+        IsCured: true

--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -574,3 +574,18 @@
       amount: 1
   products:
     ArtifactGlue: 2
+
+# Omu - Admeme, TemuViro
+- type: reaction
+  id: CE235Synthesis
+  impact: Medium
+  minTemp: 350  # Requires some heat to catalyze
+  reactants:
+    SpaceGlue:
+      amount: 1
+    DexalinPlus:
+      amount: 1
+    Dylovene:
+      amount: 1
+  products:
+    CE235: 3  # 1 from each component


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->

## About the PR
This PR adds a new component called `TemuViroComponent` which simualtes being "Sick", by making you
- Take poision damage.
- Get a drunk effect.
- Get a popup that you feel bad.

This component does not spread, that's why it's TemuViro - it is meant for **admins to manually add this** onto whoever they want.

This adds a new recepie for a cure (which admins should eventually tell the crew about though CC)
named: `CE-235`
It is made by mixing `1:1:1` of
- `SpaceGlue` (You can get it from Trevor the horse or make some).
- `DexalinPlus` common chemist chem.
- `Dylovene` also common chemist chem.
This chemical tastes & smells like glue xD.

When 5 units of it are applied the component `IsCured` is set to true which will stop the effects of the diease after 10 seconds, and the poision damage will require to be healed to remove the remaining drunk effect (once it reaches 0 it removes the effect).

## Why / Balance
Temu Viro, would be funny having the crew have no idea wtf hit them only to figure out its a fucking diease and we need to RP doing Viro.

## Technical details
TODO

## Media
TODO

**When at full (almost at 50) poision, drunk effect**
<img width="1602" height="940" alt="image" src="https://github.com/user-attachments/assets/65bca159-ba8e-4821-b7c5-3876e95acf5c" />



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
TODO

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
Not needed, this isn't a changelog players should know about.
-->
