### PR TITLE
Ultimate Silicon Victory

### DIFF
--- a/Resources/Prototypes/_Goobstation/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_Goobstation/Damage/modifier_sets.yml
@@ -32,10 +32,10 @@
 - type: damageModifierSet
   id: Silicon
   coefficients:
-    Heat: 0.8
+    Heat: 0.85
     Blunt: 0.9
-    Slash: 0.9
-    Piercing: 0.9
+    Slash: 0.85
+    Piercing: 0.85
 
 - type: damageModifierSet
   id: SiliconProtected


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->

For too long have silicon been kept down. For too long have IPCs and Cyborgs been stomped easily under the boot of a tider with a slightly sharp object. Today marks the day Silicon-kind rises and shows those organics that steel beats flesh.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

IPCs and Borgs are notoriously pretty easy to kill. They take 10% less pierce/slash damage, which is pretty small considering they can't use combat drugs to buff themselves. You'd think that the plastic/metal chassis would be a bit stronger against a broken glass bottle. 

I have given all silicon 5% extra resistance to pierce and slash, but have decreased their heat resistance by 5% to balance things out.

## Technical details
<!-- Summary of code changes for easier review. -->

Silicon damage modifier set adjusted to provide 15% pierce and slash resist compared to the previous 10%; To balance this, I have changed their heat resistance to be 5% compared to the previous 10%

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: All silicon lifeforms are SLIGHTLY more resistant to sharp objects, but weaker to heat.
