### PR TITLE
[Balance] Caplain's knife size tweak.

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/nullrod.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/nullrod.yml
@@ -237,7 +237,7 @@
         Slash: 20
     UntrainedUseString: nullrod-arrythmicknife-untrained-usage-popup
   - type: Item
-    size: Huge
+    size: Normal #Omu - size change
     sprite: _ShitChap/Objects/Weapons/Nullrod/arrythmic.rsi
   - type: Sprite
     sprite: _ShitChap/Objects/Weapons/Nullrod/arrythmic.rsi


### PR DESCRIPTION
## About the PR
On PonPon's request squished chaplain's arrythmic knife from 4x4 to 2x2.

## Why / Balance
Its a knife. It shouldn't be taking up half of your bag.

## Technical details
Literally changed a single word in YAML.

## Media
<img width="257" height="132" alt="image" src="https://github.com/user-attachments/assets/478e0745-a1da-4c41-9290-d7add2805041" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
:cl:
- tweak: Squished chaplain's arrythmic knife to a more reasonable size.
