### PR TITLE
[TWEAK] Make IPC EMP vulnerable

### DIFF
--- a/Content.Omu.Server/Cybernetics/IPCEmpVulnerableSystem.cs
+++ b/Content.Omu.Server/Cybernetics/IPCEmpVulnerableSystem.cs
@@ -1,0 +1,51 @@
+using Content.Server.Emp;
+using Content.Shared._Shitmed.Body.Organ;
+using Content.Shared._Shitmed.Body.Events;
+using Content.Shared._Shitmed.Cybernetics;
+using Content.Shared.Body.Part;
+using Content.Shared.Body.Organ;
+using Content.Shared.Body.Systems;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Prototypes;
+using Robust.Shared.Prototypes;
+using Content._Omu.Shared.Cybernetics;
+using Content.Shared._Shitmed.Damage;
+using Content.Shared._Shitmed.Targeting;
+
+namespace Content._Omu.Server.Cybernetics;
+
+internal sealed class CyberneticsSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _prototypes = default!;
+    [Dependency] private readonly DamageableSystem _damageable = default!;
+    [Dependency] private readonly SharedBodySystem _body = default!;
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<IPCEmpVulnerableComponent, EmpPulseEvent>(OnEmpPulse);
+        SubscribeLocalEvent<IPCEmpVulnerableComponent, EmpDisabledRemoved>(OnEmpDisabledRemoved);
+    }
+    private void OnEmpPulse(Entity<IPCEmpVulnerableComponent> cyberEnt, ref EmpPulseEvent ev)
+    {
+        if (!cyberEnt.Comp.Disabled)
+        {
+            ev.Affected = true;
+            ev.Disabled = true;
+            cyberEnt.Comp.Disabled = true;
+
+            if (TryComp(cyberEnt, out DamageableComponent? damageable))
+            {
+                var ion = new DamageSpecifier(_prototypes.Index<DamageTypePrototype>("Ion"), 500); // Something something, vital damage, this is spread across every limb.
+                _damageable.TryChangeDamage(cyberEnt, ion, ignoreResistances: true, targetPart: TargetBodyPart.All, splitDamage: SplitDamageBehavior.SplitEnsureAll, damageable: damageable);
+                Dirty(cyberEnt, damageable);
+            }
+        }
+    }
+
+    private void OnEmpDisabledRemoved(Entity<IPCEmpVulnerableComponent> cyberEnt, ref EmpDisabledRemoved ev)
+    {
+        if (cyberEnt.Comp.Disabled)
+        {
+            cyberEnt.Comp.Disabled = false;
+        }
+    }
+}

--- a/Content.Omu.Shared/Cybernetics/IPCEmpVulnerableComponent.cs
+++ b/Content.Omu.Shared/Cybernetics/IPCEmpVulnerableComponent.cs
@@ -1,0 +1,16 @@
+using Robust.Shared.GameStates;
+
+namespace Content._Omu.Shared.Cybernetics;
+
+/// <summary>
+/// Component for IPCs to make them take ION when emped
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class IPCEmpVulnerableComponent : Component
+{
+    /// <summary>
+    ///     Is the IPC allready EMPed?
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool Disabled = false;
+}

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
@@ -197,6 +197,8 @@
     - DoorBumpOpener
     - AnomalyHost
     - IPCDrinkBlacklist # Goobstation - Energycrit: Don't let self antagging IPCs steal power from other ipcs.
+  - type: IPCEmpVulnerable # Omu
+
 - type: entity
   save: false
   name: Urist McPositronic


### PR DESCRIPTION
## About the PR
IPCs now take ion damage from EMPs

## Why / Balance
Was brought up in admin VC, if you have cybernetics you take damage when you get emped, why should the inorganic IPC limbs not do this.

## Technical details
Yes it says 500 damage, but its split across the entire body so it comes to ~130 vital damage.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: IPCs now take ion damage from EMPs
