### PR TITLE
Minor cybernetic mantles fixes:

### DIFF
--- a/Content.Server/_White/Examine/ExaminableCharacterSystem.cs
+++ b/Content.Server/_White/Examine/ExaminableCharacterSystem.cs
@@ -13,6 +13,7 @@ using Content.Shared.Chat;
 using Content.Shared.Examine;
 using Content.Shared._White.Examine;
 using Content.Shared.Inventory;
+using Content.Shared.Inventory.VirtualItem; // Omustation Change
 using Robust.Shared.Configuration;
 using Robust.Shared.Player;
 using Robust.Shared.Utility;
@@ -87,6 +88,10 @@ public sealed class ExaminableCharacterSystem : EntitySystem
                 slotLabel += "-selfaware";
 
             if (!_inventorySystem.TryGetSlotEntity(uid, slotName, out var slotEntity))
+                continue;
+
+            // Omustation - Stop virtual items showing up on examine due to ClothingTakesUpExtraSlotsSystem
+            if (HasComp<VirtualItemComponent>(slotEntity))
                 continue;
 
             if (_entityManager.TryGetComponent<MetaDataComponent>(slotEntity, out var metaData)

--- a/Content.Shared/Clothing/Components/ClothingComponent.cs
+++ b/Content.Shared/Clothing/Components/ClothingComponent.cs
@@ -38,7 +38,7 @@ namespace Content.Shared.Clothing.Components;
 //[Access(typeof(ClothingSystem), typeof(InventorySystem))] - Fuck yo access - Goob
 public sealed partial class ClothingComponent : Component
 {
-    [DataField]
+    [DataField, AutoNetworkedField] // Omustation - autonetwork ClothingVisuals so that the eye colour of a cybernetic mantle is the same across clients
     public Dictionary<string, List<PrototypeLayerData>> ClothingVisuals = new();
 
     /// <summary>

--- a/Resources/Prototypes/_Omu/Entities/Clothing/Head/mantles.yml
+++ b/Resources/Prototypes/_Omu/Entities/Clothing/Head/mantles.yml
@@ -117,6 +117,29 @@
       - state: eyes-engineering
         shader: unshaded
 
+# variant of the engineering mantle for atmosians. Mostly because the burn chamber is a thing.
+- type: entity
+  id: ClothingCyberneticBeastMantleWorkAtmospherics
+  parent: ClothingCyberneticBeastMantleWorkEngineering
+  name: beast's atmospheric mantle
+  components:
+  - type: ComponentToggler
+    components: # copied from the parent with some additions
+    - type: VisionCorrection
+      correctionPower: 16
+    - type: NightVision
+      isEquipment: true
+      color: "#CCFFCC"
+    - type: FlashImmunity
+    - type: FlashSoundSuppression
+    - type: BreathMask
+    - type: PressureProtection
+      highPressureMultiplier: 0.4
+      lowPressureMultiplier: 1000
+    - type: TemperatureProtection
+      heatingCoefficient: 0.01
+      coolingCoefficient: 0.2
+
 # resprite of the work mantle for salvagers in particular.
 - type: entity
   id: ClothingCyberneticBeastMantleWorkSalvage

--- a/Resources/Prototypes/_Omu/Traits/physical.yml
+++ b/Resources/Prototypes/_Omu/Traits/physical.yml
@@ -64,7 +64,7 @@
     - !type:TraitGiveEquipmentIfHasJobs # Certain jobs do just need access to internals, so we'll spawn them with a more advanced version of the mantle.
       jobEquipment:
         # engineering mantle for engineers
-        AtmosphericTechnician: ClothingCyberneticBeastMantleWorkEngineering
+        AtmosphericTechnician: ClothingCyberneticBeastMantleWorkAtmospherics # special one for atmosians because burn chamber
         StationEngineer: ClothingCyberneticBeastMantleWorkEngineering
         TechnicalAssistant: ClothingCyberneticBeastMantleWorkEngineering
         # salvage mantle for salvagers


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!--- LICENSE: AGPL -->
## About the PR
Fixed some cybernetic mantle bugs. Notably:
- Eye colour is now consistent between clients.
- Virtual items no longer show up on character inspection.
- Atmosians get a mantle with temperature protection.

## Why / Balance
Bugfixes, and one role was missing critical functionality in the mantle.

## Technical details
- ExaminableCharacterSystem now checks for a virtual item component on a clothing slot's entity.
- ClothingComponent's ClothingVisuals is now an AutoNetworked field.
- A new mantle prototype has been added.
- The mantle given to an atmos tech on spawn has been changed to the new prototype.

## Media
<i>No virtual items show up on the character examine. The atmospherics mantle has temperature protection. This picture was taken on a client which joined after this character put on a cybernetic mantle, but the colour shown on the mantle is correct.</i>
<img width="581" height="625" alt="image" src="https://github.com/user-attachments/assets/7e9b675e-e978-4a7a-afbc-327b00926b5f" />

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: Gave temperature protection to the cybernetic mantle for atmospheric technicians.
- fix: Cybernetic mantle eye colours now show up as the same for each player.
- fix: Virtual items no longer show up when a character is examined.