### PR TITLE
[PORT] GridProtect from monolith

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.Interactions.cs
+++ b/Content.Server/Construction/ConstructionSystem.Interactions.cs
@@ -103,6 +103,7 @@ using Content.Shared.Radio.EntitySystems;
 using Content.Shared.Stacks;
 using Content.Shared.Temperature;
 using Content.Shared.Tools.Systems;
+using Content.Shared._Mono.NoDeconstruct; // Monolith
 using Robust.Shared.Containers;
 using Robust.Shared.Utility;
 #if EXCEPTION_TOLERANCE
@@ -143,6 +144,9 @@ namespace Content.Server.Construction
         /// <returns>The result of this interaction with the entity.</returns>
         private HandleResult HandleEvent(EntityUid uid, object ev, bool validation, ConstructionComponent? construction = null)
         {
+            if (HasComp<NoDeconstructComponent>(uid))
+                return HandleResult.False;
+
             if (!Resolve(uid, ref construction))
                 return HandleResult.False;
 

--- a/Content.Server/Shuttles/Systems/DockingSystem.Shuttle.cs
+++ b/Content.Server/Shuttles/Systems/DockingSystem.Shuttle.cs
@@ -407,4 +407,25 @@ public sealed partial class DockingSystem
 
         return _dockingSet.ToList();
     }
+
+    /// <summary>
+    /// Mono: Checks if two grids are docked together by examining if any docking port on gridA is connected to any docking port on gridB.
+    /// </summary>
+    public bool AreGridsDocked(EntityUid gridA, EntityUid gridB)
+    {
+        var docksA = GetDocks(gridA);
+
+        foreach (var dockA in docksA)
+        {
+            if (!dockA.Comp.Docked || dockA.Comp.DockedWith == null)
+                continue;
+
+            // Get the grid that this dock is connected to
+            var connectedDockGrid = Transform(dockA.Comp.DockedWith.Value).GridUid;
+            if (connectedDockGrid == gridB)
+                return true;
+        }
+
+        return false;
+    }
 }

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
@@ -65,6 +65,7 @@ using Robust.Shared.Physics.Events;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using System.Numerics;
+using Content.Shared._Mono; // Monolith
 
 namespace Content.Server.Shuttles.Systems;
 
@@ -194,6 +195,16 @@ public sealed partial class ShuttleSystem
             // if we're not enabled, stop after playing sound
             if (!_enabled)
                 continue;
+
+            // Check if either grid has GridGodMode or ForceAnchor protection // Monolith start
+            var ourProtected = HasComp<GridGodModeComponent>(args.OurEntity);
+            var otherProtected = HasComp<GridGodModeComponent>(args.OtherEntity);
+
+            // Check if the grids are docked together to prevent impact
+            var areGridsDocked = _dockSystem.AreGridsDocked(args.OurEntity, args.OtherEntity);
+
+            if (ourProtected || otherProtected || areGridsDocked)
+                continue; // Monolith end
 
             // Convert the collision point directly to tile indices
             var ourTile = new Vector2i((int)Math.Floor(ourPoint.X / ourGrid.TileSize), (int)Math.Floor(ourPoint.Y / ourGrid.TileSize));

--- a/Content.Server/Wires/WiresSystem.cs
+++ b/Content.Server/Wires/WiresSystem.cs
@@ -80,10 +80,12 @@ using Content.Shared.Tools;
 using Content.Shared.Tag; // Shitmed Change
 using Content.Shared.Tools.Components;
 using Content.Shared.Wires;
+using Content.Shared._Mono.NoHack; // Monolith
 using Robust.Server.GameObjects;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
+using System.Runtime;
 
 namespace Content.Server.Wires;
 
@@ -702,6 +704,9 @@ public sealed class WiresSystem : SharedWiresSystem
 
     private void TryDoWireAction(EntityUid target, EntityUid user, EntityUid toolEntity, int id, WiresAction action, WiresComponent? wires = null, ToolComponent? tool = null)
     {
+        if (HasComp<NoHackComponent>(target)) // Monolith
+            return;
+
         if (!Resolve(target, ref wires)
             || !Resolve(toolEntity, ref tool))
             return;

--- a/Content.Server/_Mono/GridProtect/GridGodModeSystem.cs
+++ b/Content.Server/_Mono/GridProtect/GridGodModeSystem.cs
@@ -1,0 +1,127 @@
+using System.Linq;
+using Content.Server.Damage.Systems;
+using Content.Server.Spreader;
+using Content.Shared._Mono;
+using Content.Shared.Damage.Components;
+using Content.Shared.Ghost;
+using Content.Shared.Mind;
+using Content.Shared.Mobs.Components;
+using Robust.Shared.Map.Components;
+
+namespace Content.Server._Mono;
+
+/// <summary>
+/// System that handles the GridGodModeComponent, which applies GodMode to all non-organic entities on a grid.
+/// </summary>
+public sealed class GridGodModeSystem : EntitySystem
+{
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly GodmodeSystem _godmode = default!;
+    [Dependency] private readonly SharedMindSystem _mind = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<GridGodModeComponent, MapInitEvent>(OnGridGodModeMapInit);
+        SubscribeLocalEvent<GridGodModeComponent, ComponentShutdown>(OnGridGodModeShutdown);
+    }
+
+    private void OnGridGodModeMapInit(EntityUid uid, GridGodModeComponent component, MapInitEvent args)
+    {
+        // Verify this is applied to a grid
+        if (!HasComp<MapGridComponent>(uid))
+        {
+            Log.Warning($"GridGodModeComponent applied to non-grid entity {ToPrettyString(uid)}");
+            return;
+        }
+
+        // Find all entities on the grid and apply GodMode to them if they're not organic
+        var allEntitiesOnGrid = _lookup.GetEntitiesIntersecting(uid).ToHashSet();
+
+        foreach (var entity in allEntitiesOnGrid)
+        {
+            // Skip the grid itself
+            if (entity == uid)
+                continue;
+
+            ProcessEntityOnGrid(uid, entity, component);
+        }
+    }
+
+    private void OnGridGodModeShutdown(EntityUid uid, GridGodModeComponent component, ComponentShutdown args)
+    {
+        // When the component is removed, remove GodMode from all protected entities
+        foreach (var entity in component.ProtectedEntities.ToList())
+        {
+            if (EntityManager.EntityExists(entity))
+            {
+                RemoveGodMode(entity);
+            }
+        }
+
+        component.ProtectedEntities.Clear();
+    }
+
+    /// <summary>
+    /// Process an entity on a grid and apply GodMode if appropriate
+    /// </summary>
+    private void ProcessEntityOnGrid(EntityUid gridUid, EntityUid entityUid, GridGodModeComponent component)
+    {
+        // Don't apply GodMode to organic entities, ghosts, or kudzu
+        if (IsOrganic(entityUid) || HasComp<GhostComponent>(entityUid) || HasComp<KudzuComponent>(entityUid))
+            return;
+
+        ApplyGodMode(gridUid, entityUid, component);
+    }
+
+    /// <summary>
+    /// Applies GodMode to an entity and adds it to the protected entities list
+    /// </summary>
+    private void ApplyGodMode(EntityUid gridUid, EntityUid entityUid, GridGodModeComponent component)
+    {
+        // Skip if the entity is already protected
+        if (component.ProtectedEntities.Contains(entityUid))
+            return;
+
+        // Apply GodMode
+        _godmode.EnableGodmode(entityUid);
+        component.ProtectedEntities.Add(entityUid);
+    }
+
+    /// <summary>
+    /// Removes GodMode from an entity
+    /// </summary>
+    private void RemoveGodMode(EntityUid entityUid)
+    {
+        if (HasComp<GodmodeComponent>(entityUid))
+        {
+            _godmode.DisableGodmode(entityUid);
+        }
+    }
+
+    /// <summary>
+    /// Checks if an entity is organic (i.e., has a mind or is a mob)
+    /// </summary>
+    private bool IsOrganic(EntityUid entityUid)
+    {
+        // Skip ghosts
+        if (HasComp<GhostComponent>(entityUid))
+            return false;
+        /* Omu, this bit is broken, what could go wrong disabling it >:3
+        // Check if we have a player entity that's either still around or alive and may come back
+        if (_mind.TryGetMind(entityUid, out var mind, out var mindComp) &&
+            (mindComp.Session != null || !_mind.IsCharacterDeadPhysically(mindComp)))
+        {
+            return true;
+        }
+        */
+        // Also consider anything with a MobStateComponent as organic
+        if (HasComp<MobStateComponent>(entityUid))
+        {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/Content.Server/_Mono/GridProtect/GridRaiderSystem.cs
+++ b/Content.Server/_Mono/GridProtect/GridRaiderSystem.cs
@@ -1,0 +1,132 @@
+using System.Linq;
+using Content.Shared._Mono;
+using Content.Shared._Mono.NoHack;
+using Content.Shared._Mono.NoDeconstruct;
+using Content.Shared.Doors.Components;
+using Content.Shared.VendingMachines;
+using Robust.Shared.Containers;
+using Robust.Shared.Map.Components;
+using Content.Shared._White.Other; // Omu
+
+namespace Content.Server._Mono;
+
+/// <summary>
+/// System that handles the GridRaiderComponent, which applies NoHack and NoDeconstruct to entities with Door and/or VendingMachine components on a grid.
+/// Protection is applied once during initialization and remains until the component is removed.
+/// </summary>
+public sealed class GridRaiderSystem : EntitySystem
+{
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<GridRaiderComponent, MapInitEvent>(OnGridRaiderMapInit);
+        SubscribeLocalEvent<GridRaiderComponent, ComponentShutdown>(OnGridRaiderShutdown);
+    }
+
+
+
+    private void OnGridRaiderMapInit(EntityUid uid, GridRaiderComponent component, MapInitEvent args)
+    {
+        // Verify this is applied to a grid
+        if (!HasComp<MapGridComponent>(uid))
+        {
+            Log.Warning($"GridRaiderComponent applied to non-grid entity {ToPrettyString(uid)}");
+            return;
+        }
+
+        // Find all entities on the grid and apply NoHack/NoDeconstruct to doors and vending machines
+        ApplyInitialProtection(uid, component);
+    }
+
+    private void OnGridRaiderShutdown(EntityUid uid, GridRaiderComponent component, ComponentShutdown args)
+    {
+        // When the component is removed, remove NoHack/NoDeconstruct from all protected entities
+        foreach (var entity in component.ProtectedEntities.ToList())
+        {
+            if (EntityManager.EntityExists(entity))
+            {
+                RemoveProtection(entity);
+            }
+        }
+
+        component.ProtectedEntities.Clear();
+    }
+
+
+
+
+
+    /// <summary>
+    /// Applies initial protection to all eligible entities on the grid during map initialization
+    /// </summary>
+    private void ApplyInitialProtection(EntityUid gridUid, GridRaiderComponent component)
+    {
+        // Get all entities currently on the grid
+        var allEntitiesOnGrid = _lookup.GetEntitiesIntersecting(gridUid).ToHashSet();
+
+        // Find entities that should be protected based on component settings
+        foreach (var entity in allEntitiesOnGrid)
+        {
+            // Skip the grid itself and entities inside containers
+            if (entity == gridUid || _container.IsEntityInContainer(entity))
+                continue;
+
+            // Check if this entity should be protected based on current settings
+            var shouldProtect = false;
+            var hackProtect = true;
+
+            if (component.ProtectDoors && HasComp<DoorComponent>(entity))
+                shouldProtect = true;
+
+            if (component.ProtectVendingMachines && HasComp<VendingMachineComponent>(entity))
+            {
+                shouldProtect = true;
+                hackProtect = false; // vendors can be hackable
+            }
+            if (component.ProtectStructures && HasComp<StructureComponent>(entity)) // Omu
+                shouldProtect = true;
+
+            if (shouldProtect)
+                ApplyProtection(entity, component, hackProtect);
+        }
+    }
+
+    /// <summary>
+    /// Applies NoHack and NoDeconstruct to an entity and adds it to the protected entities list
+    /// </summary>
+    private void ApplyProtection(EntityUid entityUid, GridRaiderComponent component, bool hackProtect = true, bool deconProtect = true)
+    {
+        // Skip if the entity is already protected
+        if (component.ProtectedEntities.Contains(entityUid))
+            return;
+
+        // Apply NoHack and NoDeconstruct components
+        if (hackProtect)
+            EnsureComp<NoHackComponent>(entityUid);
+        if (deconProtect)
+            EnsureComp<NoDeconstructComponent>(entityUid);
+
+        component.ProtectedEntities.Add(entityUid);
+    }
+
+    /// <summary>
+    /// Removes NoHack and NoDeconstruct from an entity
+    /// </summary>
+    private void RemoveProtection(EntityUid entityUid)
+    {
+        if (HasComp<NoHackComponent>(entityUid))
+        {
+            RemComp<NoHackComponent>(entityUid);
+        }
+
+        if (HasComp<NoDeconstructComponent>(entityUid))
+        {
+            RemComp<NoDeconstructComponent>(entityUid);
+        }
+    }
+
+
+}

--- a/Content.Shared/_Mono/GridProtect/GridGodModeComponent.cs
+++ b/Content.Shared/_Mono/GridProtect/GridGodModeComponent.cs
@@ -1,0 +1,14 @@
+namespace Content.Shared._Mono;
+
+/// <summary>
+/// Component that applies GodMode to all non-organic entities on a grid.
+/// </summary>
+[RegisterComponent]
+public sealed partial class GridGodModeComponent : Component
+{
+    /// <summary>
+    /// The list of entities that have been given GodMode by this component.
+    /// </summary>
+    [DataField]
+    public HashSet<EntityUid> ProtectedEntities = new();
+}

--- a/Content.Shared/_Mono/GridProtect/GridRaiderComponent.cs
+++ b/Content.Shared/_Mono/GridProtect/GridRaiderComponent.cs
@@ -1,0 +1,33 @@
+namespace Content.Shared._Mono;
+
+/// <summary>
+/// Component that applies NoHack and NoDeconstruct to entities with Door and/or VendingMachine components on a grid.
+/// Protection is applied once during initialization and remains until the component is removed.
+/// </summary>
+[RegisterComponent]
+public sealed partial class GridRaiderComponent : Component
+{
+    /// <summary>
+    /// The list of entities that have been given NoHack and NoDeconstruct by this component.
+    /// </summary>
+    [DataField]
+    public HashSet<EntityUid> ProtectedEntities = new();
+
+    /// <summary>
+    /// Whether to protect entities with Door components.
+    /// </summary>
+    [DataField]
+    public bool ProtectDoors = true;
+
+    /// <summary>
+    /// Whether to protect entities with VendingMachine components.
+    /// </summary>
+    [DataField]
+    public bool ProtectVendingMachines = true;
+
+    /// <summary>
+    /// Omu: Whether to protect entities with Structure components.
+    /// </summary>
+    [DataField]
+    public bool ProtectStructures = true;
+}

--- a/Content.Shared/_Mono/NoDeconstruct/NoDeconstructComponent.cs
+++ b/Content.Shared/_Mono/NoDeconstruct/NoDeconstructComponent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Mono.NoDeconstruct;
+
+/// <summary>
+/// Prevents construction/deconstruction interactions when present on an entity.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class NoDeconstructComponent : Component
+{
+}

--- a/Content.Shared/_Mono/NoHack/NoHackComponent.cs
+++ b/Content.Shared/_Mono/NoHack/NoHackComponent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Mono.NoHack;
+
+/// <summary>
+/// Prevents wire interactions (cutting, mending, pulsing).
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class NoHackComponent : Component
+{
+}

--- a/Resources/Maps/centcomm.yml
+++ b/Resources/Maps/centcomm.yml
@@ -76,6 +76,8 @@ entities:
   entities:
   - uid: 1668
     components:
+    - type: GridGodMode
+    - type: GridRaider
     - type: MetaData
       name: Central Command
     - type: MapGrid
@@ -48980,9 +48982,9 @@ entities:
 
         [color=#1e7f28]────────────────────⋆⋅☆⋅⋆──────────────────[/color]
 
-        [head=2][bold]SUBJECT: [/head][head=3][color=#babac2]The Vail[/color][/bold][/head] 
+        [head=2][bold]SUBJECT: [/head][head=3][color=#babac2]The Vail[/color][/bold][/head]
 
-        [head=2][bold]ID: [/head][head=3][color=#babac2][#NT-0570][/color][/bold][/head] 
+        [head=2][bold]ID: [/head][head=3][color=#babac2][#NT-0570][/color][/bold][/head]
 
         [color=#1e7f28]────────────────────⋆⋅☆⋅⋆──────────────────[/color]
 
@@ -48997,7 +48999,7 @@ entities:
         The vail a pittiful construct to be honest, if it wherent for the 5th fleet incident and the ripples caused by its utter destruction and destruction of our dedicated blacksite we would not be back to square one but here we are.
 
 
-        At least the cosmic cult was so nice and dontated all this facinating equipment to us, There so called "GOD" seems to be nothing more than a minor entity that breaks some laws of physics nothing we cant handle with modern bluespace technologie. Granted them acctually succeeding would destroy the local station, This research board advices that we install additonal sensors to detect such activities aboard our station. 
+        At least the cosmic cult was so nice and dontated all this facinating equipment to us, There so called "GOD" seems to be nothing more than a minor entity that breaks some laws of physics nothing we cant handle with modern bluespace technologie. Granted them acctually succeeding would destroy the local station, This research board advices that we install additonal sensors to detect such activities aboard our station.
 
 
         IN case of a summoning success it is best to wait 4 to 5 days for the local area to have cooled off before sending in a team to destroy the minor avator of the so called "god" and then take the converted material in for study.
@@ -49036,9 +49038,9 @@ entities:
 
         [color=#1e7f28]────────────────────⋆⋅☆⋅⋆──────────────────[/color]
 
-        [head=2][bold]SUBJECT: [/head][head=3][color=#babac2]Changeling[/color][/bold][/head] 
+        [head=2][bold]SUBJECT: [/head][head=3][color=#babac2]Changeling[/color][/bold][/head]
 
-        [head=2][bold]ID: [/head][head=3][color=#babac2][#NT-0570][/color][/bold][/head] 
+        [head=2][bold]ID: [/head][head=3][color=#babac2][#NT-0570][/color][/bold][/head]
 
         [color=#1e7f28]────────────────────⋆⋅☆⋅⋆──────────────────[/color]
 
@@ -49104,9 +49106,9 @@ entities:
 
         [color=#1e7f28]────────────────────⋆⋅☆⋅⋆──────────────────[/color]
 
-        [head=2][bold]SUBJECT: [/head][head=3][color=#babac2]Progress Update on NT Bioweapons[/color][/bold][/head] 
+        [head=2][bold]SUBJECT: [/head][head=3][color=#babac2]Progress Update on NT Bioweapons[/color][/bold][/head]
 
-        [head=2][bold]ID: [/head][head=3][color=#babac2][#NT-0570][/color][/bold][/head] 
+        [head=2][bold]ID: [/head][head=3][color=#babac2][#NT-0570][/color][/bold][/head]
 
         [color=#1e7f28]────────────────────⋆⋅☆⋅⋆──────────────────[/color]
 
@@ -49157,9 +49159,9 @@ entities:
 
         [color=#1e7f28]────────────────────⋆⋅☆⋅⋆──────────────────[/color]
 
-        [head=2][bold]SUBJECT: [/head][head=3][color=#babac2]Heratic blade analisi[/color][/bold][/head] 
+        [head=2][bold]SUBJECT: [/head][head=3][color=#babac2]Heratic blade analisi[/color][/bold][/head]
 
-        [head=2][bold]ID: [/head][head=3][color=#babac2][#NT-0570][/color][/bold][/head] 
+        [head=2][bold]ID: [/head][head=3][color=#babac2][#NT-0570][/color][/bold][/head]
 
         [color=#1e7f28]────────────────────⋆⋅☆⋅⋆──────────────────[/color]
 


### PR DESCRIPTION
## About the PR
Ports over GridGodMode and GridRaider from Monolith, adds these to CC, making it impossible for people to break CC.

## Why / Balance
It was planned as part of the CC revamp.

## Technical details
Any entities placed AFTER CC is loaded are not protected.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Central Command is now indestructible.