### PR TITLE
Disable xeno gibing

### DIFF
--- a/Content.Server/_White/Xenomorphs/Larva/XenomorphLarvaSystem.cs
+++ b/Content.Server/_White/Xenomorphs/Larva/XenomorphLarvaSystem.cs
@@ -11,6 +11,8 @@ using Content.Shared.Popups;
 using Robust.Server.Containers;
 using Robust.Shared.Containers;
 using Robust.Shared.Player;
+using Content.Shared.Damage; // Omu
+using Content.Shared._Shitmed.Targeting; // Omu
 
 namespace Content.Server._White.Xenomorphs.Larva;
 
@@ -21,6 +23,7 @@ public sealed class XenomorphLarvaSystem : EntitySystem
     [Dependency] private readonly DoAfterSystem _doAfter = default!;
     [Dependency] private readonly JitteringSystem _jitter = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
+    [Dependency] private readonly DamageableSystem _damageableSystem = default!; // Omu
 
     public override void Initialize()
     {
@@ -74,6 +77,10 @@ public sealed class XenomorphLarvaSystem : EntitySystem
             return;
 
         _container.Remove(uid, container);
-        _body.GibBody(victim);
+        var damage = new DamageSpecifier(); // Omu start
+        damage.DamageDict.Add("Blunt", 120);
+        damage.DamageDict.Add("Piercing", 80);
+        _damageableSystem.TryChangeDamage(uid: victim, damage: damage, ignoreResistances: true, interruptsDoAfters: false, targetPart: TargetBodyPart.Chest);
+        //_body.GibBody(victim); // Omu end
     }
 }


### PR DESCRIPTION
## About the PR
Chestbursters no longer gib, instead dealing 120 blunt and 80 peirce to the torso, killing the person, but not making them unrevivable.

## Why / Balance
Was requested by a few admins.

## Media
<img width="1036" height="531" alt="image" src="https://github.com/user-attachments/assets/c9416d5f-3ad6-4903-9df8-c3c63b806f5c" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Chestbursters no longer gib, instead they deal large amounts of damage to the torso.
