### PR TITLE
Re-enables selfcharge on eshotty.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -1197,12 +1197,12 @@
   - type: Battery
     maxCharge: 1050 # Goobstation
     startingCharge: 1050
-  # Goob - remove self recharge
-  # - type: BatterySelfRecharger
-  #   autoRecharge: true
-  #   autoRechargeRate: 24
-  #   autoRechargePause: true
-  #   autoRechargePauseTime: 30
+   # Omu - we LOVE recharge.
+  - type: BatterySelfRecharger
+    autoRecharge: true
+    autoRechargeRate: 24
+    autoRechargePause: true
+    autoRechargePauseTime: 30
 
 - type: entity
   name: temperature gun # Goobstation


### PR DESCRIPTION
## About the PR
Makes Warden's Eshotgun recharge again after Goob disabled it.

## Why / Balance
I will stand for no nerfing of an actually reasonably balanced weapon while the 8 gauge boot revolver exists.

## Technical details
Un-comments the recharge YML in the eshotty's prototype.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None AFAIK.

**Changelog**
:cl:
- tweak: Made Ward shotgun selfcharge again.


