### PR TITLE
Death to validhunting Shiva

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -978,8 +978,8 @@
 #    tags:
 #    - Security
 #    - Brig
-#  - type: Puller
-#    needsHands: false # Omu end / Death to validhunting Shiva
+  - type: Puller
+    needsHands: false # Omu end
   - type: LanguageKnowledge # Einstein Engines - Language
     speaks:
     - Xeno


### PR DESCRIPTION
## About the PR
Me when I port features from a bad fork and act surprised when people abuse them to be a shitter.
Why is shiva even giving two fucks about criminals, they're just a goofy spider that has red.

Pets validhunting shouldn't even be a thing, I don't know why we are giving Shiva any of this, Smile shouldn't have received any changes either but at least they can't make you fall asleep or be a annoying pest.

## Why / Balance
Tired of validhunting shivas, if you wanna play a secoff, join the game normally instead.

## Technical details

## Media
Insert media of shiva with a red circle with arrows pointing at them.


## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- remove: Removed Shiva's nocturine injection along with their access to security.
