### PR TITLE
Slasher tweaks

### DIFF
--- a/Content.Goobstation.Server/Slasher/Systems/SlasherSoulStealSystem.cs
+++ b/Content.Goobstation.Server/Slasher/Systems/SlasherSoulStealSystem.cs
@@ -215,6 +215,7 @@ public sealed class SlasherSoulStealSystem : EntitySystem
         var specialUnlockHappened = false;
 
         // Check for possession unlock at 10 souls
+        /* - Omu, disable slasher possession.
         if (!comp.HasUnlockedPossession
             && totalSouls >= comp.PossessionSoulThreshold)
         {
@@ -224,6 +225,7 @@ public sealed class SlasherSoulStealSystem : EntitySystem
             _popup.PopupEntity(Loc.GetString("slasher-soulsteal-unlock-possession"), user, user, PopupType.LargeCaution);
             specialUnlockHappened = true;
         }
+        */
 
         // Check for ascendance at 15 total souls
         if (!comp.HasAscended

--- a/Resources/Prototypes/_Goobstation/GameRules/midround.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/midround.yml
@@ -508,7 +508,7 @@
         softGrabSpeedModifier: 1
         hardGrabSpeedModifier: 1
         chokeGrabSpeedModifier: 1
-      - type: BreathingImmunity
+      #- type: BreathingImmunity # Omu, why would the thing that audibly breaths, be immune to breathing?
       - type: GunBlocked
         PopupText: slasher-cannot-use-guns # Seems to be broken inside AntagSelection
       - type: WeakToHoly


### PR DESCRIPTION
## About the PR
Removes possession from slasher, and removes their breathing immunity.

## Why / Balance
Slasher possession is a instant "i click you and win button", it's not very interesting to deal with, and doesn't really fit the idea of a maints slasher.

Removes their breathing immunity, since why is the mob that audibly breaths, immune to breathing?

## Technical details
Comment out a section of code, and comment out a single line of yaml.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Slasher no longer has the ability to possess others, and is no longer immune to breathing.
