### PR TITLE
Fix plastitanium windows not linking to walls

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Windows/plastitanium.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/plastitanium.yml
@@ -64,7 +64,7 @@
 
 - type: entity
   id: PlastitaniumWindowBase
-  parent: BaseStructure
+  parent: WindowRCDResistant # Omu, change parent
   abstract: true
   name: plastitanium window
   description: Don't smudge up the glass down there.
@@ -73,41 +73,41 @@
     snap:
     - Window
   components:
-  - type: RCDDeconstructable
-    deconstructable: false
-  - type: MeleeSound
-    soundGroups:
-      Brute:
-        collection: GlassSmack
-  - type: WallMount
-    arc: 360 # interact despite grilles
-  - type: Tag
-    tags:
-      - ForceFixRotations
-      - Window
-  - type: Physics
-    bodyType: Static
-  - type: ExaminableDamage
-    messages: WindowMessages
-  - type: InteractionPopup
-    interactSuccessString: comp-window-knock
-    messagePerceivedByOthers: comp-window-knock
-    interactSuccessSound:
-      path: /Audio/Effects/glass_knock.ogg
+#  - type: RCDDeconstructable # Omu start
+#    deconstructable: false
+#  - type: MeleeSound
+#    soundGroups:
+#      Brute:
+#        collection: GlassSmack
+#  - type: WallMount
+#    arc: 360 # interact despite grilles
+#  - type: Tag
+#    tags:
+#      - ForceFixRotations
+#      - Window
+#  - type: Physics
+#    bodyType: Static
+#  - type: ExaminableDamage
+#    messages: WindowMessages
+#  - type: InteractionPopup
+#    interactSuccessString: comp-window-knock
+#    messagePerceivedByOthers: comp-window-knock
+#    interactSuccessSound:
+#      path: /Audio/Effects/glass_knock.ogg # Omu end
   - type: Appearance
   - type: StaticPrice
     price: 100
-  - type: BlockWeather
+#  - type: BlockWeather # Omu
   - type: Fixtures
     fixtures:
       fix1:
         shape:
-          !type:PhysShapeAabb
-          bounds: "-0.5,-0.5,0.5,0.5"
+          !type:PhysShapeAabb {} # Omu
+          #bounds: "-0.5,-0.5,0.5,0.5" #Omu
         mask:
         - FullTileMask
         layer:
-        - WallLayer
+        - GlassLayer # Omu
         density: 4000
 
 - type: entity
@@ -123,18 +123,18 @@
     sprite: Structures/Windows/plastitanium_window.rsi
     state: full
   - type: IconSmooth
-    key: windows
+#    key: windows # Omu
     base: ptwindow
-  - type: Airtight
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeAabb {}
-        mask:
-        - FullTileMask
-        layer:
-        - GlassLayer
+#  - type: Airtight # Omu start
+#  - type: Fixtures
+#    fixtures:
+#      fix1:
+#        shape:
+#          !type:PhysShapeAabb {}
+#        mask:
+#        - FullTileMask
+#        layer:
+#        - GlassLayer # Omu end
 
 - type: entity
   id: PlastitaniumWindowIndestructible


### PR DESCRIPTION
## About the PR
Fixes Plastitanium windows not linking to walls

## Why / Balance
It was annoying that they didn't link to walls.

## Technical details
Change parent from basestructure to BaseRCDResistantWindow, comment out bits that we don't need anymore.

## Media
<img width="390" height="290" alt="image" src="https://github.com/user-attachments/assets/39938470-ccf3-4321-ab7a-c881f7dd4292" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed Plastitanium windows not linking to adjacent walls. 
