### PR TITLE
Some mistakes being rectified... (Senior BSO drip followup)

### DIFF
--- a/Resources/Prototypes/_Omu/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_Omu/Entities/Clothing/Belt/belts.yml
@@ -101,11 +101,3 @@
     damageCoefficient: 0.1
   - type: StaticPrice
     price: 500
-
-- type: loadout #BSO's belt - Moved to Loadout
-  id: BeltAssaultFilled
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorBlueshieldOfficer
-  equipment:
-    belt: ClothingBeltAssaultFilled

--- a/Resources/Prototypes/_Omu/Loadouts/Jobs/Dignitary/blueshield_officer.yml
+++ b/Resources/Prototypes/_Omu/Loadouts/Jobs/Dignitary/blueshield_officer.yml
@@ -49,4 +49,8 @@
   equipment:
     neck: ClothingNeckMantleTwoBlueshield
 
-
+# Belt
+- type: loadout #BSO's belt - Moved to Loadout
+  id: BeltAssaultFilled
+  equipment:
+    belt: ClothingBeltAssaultFilled

--- a/Resources/Prototypes/_StarLight/Loadouts/Jobs/Representives/blueshield.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/Jobs/Representives/blueshield.yml
@@ -41,6 +41,8 @@
   equipment:
     head: ClothingHeadHatBeretBlueShieldElite
 
+# Belt
+
 - type: loadout #Omu - Starlight repurposing
   id: BeltBlueshieldEliteFilled
   effects:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->I put both belts as being locked behind 52h timewall, and also the loudout prototype was in the entities folder... 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->I was stupid

## Technical details
<!-- Summary of code changes for easier review. -->moved the AssaultBeltFilled prototype to the correct folder, added a comment to indicate belt slot.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
--> :cl:Gab
- fix: The assault belt loadout on BSO is not longer a Senior BSO drip. My bad.
