### PR TITLE
Add the ruling that Prisoner icon is not crew to silicon rule 8

### DIFF
--- a/Resources/ServerInfo/Guidebook/ServerRules/SiliconRules/RuleS8DefaultCrewDefinition.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/SiliconRules/RuleS8DefaultCrewDefinition.xml
@@ -26,6 +26,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   Icons that are not job icons:
   - Empty grey square, such as those on syndicate IDs
   - A question mark that indicates lack of ID
-  - A prisoner / prison icon
+  - A prisoner / prison icon, this only counts for orders they give
   - A syndicate icon
 </Document>


### PR DESCRIPTION
## About the PR
Updates silicon rule 8 to be up to date with how its enforced

## Why / Balance
Transits being crew to AI causes a lot of problems for security, also syndicate icon shouldn't be classed as crew...

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Changed silicon rule 8 to clarify that Prisoners and Syndicate icons are not crew.
