### PR TITLE
[FIX] Fixes amag working on protected grids

### DIFF
--- a/Content.Shared/Emag/Systems/EmagSystem.cs
+++ b/Content.Shared/Emag/Systems/EmagSystem.cs
@@ -29,6 +29,7 @@ using Robust.Shared.Audio.Systems;
 using Robust.Shared.Serialization;
 using Content.Shared.Whitelist;
 using Content.Goobstation.Common.Effects; // Shitmed - Starlight Abductors
+using Content.Shared._Mono.NoHack; // Omu
 
 namespace Content.Shared.Emag.Systems;
 
@@ -81,6 +82,9 @@ public sealed class EmagSystem : EntitySystem
             return false;
 
         if (_tag.HasTag(target, ent.Comp.EmagImmuneTag))
+            return false;
+
+        if (HasComp<NoHackComponent>(target)) // Omu
             return false;
 
         Entity<LimitedChargesComponent?> chargesEnt = ent.Owner;


### PR DESCRIPTION
## About the PR
Prevents Emag/Amag working on things with NoHackComponenet

## Why / Balance
Prevents people hacking doors at CC.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed people being able to Amag doors on protected grids.