### PR TITLE
[FIX] Fixes people bypassing GridRaider system

### DIFF
--- a/Content.Shared/Prying/Systems/PryingSystem.cs
+++ b/Content.Shared/Prying/Systems/PryingSystem.cs
@@ -88,6 +88,8 @@ using Content.Shared.Verbs;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Serialization;
 using PryUnpoweredComponent = Content.Shared.Prying.Components.PryUnpoweredComponent;
+using Content.Shared._Mono.NoHack; // Omu, can people stop trying to break protected grids.
+using Content.Shared._Mono.NoDeconstruct; // Omu, can people stop trying to break protected grids.
 
 namespace Content.Shared.Prying.Systems;
 
@@ -191,6 +193,17 @@ public sealed class PryingSystem : EntitySystem
     private bool CanPry(EntityUid target, EntityUid user, out string? message, PryingComponent? comp = null, PryUnpoweredComponent? unpoweredComp = null)
     {
         BeforePryEvent canev;
+
+        if (HasComp<NoHackComponent>(target)) // Omu. Can people stop trying to break protected grids.
+        {
+            message = null;
+            return false;
+        }
+        if (HasComp<NoDeconstructComponent>(target)) // Omu. Can people stop trying to break protected grids.
+        {
+            message = null;
+            return false;
+        }
 
         if (comp != null || Resolve(user, ref comp, false))
         {

--- a/Content.Shared/Tools/Systems/SharedToolSystem.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.cs
@@ -94,6 +94,8 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
+using Content.Shared._Mono.NoHack; // Omu, can people stop trying to break protected grids.
+using Content.Shared._Mono.NoDeconstruct; // Omu, can people stop trying to break protected grids.
 
 namespace Content.Shared.Tools.Systems;
 
@@ -348,6 +350,10 @@ public abstract partial class SharedToolSystem : EntitySystem
         // check if the target allows using the tool
         if (target != null && target != tool)
         {
+            if (HasComp<NoHackComponent>(target)) // Omu. Can people stop trying to break protected grids.
+                return false;
+            if (HasComp<NoDeconstructComponent>(target)) // Omu. Can people stop trying to break protected grids.
+                return false;
             RaiseLocalEvent(target.Value, beforeAttempt);
         }
 


### PR DESCRIPTION
## About the PR
Fixes people breaking into places on protected grids.

## Why / Balance
Our playerbase seemingly cannot be trusted to not try to bypass the protections put in place.

## Technical details
Cancels prying or using tools on anything with NoHackComponent or NoDeconstructComponent

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed people being able to break into areas on Protected grids. Stop trying to bypass this.