### PR TITLE
NCT should be strippable

### DIFF
--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Dignitary/nanotrasen_career_trainer.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Dignitary/nanotrasen_career_trainer.yml
@@ -25,9 +25,6 @@
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant, BluespaceLifelineImplant ]
-  - !type:RemoveComponentSpecial # Omu, no stealing NCT's gear
-    components:
-    - type: Strippable
 #  - !type:AddComponentSpecial # Intentionally not command. I don't want them to ruin rev rounds.
 #    components:
 #    - type: CommandStaff


### PR DESCRIPTION
<!-- What did you change? -->

If they are on station, they should not be "special" or different from other players. This is immersion breaking. The same should be said for CCO's who decide to go on station.

## Why / Balance
It's immersion breaking and just bullshit tbh

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: NCT is actually a crew member - no godmode or admin special things need to apply to them
