### PR TITLE
Make Revolutionary Admin-Only

### DIFF
--- a/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
@@ -41,13 +41,13 @@
     Changeling: 0.10
     Heretic: 0.11
 #    DuoAbductorRoundstart: 0.05 # Omu, This gamerule is broken
-    Nukeops: 0.05
-    Revolutionary: 0.05
+    Nukeops: 0.07 # Omu - Increase from 0.05 due to rev removal
+    # Revolutionary: 0.05 # Omu - Admin Only
     Zombie: 0.04 # in search of how to make a rule always run alone? just tag it with LoneRunRule like zombies are
     BlobGameMode: 0.05
     Wizard: 0.025
-    CosmicCult: 0.05
-    CorporateAgent: 0.025
+    CosmicCult: 0.07 # Omu - Increase from 0.05 due to rev removal
+    CorporateAgent: 0.035 # Omu - Increase from 0.025 due to rev removal
 
 # all antags
 - type: weightedRandom
@@ -59,13 +59,13 @@
     Traitor: 0.25
     Changeling: 0.10
     Heretic: 0.11
-    Nukeops: 0.05
-    Revolutionary: 0.05
+    Nukeops: 0.07 # Omu - Increase from 0.05 due to rev removal
+    # Revolutionary: 0.05 # Omu - Admin Only
     Zombie: 0.04
     BlobGameMode: 0.05
     Wizard: 0.025
-    CosmicCult: 0.05
-    CorporateAgent: 0.025
+    CosmicCult: 0.07 # Omu - Increase from 0.05 due to rev removal
+    CorporateAgent: 0.035 # Omu - Increase from 0.025 due to rev removal
 
 - type: entity
   id: SecretPlusMid

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -41,13 +41,13 @@
     Traitor: 0.25
     Changeling: 0.10
     Traitorling: 0.05 # 2 antags but less of each type applies for all hybrid modes, they all need 30 pop. Also makes lower pops roll more traitor games.
-    Nukeops: 0.09
-    Honkops: 0.01
+    Nukeops: 0.14 # Omu - Increase from 0.09 due to removing rev
+    Honkops: 0.04 # Omu - Increase from 0.01 due to removing rev
     NukeTraitor: 0.01
     NukeLing: 0.01
-    Revolutionary: 0.04
-    RevTraitor: 0.01
-    RevLing: 0.03
+    # Revolutionary: 0.04 # Omu - Admin Only
+    # RevTraitor: 0.01 # Omu - Admin Only
+    # RevLing: 0.03 # Omu - Admin Only
     Zombie: 0.03
     Survival: 0.03
     Blob: 0.04


### PR DESCRIPTION
## About the PR
Revolutionary is not a good gamemode for a conversion antag. It pins the antagonist directly against Security and Command and leaves the middle-ground for civilians and regular station members to be a bloodbath in the middle. It offers too much murderboning and not enough play to prevent round removal of innocents and deconversion of revolutionaries. There's a reason it's admin-only on SS13 (for most servers). Until the proposed design in Wizden is acted upon, this should be admin-only.

**Changelog**
:cl:
- remove: Removed Revolutionary from Secret Classic and Secret Plus.
- tweak: Revolutionary is now Admin-Only Spawn.