### PR TITLE
[FIX] Add targeting to xenos

### DIFF
--- a/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/base.yml
+++ b/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/base.yml
@@ -155,6 +155,7 @@
 #    enabled: true
 #    groups:
 #    - XenomorphAccess
+  - type: Targeting # Omu, allow xenos to target limbs
 
 
 - type: entity


### PR DESCRIPTION
## About the PR
Allowed xenos to target limbs

## Why / Balance
Currently they hit random limbs, this causes them to not be able to crit reliably due to the change meaning that hands and feet no longer contrib to health state.

## Technical details
added a single comp

## Media
<img width="962" height="629" alt="image" src="https://github.com/user-attachments/assets/803a8417-3242-4c25-b34e-1b22eb0881b8" />

## Requirements
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Xenos can now target limbs
