### PR TITLE
Update pirate accent Pt2

### DIFF
--- a/Resources/Locale/en-US/accent/pirate.ftl
+++ b/Resources/Locale/en-US/accent/pirate.ftl
@@ -53,13 +53,13 @@ accent-pirate-replacement-13 = doubloons
 accent-pirate-replaced-14 = crate
 accent-pirate-replacement-14 = coffer
 
-accent-pirate-replaced-15 = hello
-accent-pirate-replacement-15 = ahoy
+accent-pirate-replaced-15 = of
+accent-pirate-replacement-15 = o'
 
 accent-pirate-replaced-16 = treasure
 accent-pirate-replacement-16 = booty
 
-accent-pirate-replaced-17 = attention
+accent-pirate-replaced-17 = stop
 accent-pirate-replacement-17 = avast
 
 accent-pirate-replaced-18 = stupid
@@ -106,3 +106,231 @@ accent-pirate-replacement-31 = musket
 
 accent-pirate-replaced-32 = ammo
 accent-pirate-replacement-32 = gunpowder
+
+accent-pirate-replaced-33 = shotgun
+accent-pirate-replacement-33 = blunderbuss
+
+accent-pirate-replaced-34 = floor
+accent-pirate-replacement-34 = deck
+
+accent-pirate-replaced-35 = wall
+accent-pirate-replacement-35 = bulkhead
+
+accent-pirate-replaced-36 = clean
+accent-pirate-replacement-36 = swab
+
+accent-pirate-replaced-37 = rev
+accent-pirate-replacement-37 = mutineer
+
+accent-pirate-replaced-38 = revolutionaries
+accent-pirate-replacement-38 = mutineers
+
+accent-pirate-replaced-39 = revs
+accent-pirate-replacement-39 = mutineers
+
+accent-pirate-replaced-40 = the
+accent-pirate-replacement-40 = th'
+
+accent-pirate-replaced-41 = for
+accent-pirate-replacement-41 = fer
+
+accent-pirate-replaced-42 = bathroom
+accent-pirate-replacement-42 = heads
+
+accent-pirate-replaced-43 = secoff
+accent-pirate-replacement-43 = marine
+
+accent-pirate-replaced-44 = window
+accent-pirate-replacement-44 = porthole
+
+accent-pirate-replaced-45 = beside
+accent-pirate-replacement-45 = abeam
+
+accent-pirate-replaced-46 = rear
+accent-pirate-replacement-46 = stern
+
+accent-pirate-replaced-47 = front
+accent-pirate-replacement-47 = bow
+
+accent-pirate-replaced-48 = above
+accent-pirate-replacement-48 = aloft
+
+accent-pirate-replaced-49 = drunk
+accent-pirate-replacement-49 = bully
+
+accent-pirate-replaced-50 = steal
+accent-pirate-replacement-50 = plunder
+
+accent-pirate-replaced-51 = stole
+accent-pirate-replacement-51 = plundered
+
+accent-pirate-replaced-52 = carry
+accent-pirate-replacement-52 = haul
+
+accent-pirate-replaced-53 = fast
+accent-pirate-replacement-53 = swift
+
+accent-pirate-replaced-54 = dorm
+accent-pirate-replacement-54 = berthing
+
+accent-pirate-replaced-51 = dorms
+accent-pirate-replacement-51 = berthing
+
+accent-pirate-replaced-52 = kitchen
+accent-pirate-replacement-52 = galley
+
+accent-pirate-replaced-53 = jail
+accent-pirate-replacement-53 = brig
+
+accent-pirate-replaced-54 = prison
+accent-pirate-replacement-54 = brig
+
+accent-pirate-replaced-55 = party
+accent-pirate-replacement-55 = bash
+
+accent-pirate-replaced-56 = door
+accent-pirate-replacement-56 = hatch
+
+accent-pirate-replaced-57 = shout
+accent-pirate-replacement-57 = bellow
+
+accent-pirate-replaced-58 = drain
+accent-pirate-replacement-58 = scupper
+
+accent-pirate-replaced-59 = rank
+accent-pirate-replacement-59 = rate
+
+accent-pirate-replaced-60 = whistle
+accent-pirate-replacement-60 = call
+
+accent-pirate-replaced-61 = horn
+accent-pirate-replacement-61 = whistle
+
+accent-pirate-replaced-62 = hallway
+accent-pirate-replacement-62 = passageway
+
+accent-pirate-replaced-63 = hall
+accent-pirate-replacement-63 = flats
+
+accent-pirate-replaced-64 = map
+accent-pirate-replacement-64 = chart
+
+accent-pirate-replaced-65 = sword
+accent-pirate-replacement-65 = cutlass
+
+accent-pirate-replaced-66 = spill
+accent-pirate-replacement-66 = flood
+
+accent-pirate-replaced-67 = coin
+accent-pirate-replacement-67 = guinea
+
+accent-pirate-replaced-68 = coins
+accent-pirate-replacement-68 = guineas
+
+accent-pirate-replaced-69 = bed
+accent-pirate-replacement-69 = rack
+
+accent-pirate-replaced-70 = shift
+accent-pirate-replacement-70 = watch
+
+accent-pirate-replaced-71 = drink
+accent-pirate-replacement-71 = swig
+
+accent-pirate-replaced-72 = heroic
+accent-pirate-replacement-72 = gallant
+
+accent-pirate-replaced-73 = brave
+accent-pirate-replacement-73 = bold
+
+accent-pirate-replaced-74 = tired
+accent-pirate-replacement-74 = weary
+
+accent-pirate-replaced-75 = yell
+accent-pirate-replacement-75 = bellow
+
+accent-pirate-replaced-76 = dumb
+accent-pirate-replacement-76 = daft
+
+accent-pirate-replaced-77 = sick
+accent-pirate-replacement-77 = queasy
+
+accent-pirate-replaced-78 = empty
+accent-pirate-replacement-78 = bare
+
+accent-pirate-replaced-79 = poor
+accent-pirate-replacement-79 = penniless
+
+accent-pirate-replaced-80 = rich
+accent-pirate-replacement-80 = fat-pursed
+
+accent-pirate-replaced-81 = coward
+accent-pirate-replacement-81 = yellow-bellied
+
+accent-pirate-replaced-82 = chef
+accent-pirate-replacement-82 = cook
+
+accent-pirate-replaced-83 = shield
+accent-pirate-replacement-83 = buckler
+
+accent-pirate-replaced-84 = spear
+accent-pirate-replacement-84 = pike
+
+accent-pirate-replaced-85 = flag
+accent-pirate-replacement-85 = colours
+
+accent-pirate-replaced-86 = storm
+accent-pirate-replacement-86 = squall
+
+accent-pirate-replaced-87 = cookie
+accent-pirate-replacement-87 = biscuit
+
+accent-pirate-replaced-88 = dessert
+accent-pirate-replacement-88 = duff
+
+accent-pirate-replaced-89 = thirsty
+accent-pirate-replacement-89 = parched
+
+accent-pirate-replaced-90 = grenade
+accent-pirate-replacement-90 = bomb
+
+accent-pirate-replaced-91 = ship
+accent-pirate-replacement-91 = vessel
+
+accent-pirate-replaced-92 = shuttle
+accent-pirate-replacement-92 = vessel
+
+accent-pirate-replaced-93 = guard
+accent-pirate-replacement-93 = lookout
+
+accent-pirate-replaced-94 = execute
+accent-pirate-replacement-94 = hang
+
+accent-pirate-replaced-95 = executed
+accent-pirate-replacement-95 = hanged
+
+accent-pirate-replaced-96 = tree
+accent-pirate-replacement-96 = timber
+
+accent-pirate-replaced-97 = wind
+accent-pirate-replacement-97 = gust
+
+accent-pirate-replaced-98 = enemy
+accent-pirate-replacement-98 = foe
+
+accent-pirate-replaced-99 = airlock
+accent-pirate-replacement-99 = hatch
+
+accent-pirate-replaced-100 = food
+accent-pirate-replacement-100 = grub
+
+accent-pirate-replaced-101 = alarm
+accent-pirate-replacement-101 = bell
+
+accent-pirate-replaced-102 = pod
+accent-pirate-replacement-102 = raft
+
+accent-pirate-replaced-103 = binoculars
+accent-pirate-replacement-103 = spyglass
+
+accent-pirate-replaced-104 = engineer
+accent-pirate-replacement-104 = stoker


### PR DESCRIPTION
## About the PR
Added over seventy new words for the pirate accent to replace

## Why / Balance
Yarr

## Technical details
I added listings for replacements 33 to 104, as well as updating "attention -> avast" to be "stop -> avast" since avast means stop, not attention. I also changed a duplicate "hello -> ahoy" that was in there for some reason

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- tweak: Yarr matey, th' pirate accents have been updated 🏴‍☠️

