### PR TITLE
Remove transit prisoner being able to latejoin

### DIFF
--- a/Resources/Prototypes/Maps/amber.yml
+++ b/Resources/Prototypes/Maps/amber.yml
@@ -89,7 +89,7 @@
             Detective: [ 1, 1 ]
             SecurityCadet: [ 1, 1 ]
             Lawyer: [ 1, 1 ]
-            TransitPrisoner: [2, 2] # Omu - Prisoner role
+            TransitPrisoner: [2, 0] # Omu - Prisoner role
             Brigmedic: [1, 1]
             SecuritySergeant: [ 1, 1 ] #Omu
             #supply

--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -138,7 +138,7 @@
             SecurityCadet: [ 4, 4 ]
             Lawyer: [ 2, 2 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [2, 2] # Omu - Prisoner role
+            TransitPrisoner: [2, 0] # Omu - Prisoner role
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 3, 3 ]

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -147,7 +147,7 @@
             SecurityCadet: [ 4, 4 ]
             Lawyer: [ 2, 2 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [2, 2] # Omu - Prisoner role
+            TransitPrisoner: [2, 0] # Omu - Prisoner role
             SecuritySergeant: [ 1, 1 ] #Omu
             #supply
             Quartermaster: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/fland.yml
+++ b/Resources/Prototypes/Maps/fland.yml
@@ -101,12 +101,12 @@
             SecurityCadet: [ 4, 4 ]
             Lawyer: [ 2, 2 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [2, 2] # Omu - Prisoner role
+            TransitPrisoner: [2, 0] # Omu - Prisoner role
             SecuritySergeant: [ 1, 1 ] #Omu
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 3, 3 ]
-            ShaftMiner: [ 3, 3 ] # Omu 
+            ShaftMiner: [ 3, 3 ] # Omu
             CargoTechnician: [ 4, 4 ]
             Courier: [ 2, 2 ] #Omu
             #civilian

--- a/Resources/Prototypes/Maps/loop.yml
+++ b/Resources/Prototypes/Maps/loop.yml
@@ -149,7 +149,7 @@
             SecurityCadet: [ 4, 4 ]
             Lawyer: [ 2, 2 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [2, 2] # Omu - Prisoner role
+            TransitPrisoner: [2, 0] # Omu - Prisoner role
             SecuritySergeant: [ 1, 1 ] #Omu
             #supply
             Quartermaster: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/marathon.yml
+++ b/Resources/Prototypes/Maps/marathon.yml
@@ -91,7 +91,7 @@
             SecurityCadet: [ 4, 4 ]
             Lawyer: [ 2, 2 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [2, 2] # Omu - Prisoner role
+            TransitPrisoner: [2, 0] # Omu - Prisoner role
             SecuritySergeant: [ 1, 1 ] #Omu
             #supply
             Quartermaster: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/meta.yml
+++ b/Resources/Prototypes/Maps/meta.yml
@@ -142,7 +142,7 @@
             SecurityCadet: [ 3, 6 ]
             Lawyer: [ 2, 2 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [2, 2] # Omu - Prisoner role
+            TransitPrisoner: [2, 0] # Omu - Prisoner role
             SecuritySergeant: [ 1, 1 ] #Omu
             #supply
             Quartermaster: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/oasis.yml
+++ b/Resources/Prototypes/Maps/oasis.yml
@@ -153,7 +153,7 @@
             SecurityCadet: [ 4, 4 ]
             Lawyer: [ 3, 3 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [2, 3] # Omu - Prisoner role
+            TransitPrisoner: [2, 0] # Omu - Prisoner role
             SecuritySergeant: [ 1, 1 ] #Omu
             #supply
             Quartermaster: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/omega.yml
+++ b/Resources/Prototypes/Maps/omega.yml
@@ -87,7 +87,7 @@
             SecurityCadet: [ 2, 2 ]
             Lawyer: [ 1, 1 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [2, 2] # Omu - Prisoner role
+            TransitPrisoner: [2, 0] # Omu - Prisoner role
             SecuritySergeant: [ 1, 1 ] #Omu
             #supply
             Quartermaster: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/packed.yml
+++ b/Resources/Prototypes/Maps/packed.yml
@@ -89,7 +89,7 @@
             SecurityCadet: [ 2, 2 ]
             Lawyer: [ 1, 1 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [2, 2] # Omu - Prisoner role
+            TransitPrisoner: [2, 0] # Omu - Prisoner role
             SecuritySergeant: [ 1, 1 ] #Omu
             #supply
             Quartermaster: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/saltern.yml
+++ b/Resources/Prototypes/Maps/saltern.yml
@@ -89,13 +89,13 @@
             SecurityOfficer: [ 4, 4 ]
             SecurityCadet: [ 4, 4 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [1, 2] # Omu - Prisoner role
+            TransitPrisoner: [1, 0] # Omu - Prisoner role
             SecuritySergeant: [ 1, 1 ] #Omu
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 1, 3 ]
             Courier: [ 2, 2 ] # Omu - Courier role
-            CargoTechnician: [ 2, 2 ] 
+            CargoTechnician: [ 2, 2 ]
             ShaftMiner: [ 2, 2 ]
             #civillian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/_DV/Maps/glacier.yml
+++ b/Resources/Prototypes/_DV/Maps/glacier.yml
@@ -56,7 +56,7 @@
             SecurityCadet: [ 3, 4 ]
             Detective: [ 1, 1 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [2, 2] # Omu - Prisoner role
+            TransitPrisoner: [2, 0] # Omu - Prisoner role
             SecuritySergeant: [ 1, 1 ] # Omu
             # service
             HeadOfPersonnel: [ 1, 1 ]

--- a/Resources/Prototypes/_Goobstation/Maps/atlas.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/atlas.yml
@@ -99,7 +99,7 @@
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 2, 2 ]
-            ShaftMiner: [ 2, 2 ] # Omu, 
+            ShaftMiner: [ 2, 2 ] # Omu,
             CargoTechnician: [ 2, 2 ]
             Courier: [ 2, 2 ] #Omu
             #civillian

--- a/Resources/Prototypes/_Goobstation/Maps/chloris.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/chloris.yml
@@ -61,7 +61,7 @@
             SecurityCadet: [ 3, 4 ]
             Detective: [ 1, 1 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [2, 2] # Omu - Prisoner role
+            TransitPrisoner: [2, 0] # Omu - Prisoner role
             SecuritySergeant: [ 1, 1 ] #Omu
             # service
             HeadOfPersonnel: [ 1, 1 ]

--- a/Resources/Prototypes/_Goobstation/Maps/cluster.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/cluster.yml
@@ -92,7 +92,7 @@
             SecurityOfficer: [ 3, 3 ]
             SecurityCadet: [ 2, 2 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [2, 2] # Omu - Prisoner role
+            TransitPrisoner: [2, 0] # Omu - Prisoner role
             SecuritySergeant: [ 1, 1 ] #Omu
             #supply
             Quartermaster: [ 1, 1 ]

--- a/Resources/Prototypes/_Goobstation/Maps/cog.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/cog.yml
@@ -63,7 +63,7 @@
             SecurityCadet: [ 4, 4 ]
             Lawyer: [ 2, 2 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [2, 2] # Omu - Prisoner role
+            TransitPrisoner: [2, 0] # Omu - Prisoner role
             SecuritySergeant: [ 1, 1 ] #Omu
             #supply
             Quartermaster: [ 1, 1 ]

--- a/Resources/Prototypes/_Goobstation/Maps/delta.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/delta.yml
@@ -58,7 +58,7 @@
             SecurityCadet: [ 3, 3 ]
             Detective: [ 1, 1 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [2, 2] # Omu - Prisoner role
+            TransitPrisoner: [2, 0] # Omu - Prisoner role
             SecuritySergeant: [ 1, 1 ] #Omu
             # service
             HeadOfPersonnel: [ 1, 1 ]

--- a/Resources/Prototypes/_Goobstation/Maps/flandhighpop.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/flandhighpop.yml
@@ -93,7 +93,7 @@
             SecurityCadet: [ -1, -1 ]
             Lawyer: [ 3, 3 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [2, 3] # Omu - Prisoner role
+            TransitPrisoner: [2, 0] # Omu - Prisoner role
             SecuritySergeant: [ 1, 1 ] #Omu
             #supply
             Quartermaster: [ 1, 1 ]

--- a/Resources/Prototypes/_Goobstation/Maps/kettle.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/kettle.yml
@@ -92,7 +92,7 @@
             SecurityOfficer: [ 4, 6 ]
             SecurityCadet: [ 8, 8 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [2, 2] # Omu - Prisoner role
+            TransitPrisoner: [2, 0] # Omu - Prisoner role
             SecuritySergeant: [ 1, 1 ] #Omu
             #supply
             Quartermaster: [ 1, 1 ]

--- a/Resources/Prototypes/_Goobstation/Maps/leonid.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/leonid.yml
@@ -97,7 +97,7 @@
             SecurityCadet: [ 6, 6 ]
             Lawyer: [ 3, 3 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [2, 2] # Omu - Prisoner role
+            TransitPrisoner: [2, 0] # Omu - Prisoner role
             SecuritySergeant: [ 1, 1 ] #Omu
             #supply
             Quartermaster: [ 1, 1 ]

--- a/Resources/Prototypes/_Goobstation/Maps/oasishighpop.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/oasishighpop.yml
@@ -92,7 +92,7 @@
             SecurityCadet: [ -1, -1 ]
             Lawyer: [ 3, 3 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [2, 2] # Omu - Prisoner role
+            TransitPrisoner: [2, 0] # Omu - Prisoner role
             SecuritySergeant: [ 1, 1 ] #Omu
             #supply
             Quartermaster: [ 1, 1 ]

--- a/Resources/Prototypes/_Goobstation/Maps/origin.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/origin.yml
@@ -89,7 +89,7 @@
             SecurityOfficer: [ 7, 7 ]
             SecurityCadet: [ 2, 4 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [2, 2] # Omu - Prisoner role
+            TransitPrisoner: [2, 0] # Omu - Prisoner role
             SecuritySergeant: [ 1, 1 ] #Omu
             #supply
             Quartermaster: [ 1, 1 ]

--- a/Resources/Prototypes/_Goobstation/Maps/originhighpop.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/originhighpop.yml
@@ -89,7 +89,7 @@
             SecurityCadet: [ -1, -1 ]
             Lawyer: [ 3, 3 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [2, 2] # Omu - Prisoner role
+            TransitPrisoner: [2, 0] # Omu - Prisoner role
             SecuritySergeant: [ 1, 1 ] #Omu
             #supply
             Quartermaster: [ 1, 1 ]

--- a/Resources/Prototypes/_Goobstation/Maps/serpentcrest.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/serpentcrest.yml
@@ -60,7 +60,7 @@
             SecurityCadet: [ 3, 3 ]
             Lawyer: [ 2, 2 ]
             Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [2, 2] # Omu - Prisoner role
+            TransitPrisoner: [2, 0] # Omu - Prisoner role
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 4, 4 ]


### PR DESCRIPTION
## About the PR
Sets late join slots for transit prisoner to 0.

## Why / Balance
People abuse the bug that transit prisoners do not spawn in perma when late joining to join seconds after round start and be put outside of perma.

Until someone makes it such that transits even when late joining spawn in perma, this will stop people abusing it.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- remove: Removed all latejoin slots for transit prisoner.
