### PR TITLE
Brigmed Duty Weapon Fix

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
@@ -252,7 +252,7 @@
     id: BrigmedicPDA
     ears: ClothingHeadsetBrigmedic # EE parity like i was told to do
     belt: ClothingBeltMedicalEMTFilled
-    pocket1: WeaponPistolMk58 # EE parity, make corpsman able to carry weapons like the rest of security
+    pocket1: OfficerGunCase # Omu
     pocket2: WeaponDisabler # Goob
   storage:
     back:

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Security/brigmedic.yml
@@ -53,4 +53,4 @@
     back: ClothingBackpackBrigmedic
     shoes: ClothingShoesBootsJack
     head: ClothingHeadHatBeretBrigmedic
-    pocket1: OfficerGunCase #Omu
+#    pocket1: OfficerGunCase #Omu


### PR DESCRIPTION

## About the PR
Makes the brigmedic properly spawn with a duty case. Also removes the duty selector from the brigmed chameleon outfit, which seems to have been changed by accident with the addition of selectors. (I'm not actually sure if having it in broke anything but just to be safe.)

## Media
<img width="790" height="70" alt="Starting brigmedic inventory, now with a duty case" src="https://github.com/user-attachments/assets/078b18ba-a224-419e-a5b1-544ed64e114d" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: The Brigmedic now spawns with a duty case instead of a mk58.
