### PR TITLE
Removes MomentumSteering comp from moths.

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -179,7 +179,7 @@
     baseWeightlessAcceleration: 3 # Goobstation value
     baseWeightlessFriction: 1
     baseWeightlessModifier: 1
-  - type: MomentumSteering # Goobstation - No steer
+#  - type: MomentumSteering # Goobstation - No steer
   - type: Flammable
     damage:
       types:


### PR DESCRIPTION

## Why / Balance
The zero-g movement is a major part of moth species identity, removing it without any discussion (that I can find) is a bit strange. It's not an abused feature here as far as I can tell so I see no reason to nerf it.

## Technical details
Comments the MomentumSteering comp out of the moth.yml file. Doesn't touch the component or system added in the nerf PR.

## Media

https://github.com/user-attachments/assets/afbfc3f5-489a-4a62-b6a2-08a44dc1865f



## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None AFAIK.
**Changelog**
:cl:
 - fix: Fixed moth zero-g movement nerf.