### PR TITLE
Fixes Thaven CANNOT work with internals

### DIFF
--- a/Content.Server/_Impstation/Thaven/Systems/ThavenBreatherSystem.cs
+++ b/Content.Server/_Impstation/Thaven/Systems/ThavenBreatherSystem.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Content.Goobstation.Shared.Body;
 using Content.Server._Impstation.Thaven.Components;
-using Content.Server.Atmos.EntitySystems;
 using Content.Server.Body.Components;
 using Content.Server.Body.Systems;
 using Content.Shared.Atmos;
@@ -18,7 +17,6 @@ namespace Content.Server._Impstation.Thaven.Systems;
 /// </summary>
 public sealed class ThavenBreatherSystem : EntitySystem
 {
-    [Dependency] private readonly AtmosphereSystem _atmosphere = default!;
     [Dependency] private readonly BodySystem _body = default!;
     [Dependency] private readonly RespiratorSystem _respirator = default!;
     [Dependency] private readonly SharedDrunkSystem _drunk = default!;
@@ -98,8 +96,7 @@ public sealed class ThavenBreatherSystem : EntitySystem
         if (!TryGetActiveThavenLung(ent, out var lung))
             return;
 
-        var mixture = _atmosphere.GetContainingMixture(ent.Owner, excite: true);
-        if (mixture != null && mixture.Pressure >= lung.Comp1.MinPressure)
+        if (_respirator.CanMetabolizeInhaledAir((ent.Owner, ent.Comp)))
         {
             args.Cancelled = true;
             return;

--- a/Resources/Prototypes/_Impstation/Body/Organs/thaven.yml
+++ b/Resources/Prototypes/_Impstation/Body/Organs/thaven.yml
@@ -147,6 +147,8 @@
     - Organ
     - Lungs
   - type: ThavenBreather
+    # allow standard low-pressure internals output to count as a valid breath
+    minPressure: 5
     # gas that makes them feel drunk when breathed
     intoxicatingGas: Frezon
     # minimum share of that gas in the breath mix before it does anything


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

## About the PR
Fixes Thaven not breathing with internals in space.

## Why / Balance
Thavens were still suffocating in vacuum even with valid internals running, which is a major gameplay bug. this change makes their breathing logic respect actual inhaled gas and allows standard low-pressure internals output to count as a valid to breath

## Technical details
- thaven breathing system  now checks whether the Thaven can metabolize the gas they would actually inhale, instead of only checking tile atmosphere 
- Set the minPressure to 5 on standard thaven lungs so standard internals output is treated as breathable.

## Media

https://github.com/user-attachments/assets/521152cc-ce39-458e-9401-ad5c304e28d1


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-pr-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None.

**Changelog**
:cl: Nevec
- fix: Fixed Thavens suffocating in space while using valid internals.
