### PR TITLE
Add a toggle-able light to the BSO Ensemble that matches the elite BSO Cloak's light.

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Neck/ensembles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Neck/ensembles.yml
@@ -396,6 +396,12 @@
         sprite:
           sprite: _Goobstation/Clothing/Neck/Ensembles/bso.rsi
           state: mantle-icon
+  - type: PointLight # Omu, same glow as the Elite BSO Cloak
+    enabled: false
+    radius: 2
+    energy: 4
+    color: "#84BEF4"
+  - type: UnpoweredFlashlight # Omu, allows that glow to be enabled/disabled instead of being forced
 
 - type: entity
   parent: [ClothingNeckBase, BaseCentcommCommandContraband]


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Title, the BSO Ensemble now has an identical light to the elite BSO cloak, except this one can be toggled on and off.

## Why / Balance
Some people like the light, some people dont, but if you get 100 hours as BSO, I feel like you should get to choose to have it or not, without having to sacrifice the drip of the ensemble to have it.

## Media
Not needed, the light it emits is identical to the elite cloak, and that light that can be toggled like how a PDA light can.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Added a toggleable light to the BSO's ensemble, which is identical to that of the Elite BSO Cloak.