### PR TITLE
[BOUNTY] Replace judo on the HOS belt.

### DIFF
--- a/Resources/Prototypes/_Omu/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_Omu/Entities/Clothing/Belt/belts.yml
@@ -53,7 +53,7 @@
     sprite: _Omu/Clothing/Belt/clothingbelthoscqc.rsi
   - type: Clothing
     sprite: _Omu/Clothing/Belt/clothingbelthoscqc.rsi
-  - type: GrantCorporateJudo
+  - type: GrantCapoeira
   - type: Storage
     whitelist:
       tags:
@@ -83,7 +83,7 @@
       - ScatteringGrenade
   - type: GuideHelp
     guides:
-    - CorporateJudo
+    - Capoeira
   - type: StealTarget
     stealGroup: WeaponSecHeadSword
 


### PR DESCRIPTION
## About the PR
Replaced judo on the HOS belt with Capoeira

## Why / Balance
Cyg wanted it, balance wise? capoeira requires more skill than CQC imo.

## Technical details
Copies over some stuff from GrantCQC to make GrantCapoeira work with clothing.

## Media
<img width="788" height="758" alt="image" src="https://github.com/user-attachments/assets/ade37ba9-6988-447a-829d-49cb79747845" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Changed Qua Nar'Vulna from Judo to Capoeira 
