### PR TITLE
Revert second skin armor changes

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -235,9 +235,9 @@
       NerveDamage: 0
     modifiers:
       coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.8
+        Blunt: 0.7 # Omu, was 0.8
+        Slash: 0.7 # Omu, was 0.8
+        Piercing: 0.7 # Omu, was 0.8
         Heat: 0.8
 
 - type: entity
@@ -265,9 +265,9 @@
       NerveDamage: 0
     modifiers:
       coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.8
+        Blunt: 0.7 # Omu, was 0.8
+        Slash: 0.7 # Omu, was 0.8
+        Piercing: 0.7 # Omu, was 0.8
         Heat: 0.8
 
 - type: entity
@@ -368,9 +368,9 @@
     coverage:
     - Head
     traumaDeductions:
-      Dismemberment: 0.3
-      OrganDamage: 0.3
-      BoneDamage: 0.3
+      Dismemberment: 0.2 # Omu, was 0.3
+      OrganDamage: 0.2 # Omu, was 0.3
+      BoneDamage: 0.2 # Omu, was 0.3
       VeinsDamage: 0
       NerveDamage: 0
     modifiers:
@@ -394,9 +394,9 @@
     coverage:
     - Head
     traumaDeductions:
-      Dismemberment: 0.3
-      OrganDamage: 0.3
-      BoneDamage: 0.3
+      Dismemberment: 0.2 # Omu, was 0.3
+      OrganDamage: 0.2 # Omu, was 0.3
+      BoneDamage: 0.2 # Omu, was 0.3
       VeinsDamage: 0
       NerveDamage: 0
     modifiers:
@@ -446,9 +446,9 @@
       NerveDamage: 0
     modifiers:
       coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.8
+        Blunt: 0.7 # Omu, was 0.8
+        Slash: 0.7 # Omu, was 0.8
+        Piercing: 0.7 # Omu, was 0.8
         Heat: 0.8
   - type: Tag
     tags:
@@ -644,9 +644,9 @@
       NerveDamage: 0
     modifiers:
       coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.8
+        Blunt: 0.7 # Omu, was 0.8
+        Slash: 0.7 # Omu, was 0.8
+        Piercing: 0.7 # Omu, was 0.8
         Heat: 0.8
 
 - type: entity
@@ -670,9 +670,9 @@
       NerveDamage: 0
     modifiers:
       coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.8
+        Blunt: 0.7 # Omu, was 0.8
+        Slash: 0.7 # Omu, was 0.8
+        Piercing: 0.7 # Omu, was 0.8
         Heat: 0.8
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -229,10 +229,10 @@
       NerveDamage: 0
     modifiers:
       coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.6
-        Heat: 0.6
+        Blunt: 0.35 # Omu, was 0.6
+        Slash: 0.35 # Omu, was 0.6
+        Piercing: 0.35 # Omu, was 0.6
+        Heat: 0.35 # Omu, was 0.6
         Radiation: 0.75
         Caustic: 0.75
   - type: ExplosionResistance

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -170,6 +170,7 @@
   - type: Armor
     coverage:
     - Chest
+    - Groin # Omu, add back Groin prot
     traumaDeductions:
       Dismemberment: 0.2
       OrganDamage: 0.2
@@ -178,10 +179,10 @@
       NerveDamage: 0
     modifiers:
       coefficients:
-        Blunt: 0.70
-        Slash: 0.70
-        Piercing: 0.70
-        Heat: 0.80
+        Blunt: 0.55 # Omu, was 0.7
+        Slash: 0.55 # Omu, was 0.7
+        Piercing: 0.55 # Omu, was 0.7
+        Heat: 0.7 # Omu, was 0.8
   - type: ExplosionResistance
     damageCoefficient: 0.90
   - type: ModifyDelayedKnockdown # Goobstation
@@ -240,7 +241,7 @@
       coefficients:
         Blunt: 0.35
         Slash: 0.35
-        Piercing: 0.8
+        Piercing: 0.6 # Omu, was 0.8
         Heat: 0.6
         Caustic: 0.75
   - type: ExplosionResistance
@@ -558,6 +559,7 @@
   - type: Armor
     coverage:
     - Chest
+    - Groin
     traumaDeductions:
       Dismemberment: 0.2
       OrganDamage: 0.2
@@ -566,11 +568,11 @@
       NerveDamage: 0
     modifiers:
       coefficients:
-        Blunt: 0.5
-        Slash: 0.5
-        Piercing: 0.6
-        Heat: 0.5
-        Caustic: 0.9
+        Blunt: 0.3 # Omu, was 0.5
+        Slash: 0.3 # Omu, was 0.5
+        Piercing: 0.4 # Omu, was 0.6
+        Heat: 0.3 # Omu, was 0.5
+        Caustic: 0.75 # Omu, was 0.9
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -218,11 +218,11 @@
     - Leg
     modifiers:
       coefficients:
-        Blunt: 0.65
-        Slash: 0.65
-        Piercing: 0.6
-        Heat: 0.7
-        Caustic: 0.75
+        Blunt: 0.6 # Omu, was 0.65
+        Slash: 0.6 # Omu, was 0.65
+        Piercing: 0.55 # Omu, was 0.6
+        Heat: 0.55 # Omu, was 0.7
+        Caustic: 0.6  # Omu, was 0.75
   - type: ExplosionResistance
     damageCoefficient: 0.9
   - type: ModifyDelayedKnockdown # Goobstation
@@ -245,11 +245,11 @@
     - Leg
     modifiers:
       coefficients:
-        Blunt: 0.65
-        Slash: 0.65
-        Piercing: 0.7
-        Heat: 0.7
-        Caustic: 0.9
+        Blunt: 0.6 # Omu, was 0.65
+        Slash: 0.6 # Omu, was 0.65
+        Piercing: 0.65 # Omu, was 0.7
+        Heat: 0.55 # Omu, was 0.7
+        Caustic: 0.8 # Omu, was 0.9
   - type: ExplosionResistance
     damageCoefficient: 0.9
   - type: ModifyDelayedKnockdown # Goobstation
@@ -652,7 +652,7 @@
   parent: [ClothingOuterStorageBase, BaseSecurityContraband, BaseSecondSkinHolder] # Goobstation
   id: ClothingOuterCoatAMG
   name: armored medical gown
-  description: The version of the medical gown, with elements of an armor vest, looks strange, but your heart is protected.
+  description: The version of the medical gown, with elements of a bulletproof vest, looks strange, but your heart is protected. # Omu, revert desc change
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Coats/brigmedic.rsi
@@ -665,7 +665,7 @@
       coefficients:
         Blunt: 0.7
         Slash: 0.7
-        Piercing: 0.7
+        Piercing: 0.4 # Omu, was 0.7
         Heat: 0.7
         Caustic: 0.4
   - type: ModifyDelayedKnockdown # Goobstation

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
@@ -58,12 +58,13 @@
       NerveDamage: 0
     coverage:
     - Chest
+    - Groin # Omu, add back groin coverage
     modifiers:
       coefficients:
-        Blunt: 0.6 #ballistic plates = better protection
-        Slash: 0.6
-        Piercing: 0.3
-        Heat: 0.9
+        Blunt: 0.4 # Omu, was 0.6
+        Slash: 0.4 # Omu, was 0.6
+        Piercing: 0.2 # Omu, was 0.3
+        Heat: 0.8 # Omu, was 0.9
   - type: ExplosionResistance
     damageCoefficient: 0.9
   - type: ModifyDelayedKnockdown # Goobstation
@@ -95,14 +96,15 @@
       NerveDamage: 0
     coverage:
     - Chest
+    - Groin # Omu, add back groin coverage
     modifiers:
       coefficients:
-        Blunt: 0.5
-        Slash: 0.5
-        Piercing: 0.7
-        Heat: 0.3
-        Radiation: 0.5
-        Caustic: 0.5
+        Blunt: 0.3 # Omu, was 0.5
+        Slash: 0.3 # Omu, was 0.5
+        Piercing: 0.55 # Omu, was 0.7
+        Heat: 0.2 # Omu, was 0.3
+        Radiation: 0.3 # Omu, was 0.5
+        Caustic: 0.3 # Omu, was 0.5
   - type: ExplosionResistance
     damageCoefficient: 0.5
   - type: FireProtection
@@ -133,12 +135,13 @@
       NerveDamage: 0
     coverage:
     - Chest
+    - Groin # Omu, add back groin coverage
     modifiers:
       coefficients:
-        Blunt: 0.7 #slightly better overall protection but slightly worse than bulletproof armor against bullets seems sensible
-        Slash: 0.7
-        Piercing: 0.5
-        Heat: 0.9
+        Blunt: 0.55 # Omu, was 0.7
+        Slash: 0.55 # Omu, was 0.7
+        Piercing: 0.3 # Omu, was 0.5
+        Heat: 0.8 # Omu, was 0.9
   - type: ExplosionResistance
     damageCoefficient: 0.9
   - type: ModifyDelayedKnockdown # Goobstation

--- a/Resources/Prototypes/_Goobstation/Changeling/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Entities/Clothing/OuterClothing/armor.yml
@@ -38,7 +38,7 @@
   - type: Armor
     traumaDeductions:
       Dismemberment: 1
-      OrganDamage: 0.5
+      OrganDamage: 0.3 # Omu, was 0.5
       BoneDamage: 0.5
       VeinsDamage: 0
       NerveDamage: 0

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/hats.yml
@@ -46,10 +46,10 @@
       NerveDamage: 0
     modifiers:
       coefficients:
-        Blunt: 0.7
-        Slash: 0.7
-        Piercing: 0.7
-        Heat: 0.8
+        Blunt: 0.3 # Omu, was 0.7
+        Slash: 0.3 # Omu, was 0.7
+        Piercing: 0.3 # Omu, was 0.7
+        Heat: 0.3 # Omu, was 0.8
         Radiation: 0.75
         Caustic: 0.75
   - type: ExplosionResistance
@@ -80,10 +80,10 @@
       NerveDamage: 0
     modifiers:
       coefficients:
-        Blunt: 0.7
-        Slash: 0.7
-        Piercing: 0.7
-        Heat: 0.8
+        Blunt: 0.3 # Omu, was 0.7
+        Slash: 0.3 # Omu, was 0.7
+        Piercing: 0.3 # Omu, was 0.7
+        Heat: 0.3 # Omu, was 0.8
         Radiation: 0.75
         Caustic: 0.75
   - type: ExplosionResistance
@@ -114,10 +114,10 @@
       NerveDamage: 0
     modifiers:
       coefficients:
-        Blunt: 0.7
-        Slash: 0.7
-        Piercing: 0.7
-        Heat: 0.8
+        Blunt: 0.3 # Omu, was 0.7
+        Slash: 0.3 # Omu, was 0.7
+        Piercing: 0.3 # Omu, was 0.7
+        Heat: 0.3 # Omu, was 0.8
         Radiation: 0.75
         Caustic: 0.75
   - type: ExplosionResistance
@@ -148,10 +148,10 @@
       NerveDamage: 0
     modifiers:
       coefficients:
-        Blunt: 0.7
-        Slash: 0.7
-        Piercing: 0.7
-        Heat: 0.8
+        Blunt: 0.3 # Omu, was 0.7
+        Slash: 0.3 # Omu, was 0.7
+        Piercing: 0.3 # Omu, was 0.7
+        Heat: 0.3 # Omu, was 0.8
         Radiation: 0.75
         Caustic: 0.75
   - type: ExplosionResistance
@@ -182,10 +182,10 @@
       NerveDamage: 0
     modifiers:
       coefficients:
-        Blunt: 0.7
-        Slash: 0.7
-        Piercing: 0.7
-        Heat: 0.8
+        Blunt: 0.3 # Omu, was 0.7
+        Slash: 0.3 # Omu, was 0.7
+        Piercing: 0.3 # Omu, was 0.7
+        Heat: 0.3 # Omu, was 0.8
         Radiation: 0.75
         Caustic: 0.75
   - type: ExplosionResistance
@@ -226,10 +226,10 @@
       NerveDamage: 0
     modifiers:
       coefficients:
-        Blunt: 0.7
-        Slash: 0.7
-        Piercing: 0.7
-        Heat: 0.8
+        Blunt: 0.3 # Omu, was 0.7
+        Slash: 0.3 # Omu, was 0.7
+        Piercing: 0.3 # Omu, was 0.7
+        Heat: 0.3 # Omu, was 0.8
         Radiation: 0.75
         Caustic: 0.75
   - type: ExplosionResistance

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/armour.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/armour.yml
@@ -39,10 +39,10 @@
     - Chest
     modifiers:
       coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.6
-        Heat: 0.6
+        Blunt: 0.4 # Omu, was 0.6
+        Slash: 0.4 # Omu, was 0.6
+        Piercing: 0.25 # Omu, was 0.6
+        Heat: 0.55 # Omu, was 0.6
   - type: ExplosionResistance
     damageCoefficient: 0.9
   - type: ModifyDelayedKnockdown # Goobstation
@@ -67,10 +67,10 @@
     - Chest
     modifiers:
       coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.4
-        Heat: 0.8
+        Blunt: 0.5 # Omu, was 0.6
+        Slash: 0.5 # Omu, was 0.6
+        Piercing: 0.3 # Omu, was 0.4
+        Heat: 0.3 # Omu, was 0.8
   - type: ExplosionResistance
     damageCoefficient: 0.9
   - type: ModifyDelayedKnockdown # Goobstation
@@ -135,11 +135,11 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.7
-        Heat: 0.6
-        Caustic: 0.8
+        Blunt: 0.35 # Omu, was 0.6
+        Slash: 0.35 # Omu, was 0.6
+        Piercing: 0.45 # Omu, was 0.7
+        Heat: 0.35 # Omu, was 0.6
+        Caustic: 0.6 # Omu, was 0.8
 
 - type: entity
   parent: [ ClothingOuterArmorCaptainCarapace, ClothingOuterWinterCoatToggleable ]
@@ -156,11 +156,11 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.7
-        Heat: 0.6
-        Caustic: 0.8
+        Blunt: 0.4 # Omu, was 0.6
+        Slash: 0.4 # Omu, was 0.6
+        Piercing: 0.5 # Omu, was 0.7
+        Heat: 0.4 # Omu, was 0.6
+        Caustic: 0.65 # Omu, was 0.8
   - type: ToggleableClothing
     clothingPrototypes:
       head: ClothingHeadHatHoodWinterCapFancy
@@ -232,10 +232,10 @@
     - Chest
     modifiers:
       coefficients:
-        Blunt: 0.5
-        Slash: 0.5
-        Piercing: 0.5
-        Heat: 0.5
+        Blunt: 0.35 # Omu, was 0.5
+        Slash: 0.35 # Omu, was 0.5
+        Piercing: 0.35 # Omu, was 0.5
+        Heat: 0.35 # Omu, was 0.5
   - type: ExplosionResistance
     damageCoefficient: 0.2
   - type: ModifyDelayedKnockdown


### PR DESCRIPTION
## About the PR
Second skin is disabled on omu, this reverts the armor changes made to align with second skin.

## Why / Balance
Second skin is disabled, this makes the armor align with it being removed.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Changed armor values back to pre-second skin values.