### PR TITLE
Adds a new lifeline prototype

### DIFF
--- a/Resources/Prototypes/_Omu/Entities/Effects/bluespace_acidifier.yml
+++ b/Resources/Prototypes/_Omu/Entities/Effects/bluespace_acidifier.yml
@@ -1,0 +1,55 @@
+- type: entity
+  parent: BluespaceLifeline
+  id: BluespaceLifelineSpawnCore50TC
+  name: bluespace lifeline
+  description: Teleports your body to save your life!
+  components:
+  - type: Transform
+    anchored: True
+  - type: Sprite
+    sprite: /Textures/_Goobstation/Effects/bluespace_lifeline.rsi
+    noRot: true
+    layers:
+    - state: bluespace_lifeline
+      shader: unshaded
+  - type: SpawnOnDespawn
+    prototype: AnomalyCoreBluespace
+  - type: EmitSoundOnSpawn
+    sound:
+      path: /Audio/_Goobstation/Weapons/ChronoLegionnaire/stasisgun_reload.ogg
+  - type: PointLight
+    color: SkyBlue
+    radius: 3
+    energy: 1
+    netsync: false
+  - type: TriggerOnSpawn
+  - type: SpawnOnTrigger
+    proto: SpawnPod50TC
+
+- type: entity
+  parent: BluespaceLifeline
+  id: BluespaceLifelineSpawnCore100TC
+  name: bluespace lifeline
+  description: Teleports your body to save your life!
+  components:
+  - type: Transform
+    anchored: True
+  - type: Sprite
+    sprite: /Textures/_Goobstation/Effects/bluespace_lifeline.rsi
+    noRot: true
+    layers:
+    - state: bluespace_lifeline
+      shader: unshaded
+  - type: SpawnOnDespawn
+    prototype: AnomalyCoreBluespace
+  - type: EmitSoundOnSpawn
+    sound:
+      path: /Audio/_Goobstation/Weapons/ChronoLegionnaire/stasisgun_reload.ogg
+  - type: PointLight
+    color: SkyBlue
+    radius: 3
+    energy: 1
+    netsync: false
+  - type: TriggerOnSpawn
+  - type: SpawnOnTrigger
+    proto: SpawnPod100TC

--- a/Resources/Prototypes/_Omu/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/_Omu/Entities/Objects/Misc/implanters.yml
@@ -1,0 +1,15 @@
+- type: entity
+  id: BluespaceLifelineImplanter50TC
+  suffix: Bluespace Lifeline, 50TC
+  parent: BaseImplantOnlyImplanterCentcomm
+  components:
+  - type: Implanter
+    implant: BluespaceLifelineImplant50TC
+
+- type: entity
+  id: BluespaceLifelineImplanter100TC
+  suffix: Bluespace Lifeline, 100TC
+  parent: BaseImplantOnlyImplanterCentcomm
+  components:
+  - type: Implanter
+    implant: BluespaceLifelineImplant100TC

--- a/Resources/Prototypes/_Omu/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/_Omu/Entities/Objects/Misc/subdermal_implants.yml
@@ -1,0 +1,47 @@
+- type: entity
+  parent: BaseSubdermalImplant
+  id: BluespaceLifelineImplant50TC
+  name: bluespace lifeline implant
+  description: Teleports the hosts body to Central Command on activation. They will not be able to return.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: SubdermalImplant
+    permanent: true
+    implantAction: ActionActivateBluespaceLifeline
+  - type: MansusGraspBlockTrigger
+  - type: TriggerOnMobstateChange
+    mobState:
+    - Dead
+  - type: TriggerOnActivateImplant
+  - type: WarpParentOnTrigger
+    warpLocation: "CentComm"
+  - type: SpawnOnTrigger
+    proto: BluespaceLifelineSpawnCore50TC
+  - type: Tag
+    tags:
+    - SubdermalImplant
+    - HideContextMenu
+
+- type: entity
+  parent: BaseSubdermalImplant
+  id: BluespaceLifelineImplant100TC
+  name: bluespace lifeline implant
+  description: Teleports the hosts body to Central Command on activation. They will not be able to return.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: SubdermalImplant
+    permanent: true
+    implantAction: ActionActivateBluespaceLifeline
+  - type: MansusGraspBlockTrigger
+  - type: TriggerOnMobstateChange
+    mobState:
+    - Dead
+  - type: TriggerOnActivateImplant
+  - type: WarpParentOnTrigger
+    warpLocation: "CentComm"
+  - type: SpawnOnTrigger
+    proto: BluespaceLifelineSpawnCore100TC
+  - type: Tag
+    tags:
+    - SubdermalImplant
+    - HideContextMenu

--- a/Resources/Prototypes/_Omu/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/_Omu/Entities/Objects/Specific/syndicate.yml
@@ -1,0 +1,7 @@
+- type: entity
+  parent: Telecrystal
+  id: Telecrystal100
+  suffix: 100 TC
+  components:
+  - type: Stack
+    count: 100

--- a/Resources/Prototypes/_Omu/NTR/Catalog/pods.yml
+++ b/Resources/Prototypes/_Omu/NTR/Catalog/pods.yml
@@ -6,3 +6,21 @@
   components:
   - type: SpawnOnDespawn
     prototype: CaneNT
+
+- type: entity
+  id: SpawnPod50TC
+  categories: [ HideSpawnMenu ]
+  name: Spawn50TC
+  parent: SpawnSupplyEmpty
+  components:
+  - type: SpawnOnDespawn
+    prototype: Telecrystal50
+
+- type: entity
+  id: SpawnPod100TC
+  categories: [ HideSpawnMenu ]
+  name: Spawn100TC
+  parent: SpawnSupplyEmpty
+  components:
+  - type: SpawnOnDespawn
+    prototype: Telecrystal100


### PR DESCRIPTION
## About the PR
Adds two new variants of the lifeline implant, one that spawns a 50TC dropod, and one that spawns a 100TC dropod alongside the normal bluespace lifeline stuff.

## Why / Balance
Was requested by Cyg, balance wise this should only be used in events.

## Technical details
Use TriggerOnSpawn on the lifeline animation entity and then SpawnOnTrigger to spawn the droppod.

Also adds a prototype for a stack of 100TC since I couldn't find one.

## Media

https://github.com/user-attachments/assets/2a38c63d-d213-4f48-9329-c730edbb2677


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Added a new lifeline for events.
