### PR TITLE
Disable duo abductor

### DIFF
--- a/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
@@ -26,7 +26,7 @@
     Traitor: 0.25
     Changeling: 0.10
     Heretic: 0.11
-    DuoAbductorRoundstart: 0.05
+#    DuoAbductorRoundstart: 0.05 # Omu, This gamerule is broken
     CorporateAgent: 0.025
 
 # important note: those (and above) weights aren't entirely accurate,
@@ -40,7 +40,7 @@
     Traitor: 0.25
     Changeling: 0.10
     Heretic: 0.11
-    DuoAbductorRoundstart: 0.05
+#    DuoAbductorRoundstart: 0.05 # Omu, This gamerule is broken
     Nukeops: 0.05
     Revolutionary: 0.05
     Zombie: 0.04 # in search of how to make a rule always run alone? just tag it with LoneRunRule like zombies are

--- a/Resources/Prototypes/_Goobstation/game_presets.yml
+++ b/Resources/Prototypes/_Goobstation/game_presets.yml
@@ -253,7 +253,7 @@
   name: abductors-title
   description: abductors-description
   showInVote: false
-  minPlayers: 20
+  minPlayers: 100  # Omu, was 20, This gamerule is broken, setting to 100 minplayers so it never rolls
   rules:
   - DuoAbductorRoundstart
   - SubGamemodesRule


### PR DESCRIPTION
## About the PR
Disables duo abductor from rolling round start, as it doesn't actually work.

## Why / Balance
The gamerule doesn't work.

## Technical details
Comments it out of tables, sets minplayers for its gamemode to 100.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- remove: Removed DuoAbductors from roundstart, as the rule does not work.
