### PR TITLE
Fix trait weight requirement

### DIFF
--- a/Content.Shared/_Omu/Roles/JobRequirement/WeightRequirement.cs
+++ b/Content.Shared/_Omu/Roles/JobRequirement/WeightRequirement.cs
@@ -44,7 +44,7 @@ public sealed partial class WeightRequirement : JobRequirement
         }
 
         // "fix1" is used for all collisions except for getting set on fire iirc.
-        var avg = (Profile.Width + Profile.Height) / 2;
+        var avg = (profile.Width + profile.Height) / 2;
         var radius = fixture.Fixtures["fix1"].Shape.Radius; 
         var density = fixture.Fixtures["fix1"].Density;
         var weight = MathF.Round(MathF.PI * MathF.Pow(radius * avg, 2) * density);


### PR DESCRIPTION
## About the PR
Changed trait weight calc to match profile editor

## Why / Balance
It is very weird that it was on a different calculation.

## Media
Same char for both.
Before PR:
<img width="729" height="102" alt="image" src="https://github.com/user-attachments/assets/46397449-3aba-4ddb-96d0-1d8c3f35a61b" />

After PR:
<img width="919" height="76" alt="image" src="https://github.com/user-attachments/assets/045cec4e-db41-4c80-8c65-7e4af03cb806" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed trait weight requirement so it uses the correct calculation
