### PR TITLE
[FIX] Hopefully make the server updater work consistently.

### DIFF
--- a/Content.Omu.Common/CCVar/CCVars.Omu.cs
+++ b/Content.Omu.Common/CCVar/CCVars.Omu.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices.Marshalling;
 using Robust.Shared.Configuration;
 
 namespace Content.Omu.Common.CCVar;
@@ -16,4 +17,31 @@ public sealed partial class OmuCVars
     /// </summary>
     public static readonly CVarDef<bool> DisablePathfinding =
         CVarDef.Create("omu.disable_pathfinding", false, CVar.SERVER | CVar.SERVERONLY);
+
+    #region "Server Updater"
+    /// <summary>
+    ///     Should the server send a request to the updater to restart on round end.
+    /// </summary>
+    public static readonly CVarDef<bool> ServerUpdaterEnabled =
+        CVarDef.Create("updater.server_updater_enabled", false, CVar.SERVER | CVar.SERVERONLY);
+
+    /// <summary>
+    ///    The ID of the updater to send the restart request to.
+    /// </summary>
+    public static readonly CVarDef<string> ServerUpdaterServerId =
+        CVarDef.Create("updater.server_id", string.Empty, CVar.SERVER | CVar.SERVERONLY);
+
+    /// <summary>
+    ///     The URL of the Pterodactyl panel, used to send the restart request, ex "https://panel.pterodactyl.com/"
+    /// </summary>
+    public static readonly CVarDef<string> ServerUpdaterPanelUrl =
+        CVarDef.Create("updater.panel_url", string.Empty, CVar.SERVER | CVar.SERVERONLY);
+
+    /// <summary>
+    ///     The API key to use when sending the restart request, should be in the format "ptlc_YOUR_API_KEY"
+    /// </summary>
+    public static readonly CVarDef<string> ServerUpdaterApiKey =
+        CVarDef.Create("updater.api_key", string.Empty, CVar.SERVER | CVar.SERVERONLY | CVar.CONFIDENTIAL);
+
+    #endregion
 }

--- a/Content.Omu.Common/CCVar/CCVars.Omu.cs
+++ b/Content.Omu.Common/CCVar/CCVars.Omu.cs
@@ -19,6 +19,7 @@ public sealed partial class OmuCVars
         CVarDef.Create("omu.disable_pathfinding", false, CVar.SERVER | CVar.SERVERONLY);
 
     #region "Server Updater"
+
     /// <summary>
     ///     Should the server send a request to the updater to restart on round end.
     /// </summary>

--- a/Content.Omu.Common/CCVar/CCVars.Omu.cs
+++ b/Content.Omu.Common/CCVar/CCVars.Omu.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices.Marshalling;
 using Robust.Shared.Configuration;
 
 namespace Content.Omu.Common.CCVar;

--- a/Content.Omu.Server/Updater/ServerUpdaterSystem.cs
+++ b/Content.Omu.Server/Updater/ServerUpdaterSystem.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Content.Server._EinsteinEngines.GameTicking;
 using Robust.Shared.Configuration;
 using Content.Omu.Common.CCVar;
-using Microsoft.VisualBasic;
 
 /*
     Realisticly this system shouldn't exist, but its the only way I thought of to ensure the server updates properly.
@@ -20,25 +19,33 @@ public sealed class ServerUpdaterSystem : EntitySystem
 
 
     [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly ILogManager _logMan = default!;
+
     private ISawmill _sawmill = default!;
 
     private string? serverId;
     private bool updaterEnabled = false;
 
-    private string pannelurl = _cfg.GetCVar(OmuCVars.ServerUpdaterPanelUrl);
-    private string apiKey = _cfg.GetCVar(OmuCVars.ServerUpdaterApiKey);
+    private string? pannelurl;
+    private string? apiKey;
 
-    private static readonly HttpClient client = CreateHttpClient();
+    private HttpClient client = default!;
 
     public override void Initialize()
     {
         base.Initialize();
-        _sawmill = Logger.GetSawmill("updater");
+        _sawmill = IoCManager.Resolve<ILogManager>().GetSawmill("updater");
+
+        pannelurl = _cfg.GetCVar(OmuCVars.ServerUpdaterPanelUrl);
+        apiKey = _cfg.GetCVar(OmuCVars.ServerUpdaterApiKey);
+
+        client = CreateHttpClient(pannelurl, apiKey);
 
         SubscribeLocalEvent<RoundEndedEvent>(OnRoundEnded);
 
         _cfg.OnValueChanged(OmuCVars.ServerUpdaterServerId, id => serverId = id, true);
         _cfg.OnValueChanged(OmuCVars.ServerUpdaterEnabled, enabled => updaterEnabled = enabled, true);
+
     }
 
     private void OnRoundEnded(RoundEndedEvent args)
@@ -61,23 +68,23 @@ public sealed class ServerUpdaterSystem : EntitySystem
             return;
         }
 
-        await RestartServerAsync(serverId);
+        RestartServerAsync(serverId);
     }
 
-    private static HttpClient CreateHttpClient()
+    private static HttpClient CreateHttpClient(string pannel_url, string api_key)
     {
         var httpClient = new HttpClient()
         {
-            BaseAddress = new Uri(pannelurl)
+            BaseAddress = new Uri(pannel_url)
         };
 
-        httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {apiKey}");
+        httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {api_key}");
         httpClient.DefaultRequestHeaders.Add("Accept", "Application/vnd.pterodactyl.v1+json");
 
         return httpClient;
     }
 
-    public static async Task RestartServerAsync(string serverId)
+    public async Task RestartServerAsync(string serverId)
     {
         var endpoint = $"api/client/servers/{serverId}/power";
 

--- a/Content.Omu.Server/Updater/ServerUpdaterSystem.cs
+++ b/Content.Omu.Server/Updater/ServerUpdaterSystem.cs
@@ -38,13 +38,14 @@ public sealed class ServerUpdaterSystem : EntitySystem
 
         pannelurl = _cfg.GetCVar(OmuCVars.ServerUpdaterPanelUrl);
         apiKey = _cfg.GetCVar(OmuCVars.ServerUpdaterApiKey);
+        updaterEnabled = _cfg.GetCVar(OmuCVars.ServerUpdaterEnabled);
+        serverId = _cfg.GetCVar(OmuCVars.ServerUpdaterServerId);
 
-        client = CreateHttpClient(pannelurl, apiKey);
+        if (updaterEnabled && (!string.IsNullOrEmpty(pannelurl)) && (!string.IsNullOrEmpty(apiKey)) && (!string.IsNullOrEmpty(serverId))){
+            client = CreateHttpClient(pannelurl, apiKey);
+        }
 
         SubscribeLocalEvent<RoundEndedEvent>(OnRoundEnded);
-
-        _cfg.OnValueChanged(OmuCVars.ServerUpdaterServerId, id => serverId = id, true);
-        _cfg.OnValueChanged(OmuCVars.ServerUpdaterEnabled, enabled => updaterEnabled = enabled, true);
 
     }
 

--- a/Content.Omu.Server/Updater/ServerUpdaterSystem.cs
+++ b/Content.Omu.Server/Updater/ServerUpdaterSystem.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Content.Server._EinsteinEngines.GameTicking;
+using Robust.Shared.Configuration;
+using Content.Omu.Common.CCVar;
+using Microsoft.VisualBasic;
+
+/*
+    Realisticly this system shouldn't exist, but its the only way I thought of to ensure the server updates properly.
+*/
+
+
+namespace Content.Omu.Server.ServerUpdaterSystem;
+
+public sealed class ServerUpdaterSystem : EntitySystem
+{
+
+
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+    private ISawmill _sawmill = default!;
+
+    private string? serverId;
+    private bool updaterEnabled = false;
+
+    private string pannelurl = _cfg.GetCVar(OmuCVars.ServerUpdaterPanelUrl);
+    private string apiKey = _cfg.GetCVar(OmuCVars.ServerUpdaterApiKey);
+
+    private static readonly HttpClient client = CreateHttpClient();
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _sawmill = Logger.GetSawmill("updater");
+
+        SubscribeLocalEvent<RoundEndedEvent>(OnRoundEnded);
+
+        _cfg.OnValueChanged(OmuCVars.ServerUpdaterServerId, id => serverId = id, true);
+        _cfg.OnValueChanged(OmuCVars.ServerUpdaterEnabled, enabled => updaterEnabled = enabled, true);
+    }
+
+    private void OnRoundEnded(RoundEndedEvent args)
+    {
+        if (!updaterEnabled)
+            return;
+        if (string.IsNullOrEmpty(serverId))
+        {
+            _sawmill.Warning("Server ID not set, skipping restarting updater.");
+            return;
+        }
+        if (string.IsNullOrEmpty(pannelurl))
+        {
+            _sawmill.Warning("Panel URL not set, skipping restarting updater.");
+            return;
+        }
+        if (string.IsNullOrEmpty(apiKey))
+        {
+            _sawmill.Warning("API key not set, skipping restarting updater.");
+            return;
+        }
+
+        await RestartServerAsync(serverId);
+    }
+
+    private static HttpClient CreateHttpClient()
+    {
+        var httpClient = new HttpClient()
+        {
+            BaseAddress = new Uri(pannelurl)
+        };
+
+        httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {apiKey}");
+        httpClient.DefaultRequestHeaders.Add("Accept", "Application/vnd.pterodactyl.v1+json");
+
+        return httpClient;
+    }
+
+    public static async Task RestartServerAsync(string serverId)
+    {
+        var endpoint = $"api/client/servers/{serverId}/power";
+
+        var json = "{ \"signal\": \"restart\" }";
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        try
+        {
+            var response = await client.PostAsync(endpoint, content);
+
+            if (response.StatusCode == HttpStatusCode.NoContent)
+            {
+                _sawmill.Info("Updater restart initiated");
+            }
+            else
+            {
+                var body = await response.Content.ReadAsStringAsync();
+                _sawmill.Error($"Request failed: {response.StatusCode}");
+                _sawmill.Error($"Response body: {body}");
+            }
+        }
+        catch (HttpRequestException ex)
+        {
+            _sawmill.Error($"HTTP request error: {ex.Message}");
+        }
+        catch (TaskCanceledException)
+        {
+            _sawmill.Error("Request timed out");
+        }
+    }
+}

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -83,6 +83,7 @@ using System.Numerics;
 using Content.Server.Announcements;
 using Content.Server.Discord;
 using Content.Server.GameTicking.Events;
+using Content.Server._EinsteinEngines.GameTicking; // EE
 using Content.Server.Ghost;
 using Content.Server.Maps;
 using Content.Server.Roles;
@@ -720,6 +721,7 @@ namespace Content.Server.GameTicking
 
             _replayRoundPlayerInfo = listOfPlayerInfoFinal;
             _replayRoundText = roundEndText;
+            RaiseLocalEvent(new RoundEndedEvent(RoundId, roundDuration)); // EE
         }
 
         private async void SendRoundEndDiscordMessage()

--- a/Content.Server/_EinsteinEngines/GameTicking/Events/RoundEndedEvent.cs
+++ b/Content.Server/_EinsteinEngines/GameTicking/Events/RoundEndedEvent.cs
@@ -1,0 +1,13 @@
+namespace Content.Server._EinsteinEngines.GameTicking;
+
+public sealed class RoundEndedEvent : EntityEventArgs
+{
+    public int RoundId { get; }
+    public TimeSpan RoundDuration { get; }
+
+    public RoundEndedEvent(int roundId, TimeSpan roundDuration)
+    {
+        RoundId = roundId;
+        RoundDuration = roundDuration;
+    }
+}


### PR DESCRIPTION
## About the PR
Basics of how this works, when a round ends (but has not gone to lobby yet, ex when the evac shuttle docks to CC), raise an event, then listen for this event, if the cvars for the updater are set and it is enabled, send a API request to Pterodactyl ro restart the relevant updater, this should hopefully restart in time and tell the game server to update before it would time out.

The event used is one I ported from EE for convenience.

## Why / Balance
At the moment we have a race condition with the updater.

## Technical details
See About the PR (or ask me)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed the server failing to update.
