### PR TITLE
Remove Rat king's ability to ventcrawl

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -161,7 +161,7 @@
   parent: [ SimpleMobBase, MobCombat ]
   description: He's da rat. He make da roolz.
   components:
-  - type: VentCrawler # goobstation - Ventcrawl
+#  - type: VentCrawler # goobstation - Ventcrawl #Omu - No ventcrawl.
   - type: CombatMode
   - type: MovementSpeedModifier
     baseWalkSpeed : 4.00


### PR DESCRIPTION
## About the PR
Removed Rat king's ability to ventcrawl

## Why / Balance
It can use commands while in the vents, making it unkillable to sec, and its rats don't follow it into the vents.

Until someone makes it so either the rats follow into the vents, or the RK cannot use commands while in vents, this is the best solution.

(The antag that can lag the server, kill anyone in a single frame, being able to hide in vents making it effectively unkillable is a bad idea.)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- remove: Removed Rat King's ability to ventcrawl