### PR TITLE
Added the "SyringeGunAmmo" tag to syringes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -700,6 +700,7 @@
     tags:
     - Syringe
     - Trash
+    - SyringeGunAmmo # OmuStation
 
 # Goob disabled - proper syringe guns or something
 #- type: entity


### PR DESCRIPTION
## About the PR
Added the "SyringeGunAmmo" tag to syringes allowing them to be used by syringe guns once again

## Why / Balance

## Technical details

## Media

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl: Aureu
- tweak: Fixed syringes interaction with Syringe guns
