### PR TITLE
Fix: Thavens finally can die in crit.

### DIFF
--- a/Content.Server/_Impstation/Thaven/Systems/ThavenBreatherSystem.cs
+++ b/Content.Server/_Impstation/Thaven/Systems/ThavenBreatherSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Atmos;
 using Content.Shared.Body.Components;
 using Content.Shared.Body.Organ;
 using Content.Shared.Drunk;
+using Content.Shared.Mobs.Systems;
 
 namespace Content.Server._Impstation.Thaven.Systems;
 
@@ -20,6 +21,7 @@ public sealed class ThavenBreatherSystem : EntitySystem
     [Dependency] private readonly BodySystem _body = default!;
     [Dependency] private readonly RespiratorSystem _respirator = default!;
     [Dependency] private readonly SharedDrunkSystem _drunk = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
 
     private const float MinIntoxicatingGasMoles = 0.01f;
 
@@ -95,6 +97,14 @@ public sealed class ThavenBreatherSystem : EntitySystem
     {
         if (!TryGetActiveThavenLung(ent, out var lung))
             return;
+
+        // when in crit, thavens should take respiratory damage like everyone else.
+        // skipping this check means adequate air pressure would keep them alive forever.
+        if (_mobState.IsIncapacitated(ent.Owner))
+        {
+            _respirator.UpdateSaturation(ent.Owner, -lung.Comp1.SaturationPerBreath, skipNeedsAirCheck: true);
+            return;
+        }
 
         if (_respirator.CanMetabolizeInhaledAir((ent.Owner, ent.Comp)))
         {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Thavens can now loose oxygen in critical, so they can die!

## Why / Balance
Bugfix: https://github.com/ProjectOmu/OmuStation/issues/812
## Technical details

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
N/A

:cl: Nevec
- fix: Thavens now properly take respiratory damage while in critical condition, preventing a softlock where they could not die.

