### PR TITLE
[TWEAK] Abductor walls are no longer immortal

### DIFF
--- a/Resources/Prototypes/_Shitmed/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Structures/Walls/walls.yml
@@ -54,8 +54,6 @@
         !type:DamageTrigger
         damage: 300
       behaviors:
-      - !type:ChangeConstructionNodeBehavior
-        node: girder
       - !type:PlaySoundBehavior
         sound:
           collection: MetalSlam
@@ -120,8 +118,6 @@
       - !type:PlaySoundBehavior
         sound:
           collection: MetalSlam
-      - !type:ChangeConstructionNodeBehavior
-        node: girder
       - !type:DoActsBehavior
         acts: ["Destruction"]
   # Omu end


### PR DESCRIPTION
## About the PR
Made it so abductor walls can actually be broken.

## Why / Balance
Now they will learn to fear the worm. Also them having indestructible walls is a very easy way for someone to ram the station VERY hard without consequences.

## Technical details
Copied over the relevant comps from standard shuttle walls.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Abductor walls are no longer unbreakable.
