### PR TITLE
foreigner sec blacklist

### DIFF
--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -99,7 +99,9 @@
   category: MentalTraits # Omustation - Remake EE Traits system - EE traits categories
   blacklist:
     components:
-      - BorgChassis
+    - BorgChassis
+    - SecurityStaff # Omu
+    - CommandStaff # Omu
   components:
     - type: Muted
   globalCost: -6 # Omustation - Remake EE Traits system - global trait points cost

--- a/Resources/Prototypes/_EinsteinEngines/Traits/languages.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Traits/languages.yml
@@ -6,6 +6,11 @@
   name: trait-language-foreigner-light-name
   description: trait-language-foreigner-light-desc
   category: LanguageTraits
+  blacklist: # Omu Station
+    components:
+    - BorgChassis
+    - SecurityStaff
+    - CommandStaff
   cost: -1
   components:
   - type: ForeignerTrait
@@ -23,6 +28,11 @@
   name: trait-language-foreigner-name
   description: trait-language-foreigner-desc
   category: LanguageTraits
+  blacklist: # Omu Station
+    components:
+    - BorgChassis
+    - SecurityStaff
+    - CommandStaff
   cost: -2
   components:
   - type: ForeignerTrait

--- a/Resources/Prototypes/_Goobstation/Traits/disabilities.yml
+++ b/Resources/Prototypes/_Goobstation/Traits/disabilities.yml
@@ -58,8 +58,9 @@
   category: PhysicalTraits #omu
   blacklist: # Omu Station
     components:
-      - SecurityStaff
-      - CommandStaff
+    - BorgChassis
+    - SecurityStaff
+    - CommandStaff
   components:
     - type: SocialAnxiety
   globalCost: -4 #omu i suppose. ive not tedted. If this comment is still here assume i havent tested.
@@ -73,6 +74,8 @@
   blacklist:
     components:
     - BorgChassis
+    - SecurityStaff # Omu
+    - CommandStaff # Omu
   components:
     - type: Deaf
   globalCost: -8 #it might actually be just as or more crippling that not walking in this game - omu


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
No more foreigner trait sec
No more mute trait sec
No more DEAF TRAIT SEC!!!
Also fixed borgs having social anxiety it was funny but Kinda stupid
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
How are you gonna get hired as a security officer if you cant speak the stations main language
Or if you cant speak at all
Makes no sense!! Not even regalis was this wacky!!
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: raincall
- fix: Fixed borgs having the social anxiety trait
- fix: Fixed security and command being able to take foreigner, deaf, and mute traits
