### PR TITLE
[TWEAKS/FIXES] Port PR 1745 from funky (Crew manifest changes)

### DIFF
--- a/Content.Client/CrewManifest/UI/CrewManifestSection.cs
+++ b/Content.Client/CrewManifest/UI/CrewManifestSection.cs
@@ -103,27 +103,59 @@ public sealed class CrewManifestSection : BoxContainer
             Text = Loc.GetString(section.Name)
         });
 
-        var gridContainer = new GridContainer()
+        var departmentContainer = new BoxContainer() // Funky start
         {
+            Orientation = LayoutOrientation.Horizontal,
             HorizontalExpand = true,
-            Columns = 2
+
         };
 
-        AddChild(gridContainer);
+        var namesContainer = new BoxContainer()
+        {
+            Orientation = LayoutOrientation.Vertical,
+            HorizontalExpand = true,
+            SizeFlagsStretchRatio = 3,
+        };
+
+        var titlesContainer = new BoxContainer()
+        {
+            Orientation = LayoutOrientation.Vertical,
+            HorizontalExpand = true,
+            SizeFlagsStretchRatio = 2,
+        };
+
+        departmentContainer.AddChild(namesContainer);
+        departmentContainer.AddChild(titlesContainer);
+
+        AddChild(departmentContainer); // Funky end
 
         foreach (var entry in entries)
         {
-            var name = new RichTextLabel()
+            var nameContainer = new BoxContainer() // Funky start
             {
+                Orientation = LayoutOrientation.Horizontal,
                 HorizontalExpand = true,
             };
+
+            var name = new RichTextLabel();
             name.SetMessage(entry.Name);
+
+            var gender = new RichTextLabel()
+            {
+                Margin = new Thickness(6, 0, 0, 0),
+                StyleClasses = { "CrewManifestGender" }
+            };
+            gender.SetMessage(Loc.GetString("gender-display", ("gender", entry.Gender)));
+
+            nameContainer.AddChild(name);
+            nameContainer.AddChild(gender);
 
             var titleContainer = new BoxContainer()
             {
                 Orientation = LayoutOrientation.Horizontal,
-                HorizontalExpand = true
-            };
+                HorizontalExpand = true,
+                SizeFlagsStretchRatio = 1,
+            }; // Funky end
 
             var title = new RichTextLabel();
             title.SetMessage(entry.JobTitle);
@@ -147,8 +179,8 @@ public sealed class CrewManifestSection : BoxContainer
                 titleContainer.AddChild(title);
             }
 
-            gridContainer.AddChild(name);
-            gridContainer.AddChild(titleContainer);
+            namesContainer.AddChild(nameContainer);
+            titlesContainer.AddChild(titleContainer);
         }
     }
 }

--- a/Content.Client/CrewManifest/UI/CrewManifestSection.cs
+++ b/Content.Client/CrewManifest/UI/CrewManifestSection.cs
@@ -179,8 +179,8 @@ public sealed class CrewManifestSection : BoxContainer
                 titleContainer.AddChild(title);
             }
 
-            namesContainer.AddChild(nameContainer);
-            titlesContainer.AddChild(titleContainer);
+            namesContainer.AddChild(nameContainer); // Funky
+            titlesContainer.AddChild(titleContainer); // Funky
         }
     }
 }

--- a/Content.Client/Stylesheets/StyleNano.cs
+++ b/Content.Client/Stylesheets/StyleNano.cs
@@ -323,6 +323,9 @@ namespace Content.Client.Stylesheets
         public const string StyleClassPinButtonPinned = "pinButtonPinned";
         public const string StyleClassPinButtonUnpinned = "pinButtonUnpinned";
 
+        //Manifest
+        public const string StyleClassCrewManifestGender = "CrewManifestGender"; // Funky
+
 
         public override Stylesheet Stylesheet { get; }
 
@@ -1576,6 +1579,11 @@ namespace Content.Client.Stylesheets
                     .Class(StyleClassItemStatusNotHeld)
                     .Prop("font", notoSansItalic10)
                     .Prop("font-color", ItemStatusNotHeldColor),
+
+                Element<RichTextLabel>() // Funky
+                    .Class(StyleClassCrewManifestGender)
+                    .Prop("font", notoSansItalic10)
+                    .Prop("font-style", "italic"),
 
                 Element<RichTextLabel>()
                     .Class(StyleClassItemStatus)

--- a/Content.Omu.Server/CrewManifest/OmuCrewManifestSystem.cs
+++ b/Content.Omu.Server/CrewManifest/OmuCrewManifestSystem.cs
@@ -104,6 +104,7 @@ public sealed class OmuCrewManifestSystem : EntitySystem
     {
         return new CrewManifestEntry(
             MetaData(uid).EntityName,
+            "other", // Until someone works out how to pass the gender through to this system, this will do.
             job.LocalizedName,
             job.Icon.ToString(),
             job.ID);

--- a/Content.Omu.Server/CrewManifest/OmuCrewManifestSystem.cs
+++ b/Content.Omu.Server/CrewManifest/OmuCrewManifestSystem.cs
@@ -104,7 +104,7 @@ public sealed class OmuCrewManifestSystem : EntitySystem
     {
         return new CrewManifestEntry(
             MetaData(uid).EntityName,
-            "other", // Until someone works out how to pass the gender through to this system, this will do.
+            "neuter", // Until someone works out how to pass the gender through to this system, this will do.
             job.LocalizedName,
             job.Icon.ToString(),
             job.ID);

--- a/Content.Server/CrewManifest/CrewManifestSystem.cs
+++ b/Content.Server/CrewManifest/CrewManifestSystem.cs
@@ -246,7 +246,7 @@ public sealed class CrewManifestSystem : EntitySystem
         foreach (var recordObject in iter)
         {
             var record = recordObject.Item2;
-            var entry = new CrewManifestEntry(record.Name, record.Gender.ToString().ToLowerInvariant(), record.JobTitle, record.JobIcon, record.JobPrototype);
+            var entry = new CrewManifestEntry(record.Name, record.Gender.ToString().ToLowerInvariant(), record.JobTitle, record.JobIcon, record.JobPrototype); // Funky, add gender to crew manifest.
 
             _prototypeManager.TryIndex(record.JobPrototype, out JobPrototype? job);
             entriesSort.Add((job, entry));

--- a/Content.Server/CrewManifest/CrewManifestSystem.cs
+++ b/Content.Server/CrewManifest/CrewManifestSystem.cs
@@ -246,7 +246,7 @@ public sealed class CrewManifestSystem : EntitySystem
         foreach (var recordObject in iter)
         {
             var record = recordObject.Item2;
-            var entry = new CrewManifestEntry(record.Name, record.JobTitle, record.JobIcon, record.JobPrototype);
+            var entry = new CrewManifestEntry(record.Name, record.Gender.ToString().ToLowerInvariant(), record.JobTitle, record.JobIcon, record.JobPrototype);
 
             _prototypeManager.TryIndex(record.JobPrototype, out JobPrototype? job);
             entriesSort.Add((job, entry));

--- a/Content.Shared/CrewManifest/SharedCrewManifestSystem.cs
+++ b/Content.Shared/CrewManifest/SharedCrewManifestSystem.cs
@@ -57,15 +57,18 @@ public sealed class CrewManifestEntry
 {
     public string Name { get; }
 
+    public string Gender { get; }
+
     public string JobTitle { get; }
 
     public string JobIcon { get; }
 
     public string JobPrototype { get; }
 
-    public CrewManifestEntry(string name, string jobTitle, string jobIcon, string jobPrototype)
+    public CrewManifestEntry(string name, string gender, string jobTitle, string jobIcon, string jobPrototype)
     {
         Name = name;
+        Gender = gender;
         JobTitle = jobTitle;
         JobIcon = jobIcon;
         JobPrototype = jobPrototype;

--- a/Content.Shared/CrewManifest/SharedCrewManifestSystem.cs
+++ b/Content.Shared/CrewManifest/SharedCrewManifestSystem.cs
@@ -57,7 +57,7 @@ public sealed class CrewManifestEntry
 {
     public string Name { get; }
 
-    public string Gender { get; }
+    public string Gender { get; } // Funky
 
     public string JobTitle { get; }
 
@@ -65,10 +65,10 @@ public sealed class CrewManifestEntry
 
     public string JobPrototype { get; }
 
-    public CrewManifestEntry(string name, string gender, string jobTitle, string jobIcon, string jobPrototype)
+    public CrewManifestEntry(string name, string gender, string jobTitle, string jobIcon, string jobPrototype) // Funky, add gender to crew manifest.
     {
         Name = name;
-        Gender = gender;
+        Gender = gender; // Funky
         JobTitle = jobTitle;
         JobIcon = jobIcon;
         JobPrototype = jobPrototype;

--- a/Resources/Locale/en-US/gender.ftl
+++ b/Resources/Locale/en-US/gender.ftl
@@ -1,0 +1,6 @@
+gender-display = ({$gender ->
+    [male] He / Him
+    [female] She / Her
+    [neuter] It / It
+    *[other] They / Them
+})


### PR DESCRIPTION
## About the PR
Crew manifest now scales text such that it will never overflow names onto the job section, and also shows gender of the character.

## Why / Balance
Thaven names were causing issues with how long they were, this fixes it.

## Technical details
To note, all cyborgs are marked with their gender set to other, as I could not work out a easy way to pass it through to the Omu system.

## Media
<img width="584" height="251" alt="image" src="https://github.com/user-attachments/assets/92d80504-ee91-402b-a581-ac6afe05b987" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Crew manifest now shows the gender of crew. 
- fix: Fixed long names overflowing into the job section of the crew manifest. 
