### PR TITLE
Admin command `lstraits`

### DIFF
--- a/Content.Omu.Server/Administration/Commands/lstraits.cs
+++ b/Content.Omu.Server/Administration/Commands/lstraits.cs
@@ -18,8 +18,8 @@ public sealed class LsTraits : LocalizedCommands
     [Dependency] private readonly IServerPreferencesManager _prefsManager = default!;
 
     public override string Command => "lstraits";
-    public override string Description => "Lists the traits of a specified player.";
-    public override string Help => "Usage: lstraits <Username>";
+    public override string Description => Loc.GetString("lstraits-desc");
+    public override string Help => Loc.GetString("lstraits-help");
 
     public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
@@ -31,31 +31,31 @@ public sealed class LsTraits : LocalizedCommands
 
         if (session == null)
         {
-            shell.WriteError(LocalizationManager.GetString("shell-target-player-does-not-exist"));
+            shell.WriteError(Loc.GetString("shell-could-not-find-entity"));
             return;
         }
 
         // Get the player's preferences
         if (!_prefsManager.TryGetCachedPreferences(session.UserId, out var prefs))
         {
-            shell.WriteError("Could not find player preferences. Have they fully connected?");
+            shell.WriteError(Loc.GetString("lstraits-could-not-find-player-preferences"));
             return;
         }
 
         // Get the selected character profile
         if (prefs.SelectedCharacter is not HumanoidCharacterProfile character)
         {
-            shell.WriteError("Could not find character profile.");
+            shell.WriteError(Loc.GetString("lstraits-could-not-find-profile"));
             return;
         }
 
-        shell.WriteLine($"Traits for {character.Name} (User: {session.Name}):");
+        shell.WriteLine(Loc.GetString("lstraits-traits "));
 
         // Get the player's traits
         var traits = character.TraitPreferences;
         if (!traits.Any())
         {
-            shell.WriteLine("No traits found.");
+            shell.WriteLine(Loc.GetString("lstraits-no-traits"));
             return;
         }
 
@@ -64,7 +64,7 @@ public sealed class LsTraits : LocalizedCommands
         {
             shell.WriteLine(_prototypeManager.TryIndex(traitId, out _)
                 ? $"  - {traitId}"
-                : $"  - Unknown trait: {traitId}");
+                : LocalizationManager.GetString("lstraits-unknown-trait"));
         }
     }
 
@@ -76,7 +76,7 @@ public sealed class LsTraits : LocalizedCommands
         {
             return CompletionResult.FromHintOptions(
                 CompletionHelper.SessionNames(),
-                LocalizationManager.GetString("shell-argument-username-hint"));
+                Loc.GetString("shell-argument-username-hint"));
         }
 
         return CompletionResult.Empty;

--- a/Resources/Locale/en-US/_Omu/administration/commands.ftl
+++ b/Resources/Locale/en-US/_Omu/administration/commands.ftl
@@ -1,0 +1,7 @@
+lstraits-desc = Lists the traits of a specified player.
+lstraits-help = Usage: ls-traits <Username>
+lstraits-could-not-find-player-preferences = Could not find player preferences. Have they fully connected?
+lstraits-could-not-find-profile = Could not find character profile.
+lstraits-traits = Traits for {character.Name} (User: {session.Name}):
+lstraits-no-traits = No traits found.
+lstraits-unknown-trait = Unknown trait: {traitId}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
This PR adds the new admin command `lstraits` for any admins with the `log` type access.

## Why / Balance
Allows admins to get a list of all traits from a player based upon their selected character profile.

This is also a requirement for our staff team to be capable of administrating a possible addition of traits that give you some knoweldge regarding the meta-shield.

## Media
<img width="910" height="246" alt="image" src="https://github.com/user-attachments/assets/a4cfb89e-7a66-4307-a7d4-d4570a6de018" />
<img width="735" height="85" alt="image" src="https://github.com/user-attachments/assets/dee3528f-f729-41c2-b5a0-971e48178210" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelogs
Not needed, it's admin only.
