### PR TITLE
Remove command maid as command staff

### DIFF
--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Wildcards/command_maid.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Wildcards/command_maid.yml
@@ -22,7 +22,6 @@
   #Omu Start
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]
-  - !type:AddComponentSpecial
   #Omu End
   - !type:GiveItemOnHolidaySpecial
     holiday: GarbageDay


### PR DESCRIPTION
## About the PR
They are not command, they just kiss command's ass

## Why / Balance
Bloats command role

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- remove: Command component from command maid


