### PR TITLE
Reclaim the reclaimer and expeds

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/datasets/names/mining_shuttle.ftl
+++ b/Resources/Locale/en-US/_Goobstation/datasets/names/mining_shuttle.ftl
@@ -3,4 +3,4 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-mining-shuttle-names-dataset-1 = Salvage Shuttle
+mining-shuttle-names-dataset-1 = NT-Reclaimer

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -176,6 +176,8 @@
     - id: ComputerCargoCommsFlatpack #Omu adds departmental comms board
     - id: Multitool # Omu
     - id: SlotMachineHighRollerFlatPack # Goob - gambling
+    - id: SalvageShuttleConsoleCircuitboard # Omu edit
+    - id: SalvageExpeditionsComputerCircuitboard # Omu edit
 
 - type: entity
   id: LockerQuarterMasterFilled

--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -131,6 +131,10 @@
           paths:
             - /Maps/Shuttles/trading_outpost.yml
           nameDataset: TradeStationNames
+        mining: !type:GridSpawnGroup # omu edit start
+          paths:
+          - /Maps/Shuttles/mining.yml
+          nameDataset: MiningShuttleNames # omu edit end
         # Spawn last
         ruins: !type:GridSpawnGroup
           hide: true


### PR DESCRIPTION
## About the PR
readded the nt-reclaimer for salv's to use
added the salv shuttle console circuit board and exped console board to the qm's locker

## Why / Balance
gives the salvage role more to do 
allows salv to make better use of space and add back a favoured bit of content

## Technical details
just some yaml changes

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Reclaimed the NT-Reclaimer
- add: Expeditions Make a return

