### PR TITLE
Paradox clone disabling until rework

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -186,7 +186,7 @@
     - id: DragonSpawn
     - id: KingRatMigration
     - id: NinjaSpawn
-    - id: ParadoxCloneSpawn
+    #- id: ParadoxCloneSpawn # Omu - Removed till rework, more explanation on the corresponding PR.
     #- id: RevenantSpawn  # GoobStation - removed till rework
     - id: SleeperAgents
     - id: ZombieOutbreak


### PR DESCRIPTION
## About the PR
Disabling Paradox Clones.

## Why / Balance
Okay, long rant time.
Before we received Wizden's version, pretty sure we had DeltaV's back in Goob, which actually allowed for some RP and had both the objectives to co-exist or to kill the original, you wouldn't blow up at CentComm either in round end, etc.,

But then we got Wizden's version, which is extremely closed, and is just generally bad for RP, it's just "Kill this guy and get rid of them" - No RP involved at all, just greentext.
Paradox Clones have had a long history of being instantly defused by the average "what did we do earlier on the shift" question, or a lore question from a friend of yours that knows you ooc etc etc, which is generally unfun for the person playing the paradox.

Admins have also started to reinforce that paradoxes should ALWAYS kill the original, which I find to be dumb, considering the antag itself is just awful and extremely limited in what it can do, it's just walk up to the original, kill, and then try to pretend you are them, which most don't anyways and just play them as their own character but with a different skin.

I'm sick of seeing paradox clones do the most NITRP bullshit, they also lack time requirements so anyone can take them, most paradoxes play out like they were a raider.

## Technical details

## Media
Insert image of paradox clone with "I HATE YOU" text or smth like Richard's PR.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I am malding after seeing the same exact shit happen over and over with paradox clones

## Breaking changes

**Changelog**
:cl: Diggy
- remove: Paradox clones removed pending rework :godo:
