### PR TITLE
Corrected Estoc calibre information in uplink

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Goobstation/store/uplink-catalog.ftl
@@ -120,7 +120,7 @@ uplink-m90-name = M-90
 uplink-m90-desc = A rugged assault rifle that maintains its accuracy across extreme distances. Feeds from .20 Rifle magazines.
 
 uplink-estoc-name = Estoc
-uplink-estoc-desc = A burst-fire designated marksman rifle fitted with an expensive tritium optic. Feeds from .20 Rifle magazines.
+uplink-estoc-desc = A burst-fire designated marksman rifle fitted with an expensive tritium optic. Feeds from .30 Rifle magazines.
 
 uplink-syndicate-disabler-name = Syndicate Disabler
 uplink-syndicate-disabler-desc = A sleek disabler designed from a reverse-engineered NanoTrasen prototype. While it lacks stopping power, it makes up for it with a self-recharging cell.


### PR DESCRIPTION
## About the PR
Fixed the Estoc caliber information in uplink.

## Why / Balance
Gives a correct description for the Estoc in uplink. 
Fixes #704

## Technical details
Changed the `uplink-estoc-desc` in the `uplink-catalog.ftl` to be an accurate description of the caliber the Estoc uses.

## Media
<img width="519" height="528" alt="image" src="https://github.com/user-attachments/assets/45e456aa-4a17-4df9-9867-096a2fd31b9d" />

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
:cl: 
- fix: Fixed Estoc caliber information in uplink.