### PR TITLE
[BUGFIX] Fixes salv borgs being able to carry mech pkas.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -662,8 +662,10 @@
     items:
     - id: WeaponProtoKineticAccelerator
       whitelist:
-        components:
-        - PressureDamageChange
+        tags: # Omu
+        - CyborgProtoKineticAccelerator
+        #components:
+        #- PressureDamageChange
   # Goob end
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: adv-mining-module }

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/pka.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/pka.yml
@@ -39,6 +39,9 @@
     - state: animation-icon
       visible: false
       map: [ "empty-icon" ]
+  - type: Tag # Omu
+    tags:
+    - CyborgProtoKineticAccelerator
 
   # todo: add itemcomponent with inhandVisuals states using unused texture and animation assets in kinetic_accelerator.rsi
   # todo: add clothingcomponent with clothingVisuals states using unused texture and animations assets in kinetic_accelerator.rsi

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -62,7 +62,9 @@
     items:
     - id: WeaponProtoKineticAccelerator
       whitelist:
-        components:
-        - PressureDamageChange
+        tags: # Omu
+        - CyborgProtoKineticAccelerator
+        #components:
+        #- PressureDamageChange
   - type: BorgModuleIcon
     icon: { sprite: Objects/Weapons/Guns/Basic/kinetic_accelerator.rsi, state: icon }

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/Guns/Basic/pka.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/Guns/Basic/pka.yml
@@ -89,6 +89,9 @@
         whitelist:
           tags:
           - PKAUpgrade
+  - type: Tag # Omu
+    tags:
+    - CyborgProtoKineticAccelerator
 
 - type: entity
   name: proto-kinetic repeater
@@ -118,6 +121,9 @@
     sprite: _Lavaland/Objects/Weapons/Guns/Basic/kinetic_repeater.rsi
     shape:
     - 0,0,2,1
+  - type: Tag # Omu
+    tags:
+    - CyborgProtoKineticAccelerator
 
 - type: entity
   name: proto-kinetic pistol
@@ -146,6 +152,9 @@
     shape:
     - 0,0,1,0
     - 0,1,0,1
+  - type: Tag # Omu
+    tags:
+    - CyborgProtoKineticAccelerator
 
 # Space versions of all PKAs
 - type: entity

--- a/Resources/Prototypes/_Omu/tags.yml
+++ b/Resources/Prototypes/_Omu/tags.yml
@@ -33,3 +33,6 @@
 
 - type: Tag
   id: MagazineCaselessBlackiron
+
+- type: Tag
+  id: CyborgProtoKineticAccelerator


### PR DESCRIPTION
## About the PR
Changes the whitelist for the pka module and adv mining module's pka slot to use a tag, and adds this tag to all PKA variants bar the mech one.

## Why / Balance
Mech PKA is meant to only be used on mechs, having it on borgs encourages valid hunting.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed salv borgs being able to carry mech PKAs.
