### PR TITLE
Limit Transit Prisoners to 2 on Most Maps, 3 on High Pop Maps

### DIFF
--- a/Resources/Prototypes/Maps/amber.yml
+++ b/Resources/Prototypes/Maps/amber.yml
@@ -84,7 +84,7 @@
             Detective: [ 1, 1 ]
             SecurityCadet: [ 1, 1 ]
             Lawyer: [ 1, 1 ]
-            TransitPrisoner: [3, 3] # Omu - Prisoner role
+            TransitPrisoner: [2, 2] # Omu - Prisoner role
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 2, 3 ]

--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -135,7 +135,7 @@
             SecurityCadet: [ 4, 4 ]
             Lawyer: [ 2, 2 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [3, 3] # Omu - Prisoner role
+            TransitPrisoner: [2, 2] # Omu - Prisoner role
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 3, 3 ]

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -143,7 +143,7 @@
             SecurityCadet: [ 4, 4 ]
             Lawyer: [ 2, 2 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [3, 3] # Omu - Prisoner role
+            TransitPrisoner: [2, 2] # Omu - Prisoner role
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 3, 3 ]

--- a/Resources/Prototypes/Maps/fland.yml
+++ b/Resources/Prototypes/Maps/fland.yml
@@ -98,7 +98,7 @@
             SecurityCadet: [ 4, 4 ]
             Lawyer: [ 2, 2 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [3, 3] # Omu - Prisoner role
+            TransitPrisoner: [2, 2] # Omu - Prisoner role
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 3, 3 ]

--- a/Resources/Prototypes/Maps/loop.yml
+++ b/Resources/Prototypes/Maps/loop.yml
@@ -147,7 +147,7 @@
             SecurityCadet: [ 4, 4 ]
             Lawyer: [ 2, 2 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [3, 3] # Omu - Prisoner role
+            TransitPrisoner: [2, 2] # Omu - Prisoner role
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 3, 3 ]

--- a/Resources/Prototypes/Maps/marathon.yml
+++ b/Resources/Prototypes/Maps/marathon.yml
@@ -89,7 +89,7 @@
             SecurityCadet: [ 4, 4 ]
             Lawyer: [ 2, 2 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [3, 3] # Omu - Prisoner role
+            TransitPrisoner: [2, 2] # Omu - Prisoner role
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 3, 3 ]

--- a/Resources/Prototypes/Maps/meta.yml
+++ b/Resources/Prototypes/Maps/meta.yml
@@ -139,7 +139,7 @@
             SecurityCadet: [ 3, 6 ]
             Lawyer: [ 2, 2 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [3, 3] # Omu - Prisoner role
+            TransitPrisoner: [2, 2] # Omu - Prisoner role
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 3, 3 ]

--- a/Resources/Prototypes/Maps/oasis.yml
+++ b/Resources/Prototypes/Maps/oasis.yml
@@ -150,7 +150,7 @@
             SecurityCadet: [ 4, 4 ]
             Lawyer: [ 3, 3 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [3, 3] # Omu - Prisoner role
+            TransitPrisoner: [2, 3] # Omu - Prisoner role
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 3, 3 ]

--- a/Resources/Prototypes/Maps/omega.yml
+++ b/Resources/Prototypes/Maps/omega.yml
@@ -84,7 +84,7 @@
             SecurityCadet: [ 2, 2 ]
             Lawyer: [ 1, 1 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [1, 2] # Omu - Prisoner role
+            TransitPrisoner: [2, 2] # Omu - Prisoner role
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/packed.yml
+++ b/Resources/Prototypes/Maps/packed.yml
@@ -86,7 +86,7 @@
             SecurityCadet: [ 2, 2 ]
             Lawyer: [ 1, 1 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [1, 2] # Omu - Prisoner role
+            TransitPrisoner: [2, 2] # Omu - Prisoner role
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/saltern.yml
+++ b/Resources/Prototypes/Maps/saltern.yml
@@ -86,7 +86,7 @@
             SecurityOfficer: [ 4, 4 ]
             SecurityCadet: [ 4, 4 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [1, 1] # Omu - Prisoner role
+            TransitPrisoner: [1, 2] # Omu - Prisoner role
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 1, 3 ]

--- a/Resources/Prototypes/_Goobstation/Maps/atlas.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/atlas.yml
@@ -89,7 +89,7 @@
             SecurityCadet: [ 1, 3 ]
             Detective: [ 1, 1 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [1, 2] # Omu - Prisoner role
+            TransitPrisoner: [2, 2] # Omu - Prisoner role
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 4, 4 ]

--- a/Resources/Prototypes/_Goobstation/Maps/chloris.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/chloris.yml
@@ -56,7 +56,7 @@
             SecurityCadet: [ 3, 4 ]
             Detective: [ 1, 1 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [3, 3] # Omu - Prisoner role
+            TransitPrisoner: [2, 2] # Omu - Prisoner role
             # service
             HeadOfPersonnel: [ 1, 1 ]
             Bartender: [ 1, 1 ]

--- a/Resources/Prototypes/_Goobstation/Maps/cluster.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/cluster.yml
@@ -87,7 +87,7 @@
             SecurityOfficer: [ 3, 3 ]
             SecurityCadet: [ 2, 2 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [1, 2] # Omu - Prisoner role
+            TransitPrisoner: [2, 2] # Omu - Prisoner role
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ -1, -1 ]

--- a/Resources/Prototypes/_Goobstation/Maps/cog.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/cog.yml
@@ -60,7 +60,7 @@
             SecurityCadet: [ 4, 4 ]
             Lawyer: [ 2, 2 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [3, 3] # Omu - Prisoner role
+            TransitPrisoner: [2, 2] # Omu - Prisoner role
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 3, 3 ]

--- a/Resources/Prototypes/_Goobstation/Maps/delta.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/delta.yml
@@ -54,7 +54,7 @@
             SecurityCadet: [ 3, 3 ]
             Detective: [ 1, 1 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [3, 3] # Omu - Prisoner role
+            TransitPrisoner: [2, 2] # Omu - Prisoner role
             # service
             HeadOfPersonnel: [ 1, 1 ]
             Bartender: [ 1, 1 ]

--- a/Resources/Prototypes/_Goobstation/Maps/flandhighpop.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/flandhighpop.yml
@@ -90,7 +90,7 @@
             SecurityCadet: [ -1, -1 ]
             Lawyer: [ 3, 3 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [4, 4] # Omu - Prisoner role
+            TransitPrisoner: [2, 3] # Omu - Prisoner role
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 8, 8 ]

--- a/Resources/Prototypes/_Goobstation/Maps/kettle.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/kettle.yml
@@ -89,7 +89,7 @@
             SecurityOfficer: [ 4, 6 ]
             SecurityCadet: [ 8, 8 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [3, 3] # Omu - Prisoner role
+            TransitPrisoner: [2, 2] # Omu - Prisoner role
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 6, 6 ]

--- a/Resources/Prototypes/_Goobstation/Maps/leonid.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/leonid.yml
@@ -94,7 +94,7 @@
             SecurityCadet: [ 6, 6 ]
             Lawyer: [ 3, 3 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [3, 3] # Omu - Prisoner role
+            TransitPrisoner: [2, 2] # Omu - Prisoner role
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 6, 6 ]

--- a/Resources/Prototypes/_Goobstation/Maps/oasishighpop.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/oasishighpop.yml
@@ -89,7 +89,7 @@
             SecurityCadet: [ -1, -1 ]
             Lawyer: [ 3, 3 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [3, 4] # Omu - Prisoner role
+            TransitPrisoner: [2, 2] # Omu - Prisoner role
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 8, 8 ]

--- a/Resources/Prototypes/_Goobstation/Maps/origin.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/origin.yml
@@ -86,7 +86,7 @@
             SecurityOfficer: [ 7, 7 ]
             SecurityCadet: [ 2, 4 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [3, 3] # Omu - Prisoner role
+            TransitPrisoner: [2, 2] # Omu - Prisoner role
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 8, 8 ]

--- a/Resources/Prototypes/_Goobstation/Maps/originhighpop.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/originhighpop.yml
@@ -86,7 +86,7 @@
             SecurityCadet: [ -1, -1 ]
             Lawyer: [ 3, 3 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [3, 4] # Omu - Prisoner role
+            TransitPrisoner: [2, 2] # Omu - Prisoner role
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 8, 8 ]

--- a/Resources/Prototypes/_Goobstation/Maps/serpentcrest.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/serpentcrest.yml
@@ -59,7 +59,7 @@
             SecurityCadet: [ 3, 3 ]
             Lawyer: [ 2, 2 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [3, 3] # Omu - Prisoner role
+            TransitPrisoner: [2, 2] # Omu - Prisoner role
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 4, 4 ]

--- a/Resources/Prototypes/_Goobstation/Maps/submarine.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/submarine.yml
@@ -52,7 +52,7 @@
             SecurityCadet: [ 1, 4 ]
             Warden: [ 1, 1 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [3, 4] # Omu - Prisoner role
+            TransitPrisoner: [2, 3] # Omu - Prisoner role
           #service
             Bartender: [ 2, 3 ]
             Botanist: [ 2, 5 ]


### PR DESCRIPTION
## About the PR
We don't need 3 transit prisoners on smaller maps, and we don't need 4 on high-pop maps. They should be like clowns and mimes, but more than a single person.

**Changelog**
:cl:
- tweak: Transit Prisoner has been raised to 2 job slots on Saltern.
- tweak: Transit Prisoner has been limited to 2 job slots on most maps.
- tweak: Transit Prisoner has been limited to 3 job slots on Oasis, FlandHighPop, and Submarine.
