### PR TITLE
Port 3706, Add Item Storage command, from goob.

### DIFF
--- a/Content.Omu.Server/Administration/Commands/AddItemStorage.cs
+++ b/Content.Omu.Server/Administration/Commands/AddItemStorage.cs
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+// SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
+// SPDX-FileCopyrightText: 2025 SolsticeOfTheWinter <solsticeofthewinter@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Server.Administration;
+using Content.Server.Storage.EntitySystems;
+using Content.Shared.Administration;
+using Robust.Shared.Console;
+using Robust.Shared.Prototypes;
+
+namespace Content.Omu.Server.Administration.Commands;
+
+[AdminCommand(AdminFlags.Spawn)]
+public sealed class AddItemStorage : LocalizedCommands
+{
+    private const string CommandName = "additemstorage";
+    public override string Command => CommandName;
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var entityManager = IoCManager.Resolve<IEntityManager>();
+        var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
+        var storageSystem = entityManager.System<StorageSystem>();
+
+        if (args.Length < 2)
+        {
+            shell.WriteLine(Loc.GetString("cmd-additemstorage-args-error"));
+            return;
+        }
+
+        if (!NetEntity.TryParse(args[0], out var targetNet)
+            || !entityManager.TryGetEntity(targetNet, out var targetEntity))
+        {
+            shell.WriteLine(Loc.GetString("cmd-additemstorage-bad-target", ("target", args[0])));
+            return;
+        }
+        var target = targetEntity.Value;
+
+        EntityUid item;
+        if (NetEntity.TryParse(args[1], out var itemNet)
+            && entityManager.TryGetEntity(itemNet, out var itemEntity))
+        {
+            item = itemEntity.Value;
+        }
+        else if (prototypeManager.TryIndex(args[1], out var prototype))
+        {
+            item = entityManager.SpawnEntity(prototype.ID, entityManager.GetComponent<TransformComponent>(target).Coordinates);
+        }
+        else
+        {
+            shell.WriteLine(Loc.GetString("cmd-additemstorage-bad-proto", ("item", args[1])));
+            return;
+        }
+
+
+        if (storageSystem.Insert(target, item, out _, playSound: false))
+        {
+            shell.WriteLine(Loc.GetString("cmd-additemstorage-success",
+                    ("item", entityManager.ToPrettyString(item)),
+                    ("target", entityManager.ToPrettyString(target))));
+        }
+        else
+        {
+            shell.WriteLine(Loc.GetString("cmd-additemstorage-failure",
+                ("item", entityManager.ToPrettyString(item)),
+                ("target", entityManager.ToPrettyString(target))));
+
+            entityManager.DeleteEntity(item);
+        }
+
+    }
+}

--- a/Resources/Locale/en-US/_Omu/administration/commands/additemstorage.ftl
+++ b/Resources/Locale/en-US/_Omu/administration/commands/additemstorage.ftl
@@ -1,0 +1,9 @@
+cmd-additemstorage-desc = Inserts a given entity into a specified entities storage.
+cmd-additemstorage-help = Usage: additemstorage <target> <itemUid/ProtoId>
+
+cmd-additemstorage-args-error = Invalid arguments. { cmd-additemstorage-help }
+cmd-additemstorage-bad-target = Unable to find entity '{$target}'.
+cmd-additemstorage-bad-proto = Invalid item UID/prototype: '{$item}'
+
+cmd-additemstorage-success = Inserted {$item} into {$target}.
+cmd-additemstorage-failure = Failed to insert {$item} into {$target}.


### PR DESCRIPTION
## About the PR
Ports Solstice's unmerged pr that adds a command allowing admins to spawn items directly into a container (ex: a backpack)

https://github.com/Goob-Station/Goob-Station/pull/3706

Example command for how to use this:
`self nearby 1 prototyped ClothingBackpackBlueshield do "additemstorage $ID ClothingHandsGlovesColorYellow"`

## Why / Balance
Useful for execs.

## Technical details
Ports solstice's code, re-namespaces to Omu since it was never merged in goob.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: Solstice
- add: Added a new command for admins: "additemstorage", allowing them to spawn items in a container. 