### PR TITLE
[HOTFIX] Disables lollypopcomponent as it causes issues.

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Consumable/Food/lollypops.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Consumable/Food/lollypops.yml
@@ -82,7 +82,7 @@
       reagents:
       - ReagentId: Sugar
         Quantity: 5
-  - type: Lollypop
+#  - type: Lollypop # Omu, this causes errors
 
 # Syndicate
 
@@ -423,8 +423,8 @@
       map: [ "enum.AmmoVisualLayers.Base" ]
     - state: lollypop-captain
       map: [ "enum.AmmoVisualLayers.Tip" ]
-  - type: Lollypop
-    deleteOnEmpty: false
+#  - type: Lollypop # Omu, this causes errors
+#    deleteOnEmpty: false
 
 # CentComm
 


### PR DESCRIPTION
## About the PR
Comments out the comp from the base lollypop

## Why / Balance
Its causing loads of server errors, until its fixed this will reduce the number of errors (its a minor thing anyway, as it just disables the automatic eating of lollypops in your mouth)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- remove: You no longer automatically eat lollypops in your mask slot.
