### PR TITLE
buffed the particle deccelerator so its not compleatly useless

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/PA/particles.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/PA/particles.yml
@@ -111,5 +111,5 @@
   - type: TimedDespawn
     lifetime: 0.6
   - type: SinguloFood
-    energy: -10
-    energyFactor: 0.97
+    energy: -50 #Omu
+    energyFactor: 0.90 #Omu


### PR DESCRIPTION
## About the PR
buffed the particle decelerator

## Why / Balance
the current particle decelerator is completely useless to the point that we have replaced it with a rocket lancher on current omu

## Technical details
just 2 lines of yaml changes

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: buffed the particle decelerator's damage to the tesla and singlo by 5 times
