### PR TITLE
Proper Hristov Rebalance

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
@@ -45,9 +45,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 82 # Omu Rebalance 75 -> 80 to counterbalance stamina damage reduction and firerate decrease
-      armorPenetration: 0.5 # Goobstation
-    penetrationThreshold: 100 # Goobstation - This count as penetration health
+        Piercing: 90 # Omu Rebalance 75 -> 90 to counterbalance stamina damage reduction and firerate decrease
+      armorPenetration: 0.65 # Omu Rebalance 0.5 -> 0.65
+    penetrationThreshold: 150 # Omu Rebalance 100 -> 150
   - type: StaminaDamageOnCollide
-    damage: 75
-#Omu StaminaDamage Rebalance 115 -> 70
+    damage: 85 # Omu StaminaDamage Rebalance 115 -> 85

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
@@ -49,4 +49,4 @@
       armorPenetration: 0.65 # Omu Rebalance 0.5 -> 0.65
     penetrationThreshold: 150 # Omu Rebalance 100 -> 150
   - type: StaminaDamageOnCollide
-    damage: 85 # Omu StaminaDamage Rebalance 115 -> 85
+    damage: 90 # Omu StaminaDamage Rebalance 115 -> 90

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
@@ -48,6 +48,6 @@
         Piercing: 75
       armorPenetration: 0.5 # Goobstation
     penetrationThreshold: 100 # Goobstation - This count as penetration health
-#  - type: StaminaDamageOnCollide
-#    damage: 115
-#Omu StaminaDamage Remove ^^
+  - type: StaminaDamageOnCollide
+    damage: 85
+#Omu StaminaDamage Rebalance

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
@@ -45,9 +45,9 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 75
+        Piercing: 80 # Omu Rebalance 75 -> 80 to counterbalance stamina damage reduction and firerate decrease
       armorPenetration: 0.5 # Goobstation
     penetrationThreshold: 100 # Goobstation - This count as penetration health
   - type: StaminaDamageOnCollide
-    damage: 85
-#Omu StaminaDamage Rebalance
+    damage: 75
+#Omu StaminaDamage Rebalance 115 -> 75

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
@@ -45,9 +45,9 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 80 # Omu Rebalance 75 -> 80 to counterbalance stamina damage reduction and firerate decrease
+        Piercing: 82 # Omu Rebalance 75 -> 80 to counterbalance stamina damage reduction and firerate decrease
       armorPenetration: 0.5 # Goobstation
     penetrationThreshold: 100 # Goobstation - This count as penetration health
   - type: StaminaDamageOnCollide
     damage: 75
-#Omu StaminaDamage Rebalance 115 -> 75
+#Omu StaminaDamage Rebalance 115 -> 70

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -153,7 +153,7 @@
     - suitStorage
   - type: AmmoCounter
   - type: Gun
-    fireRate: 0.75
+    fireRate: 0.45 # Omu Rebalance 0.65 -> 0.45 to make it more viable for its intended use case
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -153,7 +153,8 @@
     - suitStorage
   - type: AmmoCounter
   - type: Gun
-    fireRate: 0.45 # Omu Rebalance 0.65 -> 0.45 to make it more viable for its intended use case
+    projectileSpeed: 60 # Omu Rebalance
+    fireRate: 0.35 # Omu Rebalance 0.65 -> 0.35 to make it more viable for its intended use case
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
@@ -273,8 +274,8 @@
   #  capacity: 5
   #  proto: CartridgeAntiMateriel
   - type: SpeedModifiedOnWield
-    walkModifier: 0.8 # goob edit V
-    sprintModifier: 0.8 # goob edit ^
+    walkModifier: 0.7 # Omu Rebalance 20% -> 30% reduction
+    sprintModifier: 0.7 # Omu Rebalance 20% -> 30% reduction
   - type: CursorOffsetRequiresWield
   - type: EyeCursorOffset
     maxOffset: 8 # Goobstation - Sniper rifles buff

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -153,8 +153,8 @@
     - suitStorage
   - type: AmmoCounter
   - type: Gun
-    projectileSpeed: 60 # Omu Rebalance
-    fireRate: 0.35 # Omu Rebalance 0.65 -> 0.35 to make it more viable for its intended use case
+    projectileSpeed: 60 # Omu Rebalance 40 -> 60
+    fireRate: 0.4 # Omu Rebalance 0.65 -> 0.4 to make it more viable for its intended use case
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto


### PR DESCRIPTION
# About the PR
Rebalances the Hristov to find a good middle ground between pro-Hristov and anti-Hristov users. Balances it to be my idea of a balanced sniper rifle. Buffed and nerfed certain stats. Most notably, more damage, less fire rate, faster bullets. Removes instant stamcrit.

# Why / Balance (Yapping Segment)

## My Big Hristov Spiel:

I think that outright removing stamina damage is a bad idea, as it harms the use case of the Hristov, and severely harms its ability to land that follow up shot. I see how the stun only taking a single hit to stamcrit unarmored crew is an issue, but through my (thorough) usage of the Hristov, it still feels very nice and fair from both sides with the 2-3 shot stun seen with crew armor. The insta-stamcrit for unarmored crew has always felt cheap for me, yet I don't see it as a very good reason to outright remove the stamina damage as a whole.

As for the argument about comparing the Hristov to other weapons, the HE1G8 has a much higher price range, for less effect, and is practically unviable for syndicates as its costs 130 TC for only the stunning part required to kill someone. Its not very accurate to compare the two. Its, at heart, a support weapon, and designed to be used by nukies, as they have the TC required to support its ammo cost, can fully reap the benefit of the stun because they have a team backing them up with several other weapons. Same argument applies to the burner, as the use cases are different, and stamina damage on a machine gun is not needed and would simply be too overpowered and that's why it doesn't in the first place.

The stamina damage was not really for "realism". Its a 75 TC weapon, and as such, should perform well for its price range. The stamina damage made it easier for follow up shots, which is what its meant for.  The Hristov is an offensive weapon, its not as good in terms of DPS for rapidly pushing and maneuvering, as a bulldog or c20r will perform much better. Its supposed to be for either holding important positions or utilizing its scope and the benefit of surprise to win a fight. It is very unique in its way, and is better than most at its job. In return, its limited in its fire rate, maneuverability, ammo cost, and ammo size. Due to this, I think it should retain its stamina damage to a certain extent.

The counter for the Hristov should ideally be quick movement, pushing them from multiple angles, and using firelocked doors as cover instead of windows. The Hristov fully relies on its single target damage, and on a two shot system. The first shot should ideally maim, and make the second follow up significantly easier, while still allowing the more robust crew members still have a fair chance to hide before the second shot outright kills them. (while still retaining its power for those who decide not to take the initiative to hide)

## TLDR:

1. Hristov needs some stamina damage for its specific use case. 
2. Needs to be changed to allow it to have an easy and straightforward counter.
3. Insta-stamcrit must be removed
4. Hristov holds an important place in the uplink arsenal.
5. Hristov != HE1G8 (might in the future find a way to make the HE1G8 more interesting and viable in a separate PR)

## Problems adressed:

1. Insta-Stamcrit: reduced stamina damage to make sure its consistently 2-4 shots instead of 1-3 when used on crew, no more insta-stamcrit. Stamina damage is still kept, as its important to make sure that getting hit still means a lot, and that once you do get hit, sprinting isn't as powerful an option.

2. Hristov Counter: Firerate reduced to let the more robust of the crew do something about getting shot instead of getting unavoidably hit a second time and killed. Wielded movement speed also reduced to allow more crew to easily hit the Hristov user if they get close enough, and to make it less viable for pushes and being pushed against.

3. Uniqueness: Buffed damage to incentivize the importance of the follow up shot, but also, again, decreased the fire rate to make it a bit more challenging to land it. Increases the reward for hitting the second shot, in return for higher difficulty due to firerate. Additionally, although a change willing to revert, increased bullet speed, for added uniqueness, as well as to fit its role stronger.

# Technical details
all YAML PR....

## Direct Stat Changes:

Scale from Most Harmful to Most Beneficial

Nerf: 0.65 -> 0.4 firerate, ~40% decrease
Nerf: 115 -> 90 stamina damage, ~20% decrease
Nerf: 20% -> 30% wielded movement speed reduction, ~50% increase
Buff: 100 -> 150 Penetration Power ~50% increase
Buff: 50% -> 65% Armor Penetration ~30% increase
Buff: 75 -> 90 peircing damage, ~25% increase*
*Spicy* Buff: 40 -> 60 Bullet Speed ~50% increase

*makes it consistently 2-shot crit regular crew armors which is a significant change

## Practically, this means:

Much less movement speed
Shots to stun: 1-3 -> 2-4
(Effective Ideal) TTK: 1.85-2.51s -> ~3s 
Crew gets more of a chance to avoid the second shot

In return for:

Consistent 2 shot crit and TTK on everybody
Higher bullet speed
More penetration power

# Media
https://github.com/user-attachments/assets/a89dde56-94fc-4133-b94d-acd70b4e08b2

# Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: PickelSilly
- tweak: Hristov rebalance, brought back some stamina damage. Buffed and nerfed certain stats. Most notably, more damage, less firerate, faster bullets
