### PR TITLE
[BOUNTY] Remove Terminus Wide Swing

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/Entities/Objects/Weapons/Melee/terminus.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Objects/Weapons/Melee/terminus.yml
@@ -46,7 +46,7 @@
         Slash: 15
     soundHit:
       collection: MetalThud
-    canWideSwing: false
+    canWideSwing: false # Omu
   - type: StaminaDamageOnHit
     damage: 30
   - type: Wieldable


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

## About the PR
Makes the Terminus no longer able to wide swing when out of ammo.

## Why / Balance
charge your damn axe

## Media
https://github.com/user-attachments/assets/10c1099e-2a0b-46a4-807a-206491f473e7


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: The Terminus no longer wide-swings when out of battery
