### PR TITLE
Allow digiboard to be linked to telepads

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/folders.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/folders.yml
@@ -311,3 +311,14 @@
     - HighRiskItem
   - type: StealTarget
     stealGroup: BoxFolderQmClipboard
+  # Omu start
+  - type: DeviceNetwork
+    deviceNetId: Wireless
+    receiveFrequencyId: BasicDevice
+  - type: WirelessNetworkConnection
+    range: 200
+  - type: DeviceLinkSource
+    range: 200
+    ports:
+      - OrderSender
+  # Omu end


### PR DESCRIPTION
## About the PR
Allows QM's digiboard to be linked to cargo telepads

## Why / Balance
Cargo request computers can do it, so QM's digiboard should be able to as well.

## Media
<img width="233" height="244" alt="image" src="https://github.com/user-attachments/assets/d11d650f-404f-4e40-8fe6-68342e9e07ef" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: QM's Digiboard can now be linked to cargo telepads.
