### PR TITLE
Blacklist sec, bso and command from anxiety

### DIFF
--- a/Resources/Prototypes/_Goobstation/Traits/disabilities.yml
+++ b/Resources/Prototypes/_Goobstation/Traits/disabilities.yml
@@ -58,9 +58,6 @@
     components:
       - SecurityStaff
       - CommandStaff
-    components:
-      - SecurityStaff
-      - CommandStaff
   components:
     - type: SocialAnxiety
   globalCost: -4 #omu i suppose. ive not tedted. If this comment is still here assume i havent tested.


### PR DESCRIPTION
## About the PR
Title

## Why / Balance
It's far too punishing, makes no logical sense and just generally means you could get a sec, command or bso who are effectively dead weight.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Blacklist sec, bso and command from anxiety
