### PR TITLE
Disable the lavaland syndicate base from spawning

### DIFF
--- a/Resources/Prototypes/_Lavaland/Procedural/lavaland_grid_ruins.yml
+++ b/Resources/Prototypes/_Lavaland/Procedural/lavaland_grid_ruins.yml
@@ -16,12 +16,12 @@
   componentsToGrant:
   - type: HierophantBeat
 
-- type: lavalandGridRuin
-  id: SyndicateBase
-  name: lavaland-ruin-syndicate
-  path: /Maps/_Lavaland/Lavaland/ruin_syndicate_base.yml
-  priority: -1 # highest priority
-  patchToPlanet: false
+#- type: lavalandGridRuin # Omu, disable this.
+#  id: SyndicateBase
+#  name: lavaland-ruin-syndicate
+#  path: /Maps/_Lavaland/Lavaland/ruin_syndicate_base.yml
+#  priority: -1 # highest priority
+#  patchToPlanet: false
 
 - type: lavalandGridRuin
   id: BiodomeSnow

--- a/Resources/Prototypes/_Lavaland/Procedural/lavaland_ruin_pools.yml
+++ b/Resources/Prototypes/_Lavaland/Procedural/lavaland_ruin_pools.yml
@@ -27,7 +27,7 @@
 - type: lavalandRuinPool
   id: LavalandRuins
   gridRuins:
-    SyndicateBase: 1
+    #SyndicateBase: 1 # Omu, disable this.
     HierophantArena: 1
     RougeAI: 1
     BiodomeBeach: 2


### PR DESCRIPTION
## About the PR
Disables the lavaland syndicate base from spawning, its existence only encourages powergaming, and bug abuse (Despite my efforts of absurdly strong turrets, people still manage to bypass them either through bug abuse or unintended blind spots.

Possibly this base could be re-added if it gets ghostroles and is made significantly harder to raid, but we are better off just having LPO in space at that point.

## Why / Balance
It serves no purpose existing, its loot isn't really useful on lavaland, and is just great for killing other people.

## Technical details
Comment out some yaml 

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- remove: Removed the lavaland syndicate base.
