### PR TITLE
Fix Displacementmaps not removing from removed markings and killing client.

### DIFF
--- a/Content.Client/DisplacementMap/DisplacementMapSystem.cs
+++ b/Content.Client/DisplacementMap/DisplacementMapSystem.cs
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using System.Diagnostics.CodeAnalysis;
 using Content.Shared.DisplacementMap;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
@@ -15,6 +16,11 @@ public sealed class DisplacementMapSystem : EntitySystem
     [Dependency] private readonly ISerializationManager _serialization = default!;
     [Dependency] private readonly SpriteSystem _sprite = default!;
 
+    private static string? BuildDisplacementLayerKey(object key)
+    {
+        return key.ToString() is null ? null : $"{key}-displacement";
+    }
+
     /// <summary>
     /// Attempting to apply a displacement map to a specific layer of SpriteComponent
     /// </summary>
@@ -24,21 +30,22 @@ public sealed class DisplacementMapSystem : EntitySystem
     /// <param name="key">Unique layer key, which will determine which layer to apply displacement map to</param>
     /// <param name="displacementKey">The key of the new displacement map layer added by this function.</param>
     /// <returns></returns>
-    public bool TryAddDisplacement(DisplacementData data,
+    public bool TryAddDisplacement(
+        DisplacementData data,
         Entity<SpriteComponent> sprite,
         int index,
         object key,
-        out string displacementKey)
+        [NotNullWhen(true)] out string? displacementKey
+    )
     {
-        displacementKey = $"{key}-displacement";
-
-        if (key.ToString() is null)
+        displacementKey = BuildDisplacementLayerKey(key);
+        if (displacementKey is null)
             return false;
 
-        if (data.ShaderOverride != null)
-            sprite.Comp.LayerSetShader(index, data.ShaderOverride);
+        EnsureDisplacementIsNotOnSprite(sprite, key);
 
-        _sprite.RemoveLayer(sprite.AsNullable(), displacementKey, false);
+        if (data.ShaderOverride is not null)
+            sprite.Comp.LayerSetShader(index, data.ShaderOverride);
 
         //allows you not to write it every time in the YML
         foreach (var pair in data.SizeMaps)
@@ -75,7 +82,11 @@ public sealed class DisplacementMapSystem : EntitySystem
         }
 
         var displacementLayer = _serialization.CreateCopy(displacementDataLayer, notNullableOverride: true);
-        displacementLayer.CopyToShaderParameters!.LayerKey = key.ToString() ?? "this is impossible";
+
+        // This previously assigned a string reading "this is impossible" if key.ToString eval'd to false.
+        // However, for the sake of sanity, we've changed this to assert non-null - !.
+        // If this throws an error, we're not sorry. Nanotrasen thanks you for your service fixing this bug.
+        displacementLayer.CopyToShaderParameters!.LayerKey = key.ToString()!;
 
         _sprite.AddLayer(sprite.AsNullable(), displacementLayer, index);
         _sprite.LayerMapSet(sprite.AsNullable(), displacementKey, index);
@@ -83,14 +94,18 @@ public sealed class DisplacementMapSystem : EntitySystem
         return true;
     }
 
-    /// <inheritdoc cref="TryAddDisplacement"/>
-    [Obsolete("Use the Entity<SpriteComponent> overload")]
-    public bool TryAddDisplacement(DisplacementData data,
-        SpriteComponent sprite,
-        int index,
-        object key,
-        out string displacementKey)
+    /// <summary>
+    /// Ensures that the displacement map associated with the given layer key is not in the Sprite's LayerMap.
+    /// </summary>
+    /// <param name="sprite">The sprite to remove the displacement layer from.</param>
+    /// <param name="key">The key of the layer that is referenced by the displacement layer we want to remove.</param>
+    /// <param name="logMissing">Whether to report an error if the displacement map isn't on the sprite.</param>
+    public void EnsureDisplacementIsNotOnSprite(Entity<SpriteComponent> sprite, object key)
     {
-        return TryAddDisplacement(data, (sprite.Owner, sprite), index, key, out displacementKey);
+        var displacementLayerKey = BuildDisplacementLayerKey(key);
+        if (displacementLayerKey is null)
+            return;
+
+        _sprite.RemoveLayer(sprite.AsNullable(), displacementLayerKey, false);
     }
 }

--- a/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
+++ b/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
@@ -316,25 +316,26 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
     private void RemoveMarking(Marking marking, Entity<SpriteComponent> spriteEnt)
     {
         if (!_markingManager.TryGetMarking(marking, out var prototype))
-        {
             return;
-        }
 
         foreach (var sprite in prototype.Sprites)
         {
             if (sprite is not SpriteSpecifier.Rsi rsi)
-            {
                 continue;
-            }
 
             var layerId = $"{marking.MarkingId}-{rsi.RsiState}";
             if (!_sprite.LayerMapTryGet(spriteEnt.AsNullable(), layerId, out var index, false))
-            {
                 continue;
-            }
 
             _sprite.LayerMapRemove(spriteEnt.AsNullable(), layerId);
             _sprite.RemoveLayer(spriteEnt.AsNullable(), index);
+
+            // If this marking is one that can be displaced, we need to remove the displacement as well; otherwise
+            // altering a marking at runtime can lead to the renderer falling over.
+            // The Vulps must be shaved.
+            // (https://github.com/space-wizards/space-station-14/issues/40135).
+            if (prototype.CanBeDisplaced)
+                _displacement.EnsureDisplacementIsNotOnSprite(spriteEnt, layerId);
         }
     }
     private void ApplyMarking(MarkingPrototype markingPrototype,
@@ -346,9 +347,7 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
         var sprite = entity.Comp2;
 
         if (!_sprite.LayerMapTryGet((entity.Owner, sprite), markingPrototype.BodyPart, out var targetLayer, false))
-        {
             return;
-        }
 
         visible &= !IsHidden(humanoid, markingPrototype.BodyPart);
         visible &= humanoid.BaseLayers.TryGetValue(markingPrototype.BodyPart, out var setting)
@@ -359,9 +358,7 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
             var markingSprite = markingPrototype.Sprites[j];
 
             if (markingSprite is not SpriteSpecifier.Rsi rsi)
-            {
-                continue;
-            }
+                return;
 
             var layerId = $"{markingPrototype.ID}-{rsi.RsiState}";
 
@@ -391,9 +388,7 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
             _sprite.LayerSetVisible((entity.Owner, sprite), layerId, visible);
 
             if (!visible || setting == null) // this is kinda implied
-            {
                 continue;
-            }
 
             // Okay so if the marking prototype is modified but we load old marking data this may no longer be valid
             // and we need to check the index is correct.
@@ -418,9 +413,7 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
             }
 
             if (humanoid.MarkingsDisplacement.TryGetValue(markingPrototype.BodyPart, out var displacementData) && markingPrototype.CanBeDisplaced)
-            {
                 _displacement.TryAddDisplacement(displacementData, (entity.Owner, sprite), targetLayer + j + 1, layerId, out _);
-            }
         }
     }
 


### PR DESCRIPTION
## About the PR
see: https://github.com/space-wizards/space-station-14/pull/40171

Early cherrpick of that upstream PR.

## Why / Balance
needed for:
https://github.com/ProjectOmu/OmuStation/pull/872
and
https://github.com/ProjectOmu/OmuStation/pull/781

I had no issues doing this with hair, but i suspect that i never removed it to see this happen.

## Technical details
In humanoidapparancesystem when markings are removed you check the layermap for the marking, get the layer, and the index, and remove the layer. However we never check for a displacementmap layer FOR that removed marking. Therefore when system 'clears' markings itll fuck shit up.

You can in fact see this behaviour happen if you watch it step by step in debugger, the displacement layer never leaves.

<img width="1619" height="680" alt="image" src="https://github.com/user-attachments/assets/bb4112aa-e92b-451f-8ed9-2b0fa094f58a" />

Cheers to mariki for spotting this early i have the suspicion hairless resomi could've made the renderer shit itself for players.

Also i made my own fix and only THEN did i realize there was one upstream smh.

## Media


## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
Not player facing, this is a rare instance of preventing a bug?
