### PR TITLE
Remove Nexus mention in the guidebook entry for Avali

### DIFF
--- a/Resources/ServerInfo/Guidebook/Mobs/Avali.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Avali.xml
@@ -16,7 +16,7 @@
   - Deal [color=red]6.25[/color] slashing damage with claws.
   - Can fly in Zero-G.
   <!-- - [color=#ffbc48]Nanite Technology![/color] Can encase themselves in a [color=#ffbc48]Nanite Shell[/color] to heal most common types of damage. # Omu, this was removed.-->
-  - Can talk over [color=#ffbc48]The Nexus with +N.[/color]
+  <!-- - Can talk over [color=#ffbc48]The Nexus with +N.[/color] # Omu, this was removed.-->
   - 2x Hunger rate, stay fed!
   - Can only eat meat-related food items (including organs) and pills.
   - Heal airloss from Ammonia and Amoxla but..


### PR DESCRIPTION
## About the PR
Removed Avali mentioning the Nexus in the guidebook

## Why / Balance
New players are seeing it and thinking something is not working properly

## Technical details

## Media

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl: Aureu
- remove: Mention of Nexus from the Avali guidebook.
