### PR TITLE
[FIX] Allow larger characters to block with shields properly.

### DIFF
--- a/Content.Shared/Blocking/BlockingSystem.cs
+++ b/Content.Shared/Blocking/BlockingSystem.cs
@@ -191,7 +191,7 @@ public sealed partial class BlockingSystem : EntitySystem
             CantBlockError(user);
             return false;
         }
-
+        /* - Omu, this breaks stuff with larger characters, making them entierly unable to block.
         //Don't allow someone to block if someone else is on the same tile
         var playerTileRef = _turf.GetTileRef(xform.Coordinates);
         if (playerTileRef != null)
@@ -207,6 +207,7 @@ public sealed partial class BlockingSystem : EntitySystem
                 }
             }
         }
+        */
 
         //Don't allow someone to block if they're somehow not anchored.
         _transformSystem.AnchorEntity(user, xform);

--- a/Content.Shared/Blocking/BlockingSystem.cs
+++ b/Content.Shared/Blocking/BlockingSystem.cs
@@ -191,12 +191,12 @@ public sealed partial class BlockingSystem : EntitySystem
             CantBlockError(user);
             return false;
         }
-        /* - Omu, this breaks stuff with larger characters, making them entierly unable to block.
+
         //Don't allow someone to block if someone else is on the same tile
         var playerTileRef = _turf.GetTileRef(xform.Coordinates);
         if (playerTileRef != null)
         {
-            var intersecting = _lookup.GetLocalEntitiesIntersecting(playerTileRef.Value, 0f);
+            var intersecting = _lookup.GetLocalEntitiesIntersecting(playerTileRef.Value, -0.2f); // Omu change 0f to -0.2f to allow large characters to block
             var mobQuery = GetEntityQuery<MobStateComponent>();
             foreach (var uid in intersecting)
             {
@@ -207,7 +207,7 @@ public sealed partial class BlockingSystem : EntitySystem
                 }
             }
         }
-        */
+
 
         //Don't allow someone to block if they're somehow not anchored.
         _transformSystem.AnchorEntity(user, xform);

--- a/Content.Shared/Blocking/BlockingSystem.cs
+++ b/Content.Shared/Blocking/BlockingSystem.cs
@@ -208,7 +208,6 @@ public sealed partial class BlockingSystem : EntitySystem
             }
         }
 
-
         //Don't allow someone to block if they're somehow not anchored.
         _transformSystem.AnchorEntity(user, xform);
         if (!xform.Anchored)


### PR DESCRIPTION
## About the PR
Removes the check for intersecting people when blocking (you push people out the way when you raise your shield anyway so this check isn't really needed), this makes it so that larger species can block using shields properly.

## Why / Balance
Larger species should be able to also block using shields.

## Technical details
Comments out a check for intersecting mobs

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Larger characters should be able to block using shields again.
