### PR TITLE
Removed CQC Neck-snapping

### DIFF
--- a/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.CQC.cs
+++ b/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.CQC.cs
@@ -143,36 +143,6 @@ public partial class SharedMartialArtsSystem
                 _stamina.TakeStaminaDamage(args.Target, 25f, applyResistances: true);
                 break;
             case ComboAttackType.Harm:
-                // Snap neck
-                if (!_mobState.IsDead(args.Target) && !HasComp<GodmodeComponent>(args.Target) &&
-                    TryComp(ent, out PullerComponent? puller) && puller.Pulling == args.Target &&
-                    TryComp(args.Target, out PullableComponent? pullable) &&
-                    TryComp(args.Target, out BodyComponent? body) &&
-                    TryComp(args.Target, out StaminaComponent? stamina) && stamina.Critical &&
-                    puller.GrabStage == GrabStage.Suffocate && TryComp(ent, out TargetingComponent? targeting) &&
-                    targeting.Target == TargetBodyPart.Head
-                    && _mobThreshold.TryGetDeadThreshold(args.Target, out var damageToKill))
-                {
-                    _pulling.TryStopPull(args.Target, pullable);
-
-                    var blunt = new DamageSpecifier(_proto.Index<DamageTypePrototype>("Blunt"), damageToKill.Value);
-                    _damageable.TryChangeDamage(args.Target, blunt, true, targetPart: TargetBodyPart.Chest);
-
-                    var (partType, symmetry) = _body.ConvertTargetBodyPart(targeting.Target);
-                    var targetedBodyPart = _body.GetBodyChildrenOfType(args.Target, partType, body, symmetry)
-                        .ToList()
-                        .FirstOrNull();
-
-                    if (targetedBodyPart == null ||
-                        !TryComp(targetedBodyPart.Value.Id, out WoundableComponent? woundable) ||
-                        woundable.Bone.ContainedEntities.FirstOrNull() is not { } bone ||
-                        !TryComp(bone, out BoneComponent? boneComp) || boneComp.BoneSeverity == BoneSeverity.Broken)
-                        break;
-
-                    _trauma.ApplyDamageToBone(bone, boneComp.BoneIntegrity, boneComp);
-                    ComboPopup(ent, args.Target, "Neck Snap");
-                    break;
-                }
 
                 // Leg sweep
                 if (!TryComp<StandingStateComponent>(ent, out var standing)

--- a/Resources/ServerInfo/_Goobstation/Guidebook/MartialArts/CQC.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/MartialArts/CQC.xml
@@ -18,11 +18,6 @@
 
   CQC users are better at Disarm intent, as their shoves will deal extra stamina damage to the opponent.
 
-  ### Neck Snap
-
-  There is no escape from a choke grab of a CQC master. With a single Harm action to the head, the victim's neck breaks,
-  killing them instantly. No armor can shield against this deadly precision. The end comes swiftly, and without mercy.
-
   ## Combo attacks
 
   ### Slam


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Removed CQC Neck-snapping

## Why / Balance
It sucks, you have CQC an already powerful martial arts, just use the combos, no more neck-snapping in 3 seconds.

## Technical details
Just removed it

## Media
<img width="1882" height="886" alt="image" src="https://github.com/user-attachments/assets/2e175839-aa3d-4b57-946c-c949dd9a0653" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Richard Blonski
- remove: Removed CQC Neck-snapping
