### PR TITLE
kills the present anom

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/anomaly.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/anomaly.yml
@@ -43,8 +43,8 @@
     - id: AnomalyFlora
     - id: AnomalyShadow
     - id: AnomalyTech
-    - id: AnomalySanta
-      weight: .4 #  Make more common in december
+    # - id: AnomalySanta #omu edit 
+    #   weight: .4
     - id: RandomAnomalyInjectorSpawner # formerly rareChance 0.3, 30% chance of spawning. keep similar
       weight: 3.97 # (1/12*3.97)-(0.4/13) is very close to 30%
 
@@ -98,5 +98,5 @@
     - id: AnomalyTrapGravity
     - id: AnomalyTrapTech
     - id: AnomalyTrapRock
-    - id: AnomalyTrapSanta # Make more common in December
-      weight: .4
+    # - id: AnomalyTrapSanta #omu edit 
+    #   weight: .4


### PR DESCRIPTION
## About the PR
Removed the present anom from spawning naturally 

## Why / Balance
The present anom does not fit MRP, and is also almost completely safe, unlike other anoms 

## Technical details
just commenting out some lines of yaml

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- remove: Present anoms

