### PR TITLE
Add speech color for Mice & Rodentia

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/Language/animal.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Language/animal.yml
@@ -61,6 +61,8 @@
 
 - type: language
   id: Mouse
+  speech:
+    color: "#8B532C" #omuchange
   obfuscation:
     !type:SyllableObfuscation
     minSyllables: 2

--- a/Resources/Prototypes/_EinsteinEngines/Language/animal.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Language/animal.yml
@@ -62,7 +62,7 @@
 - type: language
   id: Mouse
   speech:
-    color: "#C4A484" #omuchange
+    color: "#C4A484" # Omu
   obfuscation:
     !type:SyllableObfuscation
     minSyllables: 2

--- a/Resources/Prototypes/_EinsteinEngines/Language/animal.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Language/animal.yml
@@ -62,7 +62,7 @@
 - type: language
   id: Mouse
   speech:
-    color: "#8B532C" #omuchange
+    color: "#C4A484" #omuchange
   obfuscation:
     !type:SyllableObfuscation
     minSyllables: 2


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
I added a colour to the Mouse Language. Did infact make it a lighter brown
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This change was made because the font and colour is the exact same as Tau-ceti. as a language that Rodentia speak its impossible to tell if you the one speaking are actually speaking Mouse or Tau. this change will help clarify that.
## Technical details
<!-- Summary of code changes for easier review. -->
adds  

 speech:
    color: "#C4A484" #omu

to the Mouse language in the animal.yml file in "OmuStation\Resources\Prototypes\_EinsteinEngines\Language"
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: A Brown Colour to the mouse language. rodentia and mice now speak in a brown.

