### PR TITLE
Update the voting related cvars

### DIFF
--- a/Resources/ConfigPresets/_Omu/OmuCore.toml
+++ b/Resources/ConfigPresets/_Omu/OmuCore.toml
@@ -92,8 +92,8 @@ time = 60 # Increased from 45
 
 [vote]
 enabled = true
-map_enabled = false
-preset_enabled = true
+map_enabled = true
+preset_enabled = false
 restart_enabled = false
 restart_ghost_percentage = 60 # 24 players must be dead
 restart_max_players = 40 # General midground for max players right now


### PR DESCRIPTION
## About the PR
Disabled gamemode voting, enables map voting.

## Why / Balance
Gamemode should only be the gamedirector.
Mapvoting allows the players to decide the map should they wish to play on a specific map.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Disabled gamemode voting, enabled map voting.
