### PR TITLE
Removed foam sword sheath contraband level

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Belt/belts.yml
@@ -66,12 +66,34 @@
       - GunApplySolution # Goobstation - Syndicate dart gun
 
 - type: entity
-  parent: ClothingBeltSheath
+  parent: [ClothingBeltBase, ClothingSlotBase]
   id: ClothingBeltFoamSheath
   name: foam sheath
   description: A foam sheath to cosplay as the captain! It seems to be able to fit a real sabre in it.
   components:
   - type: Sprite
     sprite: _DV/Clothing/Belt/foamsheath.rsi
+    state: sheath
   - type: Clothing
     sprite: _DV/Clothing/Belt/foamsheath.rsi
+  - type: Item
+    size: Ginormous
+  - type: ItemSlots
+    slots:
+      item:
+        name: Sabre
+        insertVerbText: sheath-insert-verb
+        ejectVerbText: sheath-eject-verb
+        insertSound: /Audio/Items/sheath.ogg
+        ejectSound: /Audio/Items/unsheath.ogg
+        whitelist:
+          tags:
+          - CaptainSabre
+  - type: ItemMapper
+    mapLayers:
+      sheath-sabre:
+        whitelist:
+          tags:
+          - CaptainSabre
+  - type: Appearance
+


### PR DESCRIPTION
## About the PR
Removed the contraband status from the foam sword sheath.

## Why / Balance
The toy sword sheath should not have a contraband level when the foam sword does not have one.
Fixes #760 

## Technical details
Had to copy the values from `ClothingBeltSheath` to `ClothingBeltFoamSheath` without the parent of `BaseCommandContraband` being inherited. 

## Media
<img width="536" height="235" alt="image" src="https://github.com/user-attachments/assets/cf02adc3-f61e-468a-91c5-585fd4381a7a" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
No breaking changes to my knowledge 

**Changelog**
:cl:
- fix: Contraband level from Foam sword sheath