### PR TITLE
Earlymerge Fix Construction Dupe

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.Initial.cs
+++ b/Content.Server/Construction/ConstructionSystem.Initial.cs
@@ -619,12 +619,11 @@ namespace Content.Server.Construction
             if(edge == null)
                 throw new InvalidDataException($"Can't find edge from starting node to the next node in pathfinding! Recipe: {prototypeName}");
 
-            if (_handsSystem.GetActiveItem((user, hands)) is {} holding
-                && senderSession != null) // Goobstation - don't check this for constructor machine
+            if (senderSession != null) // Goobstation - don't check this for constructor machine
             {
                 var valid = false;
 
-                if (entWith == null) // Goobstation - don't check for constructor machine
+                if (entWith is not {Valid: true} holding) // Goobstation - don't check for constructor machine
                 {
                     Cleanup();
                     return false;


### PR DESCRIPTION
## About the PR

see https://github.com/Goob-Station/Goob-Station/pull/6125

We never check if we have the mats to build what we have in constructionsystem so spamclicking ghosts lets you build if you run out of mats.

## Why / Balance


## Technical details


## Media


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**

:cl:
- fix: You can no longer construct buildables without actually having the materials to do so.