### PR TITLE
Add PenetrationFactor to projectiles.

### DIFF
--- a/Content.Server/Projectiles/ProjectileSystem.cs
+++ b/Content.Server/Projectiles/ProjectileSystem.cs
@@ -193,12 +193,12 @@ public sealed class ProjectileSystem : SharedProjectileSystem
             {
                 // Goobstation - Here penetration threshold count as "penetration health".
                 // If it's lower than damage than penetation damage entity cause it deletes projectile
-                if (component.PenetrationThreshold < penetratable.PenetrateDamage)
+                if (component.PenetrationThreshold < (penetratable.PenetrateDamage * component.PenetrationFactor)) // Omu, add penetration factor
                 {
                     component.ProjectileSpent = true;
                 }
 
-                component.PenetrationThreshold -= FixedPoint2.New(penetratable.PenetrateDamage);
+                component.PenetrationThreshold -= (FixedPoint2.New(penetratable.PenetrateDamage) * component.PenetrationFactor); // Omu, add penetration factor
                 component.Damage *= (1 - penetratable.DamagePenaltyModifier);
             }
         }

--- a/Content.Shared/Projectiles/ProjectileComponent.cs
+++ b/Content.Shared/Projectiles/ProjectileComponent.cs
@@ -148,4 +148,10 @@ public sealed partial class ProjectileComponent : Component
     [DataField]
     public Vector2 TargetCoordinates;
     // Goobstation end
+
+    /// <summary>
+    /// Omu:    Effects how much of the PenetrateDamage is taken into account (1 = 100%)
+    /// </summary>
+    [DataField]
+    public FixedPoint2 PenetrationFactor = 1f;
 }

--- a/Resources/Prototypes/_Omu/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/blackiron.yml
+++ b/Resources/Prototypes/_Omu/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/blackiron.yml
@@ -12,6 +12,7 @@
         Structural: 1000
       armorPenetration: 1
     penetrationThreshold: 200
+    penetrationFactor: 0.01
   - type: StaminaDamageOnCollide
     damage: 150
 


### PR DESCRIPTION
## About the PR
Allows projectiles to modify how much Penetration Damage is taken when hitting an object, currently used by BlackIron slugs.

## Why / Balance
So bullets can penetrate further without needing to do ridiculous amounts of damage to a single target.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: BlackIron slugs now penetrate through even more walls.
