### PR TITLE
Make hollows revivable

### DIFF
--- a/Content.Goobstation.Server/Changeling/ChangelingSystem.Abilities.cs
+++ b/Content.Goobstation.Server/Changeling/ChangelingSystem.Abilities.cs
@@ -194,7 +194,7 @@ public sealed partial class ChangelingSystem
         _blood.SpillAllSolutions(target);
 
         EnsureComp<AbsorbedComponent>(target);
-        EnsureComp<UnrevivableComponent>(target);
+        // EnsureComp<UnrevivableComponent>(target); Omu - Make hollows revivable again
 
         var popup = string.Empty;
         var bonusChemicals = 0f;


### PR DESCRIPTION
## About the PR
Hollows are now revivable again.

## Why / Balance
I hate ling
jks
cyg wanted this
also it was sneaked into the ling shit in a "cryo rework" without a proper changelog.

## Technical details


## Media
<img width="209" height="157" alt="FUCK" src="https://github.com/user-attachments/assets/a662c8d2-ac7f-44ac-9316-d73055db0eab" />


Why is space better than bothering with Cryo vro.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I did not hire a hitman to hunt whoever nerfed cryo to the tomb.

## Breaking changes


**Changelog**
:cl:
- tweak: Hollowed out people can now be revived if you get rid of the genetic damage.
