### PR TITLE
Remove command's exemption to the metashield.

### DIFF
--- a/Resources/ServerInfo/_Omu/Guidebook/ServerRules/RoleplayRules/RuleR13Metashield.xml
+++ b/Resources/ServerInfo/_Omu/Guidebook/ServerRules/RoleplayRules/RuleR13Metashield.xml
@@ -45,7 +45,7 @@ SPDX-License-Identifier: MIT
   - Chameleon items and mysterious fibers
   - Stealth items
 
-  However, *all command members do not have a metashield.* They are fully aware of any potential threats, and are specifically "trained" on how to deal with any threat. If the situation requires it, they are also allowed to tell crewmates what is happening and lift the shield. Security is still under metashield, however it is slightly modified and less strict. Please see the "Security Training Manual" for what they specifically know.
+  Command is under a even less strict metashield see "Command Training Manual" for what they specifically know, and if the situation requires it, they are also allowed to tell crewmates what is happening and lift the shield. Security is still under metashield, however it is slightly modified and less strict. Please see the "Security Training Manual" for what they specifically know.
 
   This comes at the expense of being against Nanotrasen policy. Wrongfully lifting the metashield, as a command member, has both IC and OOC consequences. Please see the general Command SOP for when it is considered wrong or right to lift the shield. The fact that Nanotrasen is hiding something from its crewmates is not shielded, but the actual secrets are shielded.
 
@@ -74,6 +74,7 @@ SPDX-License-Identifier: MIT
   - Cargo Bingles are a marketable mascot! Let them walk around and do their job!
 
   ## Not Shielded For Specific Jobs
+  - Deathsquad are not shielded to Dignitaries
   - Zombies are not Shielded to Virologists and Chemists, and can divulge information as needed (Such as needing zombie blood to make Ambuzol)
   - Chaplains know about mystical threats such as Heretics, Cosmic Cultists and Revenants but should roleplay the situation appropriately 
   - Xenobiolgists will know basic features of Xenomorphs such as the fact they reproduce through a parasitic facehugger but will not know specific castes. 


### PR DESCRIPTION
## About the PR
Removes command's blanket exemption to the metashield, instead the Command Training manual dictates what they know.

## Why / Balance
Command training manual doesn't serve much of a purpose with this exemption in place, and it encourages nrp behaviour. 

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Command is no longer exempt to the metashield, refer to the command training manual to see what you know.