### PR TITLE
Fix changling abilities not being copied when polymorphing

### DIFF
--- a/Content.Goobstation.Server/Changeling/ChangelingSystem.Omu.cs
+++ b/Content.Goobstation.Server/Changeling/ChangelingSystem.Omu.cs
@@ -1,0 +1,49 @@
+using Content.Goobstation.Shared.Changeling.Components;
+using Content.Shared.Eye.Blinding.Components;
+using Content.Shared.Flash.Components;
+
+namespace Content.Goobstation.Server.Changeling;
+
+public sealed partial class ChangelingSystem
+{
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+    private ISawmill _sawmill = default!;
+
+    // Keep a list of all components changeling abilities we want to copy
+    private static readonly Type[] ComponentsToCopy =
+    {
+        typeof(FlashImmunityComponent),
+        typeof(EyeProtectionComponent),
+        typeof(Shared.Overlays.NightVisionComponent),
+        typeof(Shared.Overlays.ThermalVisionComponent),
+        typeof(VoidAdaptionComponent),
+    };
+
+    /// <summary>
+    /// Copies essential changeling ability components from one entity to another during polymorph.
+    /// This ensures that changelings retain their special abilities (like thermal vision and space immunity)
+    /// when transforming between different forms.
+    /// </summary>
+    /// <param name="uid">Source entity to copy components from</param>
+    /// <param name="newEnt">Target entity to copy components to</param>
+    /// <param name="comp">Optional ChangelingIdentityComponent reference</param>
+    private void TryChangelingCopyComp(EntityUid uid, EntityUid newEnt, ChangelingIdentityComponent? comp)
+    {
+        // Try to copy each component individually
+        foreach (var componentType in ComponentsToCopy)
+        {
+            try
+            {
+                if (!_entityManager.TryGetComponent(uid, componentType, out var component))
+                    continue;
+
+                var newComp = (Component) _serialization.CreateCopy(component, notNullableOverride: true);
+                _entityManager.AddComponent(newEnt, newComp);
+            }
+            catch (Exception ex)
+            {
+                _sawmill.Error($"Changling Polymorph Copy System: Failed to copy component {componentType.Name}: {ex.Message}");
+            }
+        }
+    }
+}

--- a/Content.Goobstation.Server/Changeling/ChangelingSystem.cs
+++ b/Content.Goobstation.Server/Changeling/ChangelingSystem.cs
@@ -690,6 +690,11 @@ public sealed partial class ChangelingSystem : SharedChangelingSystem
         // otherwise we can only transform once
         RemCompDeferred<PolymorphedEntityComponent>(newEnt);
 
+        // Omu - Ensure changlings copy all components when they polymorphs.
+        TryChangelingCopyComp(uid, newEnt, comp);
+        // Refer to - ChangelingSystem.Omu.cs for edits
+        #region Omu edits - outdated code
+        /*
         // exceptional comps check
         // TODO make PolymorphedEvent handlers for all
         List<Type> types = new()
@@ -702,6 +707,9 @@ public sealed partial class ChangelingSystem : SharedChangelingSystem
         };
         foreach (var type in types)
             _polymorph.CopyPolymorphComponent(uid, newEnt, nameof(type));
+        */
+        // Omu End
+        #endregion
 
         // CopyPolymorphComponent fails to copy the HumanoidAppearanceComponent in TransformData
         // outside of the first list item so this has to be done manually unfortunately


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
This PR ensures changlings abilities (components) get copied when they polymorph.

## Why / Balance
Bug

## Technical details
Commented out the code we replacing and moved our code into `.Omu.cs` File

## Media
https://youtu.be/SNHa8NQCyCw

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Richard Blonski
- fix: Fixed changlings abilities being lost when polymorphed