### PR TITLE
Cherry Pick End Facehugger Torment Nexus (#4931) from upstream

### DIFF
--- a/Content.Server/_White/Xenomorphs/FaceHugger/FaceHuggerComponent.cs
+++ b/Content.Server/_White/Xenomorphs/FaceHugger/FaceHuggerComponent.cs
@@ -50,7 +50,7 @@ public sealed partial class FaceHuggerComponent : Component
 
     // Goobstation start
     [DataField]
-    public string SleepChem = "AlienSedative";
+public string SleepChem = "Nocturine";
 
     [DataField]
     public float SleepChemAmount = 10f;


### PR DESCRIPTION
## About the PR
Made it so that the facehuggers do not inject a nonexistent reagent (AlienSedative), which was causing the endless reloads we see ingame.

## Why / Balance
Major bugfix, game is unplayable when you're refreshing after half a second of actual input, forever.

## Technical details
1 line C# change, "AlienSedative" -> "Nocturine"

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Hopefully ended the facehugger torment nexus
