### PR TITLE
[FIX] Fix corpsman mantle being invisible

### DIFF
--- a/Resources/Prototypes/_Omu/Entities/Clothing/Head/mantles.yml
+++ b/Resources/Prototypes/_Omu/Entities/Clothing/Head/mantles.yml
@@ -309,7 +309,7 @@
   - type: Clothing
     sprite: _Omu/Clothing/Head/mantle.rsi
     clothingVisuals:
-      eyes:
+      head:
       - state: helmet-corpsman
       - state: eyes-corpsman
         shader: unshaded


### PR DESCRIPTION
## About the PR
Changes the layer from "eyes" to "head" for the mantle so it is actually visible.

## Why / Balance
Bugfix

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed Corpsman Cyberbeast mantle not showing up when worn.
