### PR TITLE
Minor changes to Heirophant's Club

### DIFF
--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/hierophant_club.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/hierophant_club.yml
@@ -21,7 +21,7 @@
 
 - type: entity
   id: LavalandHierophantClub
-  parent: BaseItem
+  parent: [ BaseItem, BaseMagicalContraband ] #Omu, add BaseMagicalContraband
   name: hierophant club
   description: Get item'ed lol
   components:
@@ -34,7 +34,7 @@
     - back
     - suitStorage
   - type: Item
-    size: Normal
+    size: Ginormous # Omu, was Normal
     sprite: _Lavaland/Objects/Weapons/hierophant_club-inhands.rsi
   - type: StaticPrice
     price: 5000


### PR DESCRIPTION
## About the PR
Heirophant's club no longer fits in a bag, carry it in suitstorage or hold it inhand, And Heirophant's club now is classed as magical contraband

## Why / Balance
It's a decently easy to obtain item that is stupidly strong and abused too much, this makes it so they run the risk of sec arresting them (Or outright killing them if they use it, as it is classed as magic).

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Heirophant's club is now classed as magical contraband, and no longer fits in bags.
