### PR TITLE
Added A Global DoAfter Delay to All Oni & Predicted the Delay

### DIFF
--- a/Content.Goobstation.Common/DoAfter/DoAfterDelayMultiplierComponent.cs
+++ b/Content.Goobstation.Common/DoAfter/DoAfterDelayMultiplierComponent.cs
@@ -6,14 +6,13 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-using Robust.Shared.GameObjects;
-using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.GameStates;
 
 namespace Content.Goobstation.Common.DoAfter;
 
-[RegisterComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState] // Omu Station Change - Made NetWorked for Prediction
 public sealed partial class DoAfterDelayMultiplierComponent : Component
 {
-    [DataField]
+    [DataField, AutoNetworkedField] // Omu Change- Prediction
     public float Multiplier = 1f;
 }

--- a/Content.Goobstation.Shared/DoAfter/DoAfterDelayMultiplierSystem.cs
+++ b/Content.Goobstation.Shared/DoAfter/DoAfterDelayMultiplierSystem.cs
@@ -37,5 +37,6 @@ public sealed class DoAfterDelayMultiplierSystem : EntitySystem
     private void OnGetMultiplier(Entity<DoAfterDelayMultiplierComponent> ent, ref GetDoAfterDelayMultiplierEvent args)
     {
         args.Multiplier *= ent.Comp.Multiplier;
+        Dirty(ent); // Omu Change, DoAfterDelay Prediction
     }
 }

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/Oni.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/Oni.yml
@@ -81,6 +81,9 @@
     - DoorBumpOpener
     - AnomalyHost
     - Oni
+  # Omu Station - Global Oni DoAfter Delay
+  - type: DoAfterDelayMultiplier
+    multiplier: 2
 
 - type: entity
   save: false


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
This PR Adds a Global DoAfter to all Oni. (Makes it 2x longer)

## Why / Balance
Oni are large and it should take them longer to preform actions (This make its 2x longer to do anything with DoAfter)
Also Bounty.

## Technical details
- ~~WoundMed~~ ShitMed already had a GlobalDoAfterMultiplyer which was changed to be predicted (by just making the component be sent to the client, otherwise it will show the normal progress than switch onto the one from the server making the progress bar look unsmooth.
- **Surgical Gloves**, if an Oni uses surgical gloves or tools their Delay will be applied along their multiplyer, so by this PR Oni multiplyer is 2x while surgical gloves is 0.6x, it means with surgical gloves Oni Do After will be 1.2x longer than normal.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Richard Blonski
- tweak: Tweak: Oni take longer to preform actions, due to their size.
