### PR TITLE
Return Parries to every other CQC User

### DIFF
--- a/Content.Goobstation.Shared/MartialArts/Components/GrantMartialArtKnowledgeComponent.cs
+++ b/Content.Goobstation.Shared/MartialArts/Components/GrantMartialArtKnowledgeComponent.cs
@@ -36,6 +36,9 @@ public abstract partial class GrantMartialArtKnowledgeComponent : Component
 
     [DataField]
     public SoundSpecifier? SoundOnUse = new SoundPathSpecifier("/Audio/Effects/fire.ogg", AudioParams.Default.WithVolume(10));
+
+    [DataField] // Omu Edit - Cooks and Syndie can have their CQC superiority
+    public bool CanAutoRiposte = false;
 }
 
 [RegisterComponent]

--- a/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.cs
+++ b/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.cs
@@ -502,11 +502,13 @@ public abstract partial class SharedMartialArtsSystem : EntitySystem
                 EnsureComp<NinjutsuSneakAttackComponent>(user);
                 break;
             case MartialArtsForms.CloseQuartersCombat:
-                // Omustation edit. Do not grant riposte with CQC. Remove comments to reenable - the event still fires so other shit doesnt fuck up though.
 
                  var thisVariableIsNeverUsedButIfIdontAssignAvariableToAnEventMyIdEcomplainsSoHereYouGo =
                     new CanDoCQCEvent();
-                /*
+
+                if (!comp.CanAutoRiposte) // Omustation edit. Do not grant riposte with to everyone with CQC
+                    break;
+
                 var riposte = EnsureComp<RiposteeComponent>(user);
                 riposte.Data.TryAdd("CQC",
                     new(0.1f,
@@ -521,7 +523,6 @@ public abstract partial class SharedMartialArtsSystem : EntitySystem
                     null,
                     null,
                     new CanDoCQCEvent()));
-                    */ // Omustation edit end.
                 break;
         }
 

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -178,6 +178,7 @@
     implants:
     - SpaceItalianTranslatorImplant   #chefs should speak space italian
   - type: GrantCqc                    #Chefs should have CqC
+    canAutoRiposte: true
 # Goobstation end
 
 - type: randomHumanoidSettings

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
@@ -102,6 +102,7 @@
       - type: GrantCqc
         startingStage: Hard
         isBlocked: true
+        canAutoRiposte: true
   - !type:AddImplantSpecial # Chefs speak space italian
     implants: [ SpaceItalianTranslatorImplant ]
 

--- a/Resources/Prototypes/_Goobstation/Entities/Specific/syndicate.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Specific/syndicate.yml
@@ -22,6 +22,7 @@
   - type: StaticPrice
     price: 3000
   - type: GrantCqc
+    canAutoRiposte: true
   - type: GuideHelp
     guides:
     - CQC

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Misc/misc.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Misc/misc.yml
@@ -118,6 +118,7 @@
     - type: GrantCqc
       startingStage: Hard
       isBlocked: false
+      canAutoRiposte: true
     - type: NpcFactionMember
       factions:
       - Syndicate

--- a/Resources/Prototypes/_Omu/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_Omu/Entities/Clothing/Belt/belts.yml
@@ -47,7 +47,7 @@
   parent: ClothingBeltSecurity
   id: ClothingBeltHOSCQC
   name: Qua Nar'Vulna
-  description: A Relic belt of an ancient art, This belt gives its weilder terrifying power
+  description: An elaborate-looking belt. There is a Vemu tag on the inside which reads "A Relic belt of an ancient art, This belt gives its weilder terrifying power."
   components:
   - type: Sprite
     sprite: _Omu/Clothing/Belt/clothingbelthoscqc.rsi

--- a/Resources/ServerInfo/_Goobstation/Guidebook/MartialArts/CQC.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/MartialArts/CQC.xml
@@ -18,6 +18,11 @@
 
   CQC users are better at Disarm intent, as their shoves will deal extra stamina damage to the opponent.
 
+  ### Riposte
+
+  With lightning reflexes, a CQC master has a chance to parry any incoming melee attack. In that brief moment, the attacker is left vulnerable,
+  so the CQC master strikes back and stuns them automatically, unless they are also a CQC master. A calculated, deadly response to any assault.
+
   ### Neck Snap
 
   There is no escape from a choke grab of a CQC master. With a single Harm action to the head, the victim's neck breaks,


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Bringing back balance to the mald
<img width="373" height="163" alt="image" src="https://github.com/user-attachments/assets/09f5394a-99ca-42d1-870a-3dc04d2a1c43" />
Returned auto parrying to most sources of CQC martial arts, but left out the HoS' belt. Since with this edit it would be weird for an ancient relic to be worse than an Old Manual, the description has also been edited. Funny side effect is that the spelling mistakes can be kept without issue.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
#186 was very necessary, let me get that out of the way! However, as the image illustrates what I can't in words, I think unrelated playstyles should not be caught in the crossfire of a needed change. This PR aims to improve on Clive's work!

## Technical details
<!-- Summary of code changes for easier review. -->
`SharedMartialArtsSystem.cs` received a new if-check right before the ParryingComponent part.
Added a `CanAutoRiposte` variable in `GrantMartialArtKnowledgeComponent.cs`, which only when set to true grants the CQC user with melee parries. This has been applied to every prototype of GrantCQC (Cook Job, Cook Prototype, Old Manual, Syndicate High Commander Job), except for HoS' CQC belt.
`CanAutoRiposte` set to false by default, but I would like maintainers to decide whether to have it default to true or false.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="673" height="303" alt="image" src="https://github.com/user-attachments/assets/f021da00-b720-46e8-90e8-a54d06e130ed" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Cooks and Syndicate rejoice! CQC users have their auto parry returned. Note: Head of Security's belt turned out to be a Vemu fake, they just move like that while wearing it.
