### PR TITLE
Fix Prevent lobby players from hearing barks

### DIFF
--- a/Content.Goobstation.Client/Barks/BarkSystem.cs
+++ b/Content.Goobstation.Client/Barks/BarkSystem.cs
@@ -7,6 +7,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using Content.Goobstation.Common.CCVar;
+using Robust.Client.Player;
 
 namespace Content.Goobstation.Client.Barks;
 
@@ -17,6 +18,7 @@ public sealed class BarkSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedAudioSystem _sharedAudio = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!; // Omu
 
     private readonly Dictionary<NetEntity, EntityUid> _playingSounds = new();
     private static readonly char[] Characters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890".ToCharArray();
@@ -66,6 +68,12 @@ public sealed class BarkSystem : EntitySystem
         var volume = GetVolume(whisper, proto);
         if (volume <= -20f)
             return;
+
+        // Omu inLobby bark-fix
+        var session = _playerManager.LocalSession;
+        if (session?.AttachedEntity == null)
+            return;
+        // Omu end
 
         var upperCount = 0;
         foreach (var c in message)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
When you're in the lobby and doing other things but the game is open in the background you're still able to hear the barks-voices of some clients.

I was unable to reproduce this bug locally with multiple clients, so hopefully this works.
Should be a minimal change that uses AttachedEntity to detect lobby state.

## Why / Balance
Players in the lobby shouldn't hear barks. Audio leaked from the game world into the lobby, which is incredibly annoying when you're just seeding or doing something else.

## Technical details
Added a simple null check for `AttachedEntity` to (hopefully) detect in-lobby state. It should be null when you're in the lobby or not spawned in, givess an early return to prevent bark audio playing. Worst case bug persists, shouldn't affect players in the game.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A - Audio fix

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
fix: Lobby players should no longer hear barks from in-game players
