### PR TITLE
[Port] Port synth trait from DV

### DIFF
--- a/Content.Server/StationEvents/Events/IonStormRule.cs
+++ b/Content.Server/StationEvents/Events/IonStormRule.cs
@@ -17,12 +17,20 @@ using Content.Server.StationEvents.Components;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Silicons.Laws.Components;
 using Content.Shared.Station.Components;
+// CD - start synth trait
+using Content.Server._CD.Traits;
+using Content.Server.Chat.Managers;
+using Content.Shared.Chat;
+using Robust.Shared.Player;
+using Robust.Shared.Random;
+// CD - end synth trait
 
 namespace Content.Server.StationEvents.Events;
 
 public sealed class IonStormRule : StationEventSystem<IonStormRuleComponent>
 {
     [Dependency] private readonly IonStormSystem _ionStorm = default!;
+    [Dependency] private readonly IChatManager _chatManager = default!; // CD - Used for synth trait
 
     protected override void Started(EntityUid uid, IonStormRuleComponent comp, GameRuleComponent gameRule, GameRuleStartedEvent args)
     {
@@ -30,6 +38,22 @@ public sealed class IonStormRule : StationEventSystem<IonStormRuleComponent>
 
         if (!TryGetRandomStation(out var chosenStation))
             return;
+
+        // CD - Go through everyone with the SynthComponent and inform them a storm is happening.
+        var synthQuery = EntityQueryEnumerator<SynthComponent>();
+        while (synthQuery.MoveNext(out var ent, out var synthComp))
+        {
+            if (RobustRandom.Prob(synthComp.AlertChance))
+                continue;
+
+            if (!TryComp<ActorComponent>(ent, out var actor))
+                continue;
+
+            var msg = Loc.GetString("station-event-ion-storm-synth");
+            var wrappedMessage = Loc.GetString("chat-manager-server-wrap-message", ("message", msg));
+            _chatManager.ChatMessageToOne(ChatChannel.Server, msg, wrappedMessage, default, false, actor.PlayerSession.Channel, colorOverride: Color.Yellow);
+        }
+        // CD - End of synth trait
 
         var query = EntityQueryEnumerator<SiliconLawBoundComponent, TransformComponent, IonStormTargetComponent>();
         while (query.MoveNext(out var ent, out var lawBound, out var xform, out var target))

--- a/Content.Server/_CD/Traits/SynthComponent.cs
+++ b/Content.Server/_CD/Traits/SynthComponent.cs
@@ -1,0 +1,14 @@
+namespace Content.Server._CD.Traits;
+
+/// <summary>
+/// Set players' blood to coolant, and is used to notify them of ion storms
+/// </summary>
+[RegisterComponent, Access(typeof(SynthSystem))]
+public sealed partial class SynthComponent : Component
+{
+    /// <summary>
+    /// The chance that the synth is alerted of an ion storm
+    /// </summary>
+    [DataField]
+    public float AlertChance = 0.3f;
+}

--- a/Content.Server/_CD/Traits/SynthSystem.cs
+++ b/Content.Server/_CD/Traits/SynthSystem.cs
@@ -1,0 +1,36 @@
+using Content.Server.Body.Systems;
+using Content.Server.Database;
+using Content.Shared.Chat.TypingIndicator;
+using Content.Shared.Chemistry.Reagent;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._CD.Traits;
+
+public sealed class SynthSystem : EntitySystem
+{
+    // Begin DeltaV - make strings static readonly
+    private static readonly ProtoId<TypingIndicatorPrototype> RobotTypingIndicator = "robot";
+    private static readonly ProtoId<ReagentPrototype> SynthBloodReagent = "SynthBlood";
+    // End DeltaV
+
+    [Dependency] private readonly BloodstreamSystem _bloodstream = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SynthComponent, ComponentStartup>(OnStartup);
+    }
+
+    private void OnStartup(EntityUid uid, SynthComponent component, ComponentStartup args)
+    {
+        if (TryComp<TypingIndicatorComponent>(uid, out var indicator))
+        {
+            indicator.TypingIndicatorPrototype = RobotTypingIndicator; // DeltaV - make strings static readonly
+            Dirty(uid, indicator);
+        }
+
+        // Give them synth blood. Ion storm notif is handled in that system
+        _bloodstream.ChangeBloodReagent(uid, SynthBloodReagent); // DeltaV - make strings static readonly
+    }
+}

--- a/Content.Shared/Chat/TypingIndicator/TypingIndicatorComponent.cs
+++ b/Content.Shared/Chat/TypingIndicator/TypingIndicatorComponent.cs
@@ -18,7 +18,7 @@ namespace Content.Shared.Chat.TypingIndicator;
 ///     Added automatically when player poses entity.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-[Access(typeof(SharedTypingIndicatorSystem))]
+// [Access(typeof(SharedTypingIndicatorSystem))] CD - Restricted access breaks synth trait because it rewrites the speech bubble over the default race indicator
 public sealed partial class TypingIndicatorComponent : Component
 {
     /// <summary>

--- a/Resources/Locale/en-US/_CD/reagents/meta/biological.ftl
+++ b/Resources/Locale/en-US/_CD/reagents/meta/biological.ftl
@@ -1,0 +1,2 @@
+reagent-name-synth-blood = synth blood
+reagent-desc-synth-blood = Not quite coolant, not quite blue powerade.

--- a/Resources/Locale/en-US/_CD/station/events.ftl
+++ b/Resources/Locale/en-US/_CD/station/events.ftl
@@ -1,0 +1,1 @@
+station-event-ion-storm-synth = You detect an Ion Storm. Your internal systems may be tampered with or damaged as a result.

--- a/Resources/Locale/en-US/_CD/traits/traits.ftl
+++ b/Resources/Locale/en-US/_CD/traits/traits.ftl
@@ -1,0 +1,2 @@
+trait-synth-name = Synthetic
+trait-synth-desc = You are a biomechanical construct, who bleeds coolant and is notified of ongoing Ion Storms.

--- a/Resources/Prototypes/_CD/Reagents/biological.yml
+++ b/Resources/Prototypes/_CD/Reagents/biological.yml
@@ -15,7 +15,7 @@
         conditions:
           - !type:OrganType # Omu, replace metabolisertype with organtype
             type: Human
-            inverted: true
+            shouldHave: false
   footstepSound:
     collection: FootstepBlood
     params:

--- a/Resources/Prototypes/_CD/Reagents/biological.yml
+++ b/Resources/Prototypes/_CD/Reagents/biological.yml
@@ -1,0 +1,22 @@
+- type: reagent
+  id: SynthBlood
+  name: reagent-name-synth-blood
+  group: Biological
+  desc: reagent-desc-synth-blood
+  flavor: metallic
+  color: "#00b8f5"
+  recognizable: true
+  physicalDesc: reagent-physical-desc-reflective
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 1.5
+        conditions:
+          - !type:OrganType # Omu, replace metabolisertype with organtype
+            type: Human
+            inverted: true
+  footstepSound:
+    collection: FootstepBlood
+    params:
+      volume: 6

--- a/Resources/Prototypes/_CD/Traits/traits.yml
+++ b/Resources/Prototypes/_CD/Traits/traits.yml
@@ -1,0 +1,18 @@
+- type: trait
+  category: PhysicalTraits
+  id: Synthetic
+  name: trait-synth-name
+  description: trait-synth-desc
+  # Begin DeltaV Additions - blacklist IPCs
+  blacklist:
+    components:
+      - Silicon
+      - BorgChassis
+  # End DeltaV Additions - blacklist IPCs
+  requirements:
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+        - IPC
+  components:
+    - type: Synth


### PR DESCRIPTION
## About the PR
Ports the synth trait from DV, this trait replaces  your blood with SynthBlood, and gives you a chance to be notified of ion storms.

## Why / Balance
Artemis mentioned wanting it, balance wise no impact, hence trait costs 0 points, (does take up a trait slot though.)

## Media
<img width="1851" height="686" alt="image" src="https://github.com/user-attachments/assets/344f0a30-0a73-4f53-87f4-69eb3843ad79" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
`Content.Shared\Chat\TypingIndicator\TypingIndicatorComponent.cs` no longer is restricted access, as it breaks the trait.

**Changelog**
:cl:
- add: Ported the synth trait from DV
