### PR TITLE
North star + Concussive gauntlet tweaks

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -554,7 +554,7 @@
     soundHit:
       collection: Punch
     animation: WeaponArcFist
-    #mustBeEquippedToUse: true # goob edit
+    mustBeEquippedToUse: true # Omu, they are gloves, you should need to equip them.
     heavyStaminaCost: 0 # goob edit
     canWideSwing: false # goob edit
   - type: Fiber

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Hands/gloves.yml
@@ -22,6 +22,7 @@
     soundHit:
       collection: ExplosionSmall
     heavyStaminaCost: 5
+    mustBeEquippedToUse: true # Omu, they are gloves, you should need to equip them.
   - type: Tag
     tags:
     - Pickaxe


### PR DESCRIPTION
## About the PR
Make it so North stars and Concussive gauntlets need to be in your glove slot to be a melee.

## Why / Balance
Otherwise it kinda defeats the point of them being glove weapons?, You should have to sacrifice insulation in both cases for the strength of the weapon.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Northstars and Concussive Gauntlets now actually need to be worn to work.