### PR TITLE
[FIX] Allow heretic summons to use abilities again

### DIFF
--- a/Content.Shared/_Shitcode/Heretic/Systems/Abilities/SharedHereticAbilitySystem.cs
+++ b/Content.Shared/_Shitcode/Heretic/Systems/Abilities/SharedHereticAbilitySystem.cs
@@ -186,10 +186,11 @@ public abstract partial class SharedHereticAbilitySystem : EntitySystem
 
         // doesn't have any roles that allow heretic abilities
         // this is mostly a barrier for idiots who want to transfer their brains into heretic bodies.
+        /* - Omu, this check breaks all summons, and isn't really needed, so its getting disabled.
         if (_mind.TryGetMind(ent, out var mindId, out var mind)
         && mind.MindRoles.Where(q => HasComp<HereticRoleComponent>(q)).ToList().Count == 0)
             return false;
-
+        */
         // check if any magic items are worn
         if (!TryComp<HereticComponent>(ent, out var hereticComp)
         || !actionComp.RequireMagicItem


### PR DESCRIPTION
## About the PR
Fixes heretic summons being unable to use abilities 

## Why / Balance
Bugfix

## Technical details
Comments out the check for Hereticmindroll for heretic abilities (There is no real reason to have this, and it breaks shit by having it)

## Media
<img width="1057" height="807" alt="image" src="https://github.com/user-attachments/assets/4444e8e6-5a48-4a45-867e-6295648edf3a" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed Heretic summons being unable to use their abilities.
