### PR TITLE
Re-enable cadet time limit

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -102,7 +102,7 @@
   requirements:
     - !type:OverallPlaytimeRequirement
       time: 18000 #5 hours - Omu edit start -  No way should you learn what the game is about as sec.
-      !type:DepartmentTimeRequirement
+    - !type:DepartmentTimeRequirement
       department: Security
       time: 36000 #10 hours
       inverted: true # Omu edit end


### PR DESCRIPTION
## About the PR
Sec is overfilled 

## Why / Balance
This role should be open to new players, not experienced players who wanna play sec. You can get back into the swing of things as a secoff just fine. There's no punishment for being unrobust.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Cadet is time limited again


