### PR TITLE
Derotate chloris

### DIFF
--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -207,7 +207,7 @@ namespace Content.IntegrationTests.Tests
             "Barratry",
             "Box",            // Not in pool
             "CentComm",       // CentComm
-            "Chloris",
+            //"Chloris", // Omu, remove this map.
             "Cluster",
             "Cog",
             "Core",           // Not in pool.
@@ -247,10 +247,10 @@ namespace Content.IntegrationTests.Tests
               "Amber",
               "Atlas",
               "Bagel",
-              "Barratry",
+              //"Barratry", // Omu, not in rotation
             //"Box",            // Not in pool
               "CentComm",      // CentComm
-              "Chloris",
+              //"Chloris", // Omu, derotate this map
               "Cluster",
               "Cog",
             //"Core",           // Not in pool.

--- a/Content.IntegrationTests/Tests/Power/StationPowerTests.cs
+++ b/Content.IntegrationTests/Tests/Power/StationPowerTests.cs
@@ -26,7 +26,7 @@ public sealed class StationPowerTests
         "Box",
         "Cluster",
         "Fland",
-        "Loop",
+        //"Loop", // Omu, not in rotation
         "Marathon",
         "Meta",
         "Oasis",
@@ -36,11 +36,11 @@ public sealed class StationPowerTests
         "Packed",
         "Reach",
         "OasisHighPop",
-        "Barratry",
+        //"Barratry", // Omu, not in rotation
         "Kettle",
         "Leonid",
         "Delta",
-        "Chloris",
+        //"Chloris", // Omu, not in rotation
         "Cog"
     ];
 

--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -76,7 +76,7 @@
   - Kettle # Goobstation - Re-add kettle (before it was gemini!)
   - Leonid # Goobstation - for goob by goob
   - Delta # Goobstation - ported from Corvax
-  - Chloris # Goobstation - also Corvax because we love goidamaps
+  #- Chloris # Goobstation - also Corvax because we love goidamaps # Omu, derotate this map.
   - Cog # those who forget to clear their multitool
   - Glacier #OMU!!!!
   #- Serpentcrest # Omu, HELL NO

--- a/Resources/Prototypes/_Goobstation/Maps/chloris.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/chloris.yml
@@ -6,86 +6,86 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-- type: gameMap
-  id: Chloris
-  mapName: 'Chloris'
-  mapPath: /Maps/_Omu/chloris.yml # Omu - Prisoner role mapping
-  minPlayers: 80
-  stations:
-    Chloris:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Chloris {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'LPK'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_wode.yml
-        - type: StationJobs
-          availableJobs:
-            # command
-            Captain: [ 1, 1 ]
-            AdministrativeAssistant: [ 1, 1 ] # Delta V
-            NanotrasenRepresentative: [ 1, 1 ]
-            BlueshieldOfficer: [ 1, 1 ]
-            NanotrasenCareerTrainer: [ 2, 2] # Omu
-            # cargo
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 4, 4 ]
-            ShaftMiner: [ 3, 3 ] # Omu, needs mapping
-            CargoTechnician: [ 5, 6 ]
-            Courier: [ 2, 2 ] #Omu
-            # engineering
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 2, 3 ]
-            StationEngineer: [ 6, 8 ]
-            TechnicalAssistant: [ 3, 4 ]
-            # medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            MedicalDoctor: [ 6, 8 ]
-            MedicalIntern: [ 3, 4 ]
-            Psychologist: [ 1, 1 ]
-            Paramedic: [ 2, 2 ] # Omu 1 -> 2
-            Chemist: [ 2, 2 ]
-            Virologist: [ 1, 1 ] # Omu
-            # science
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 6, 8 ]
-            ResearchAssistant: [ 3, 4 ]
-            Roboticist: [ 2, 2 ] #Omu
-            # security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 7, 9 ]
-            SecurityCadet: [ 3, 4 ]
-            Detective: [ 1, 1 ]
-            Brigmedic: [ 1, 1 ]
-            TransitPrisoner: [2, 2] # Omu - Prisoner role
-            SecuritySergeant: [ 1, 1 ] #Omu
-            # service
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 1, 1 ]
-            Botanist: [ 3, 4 ]
-            Chaplain: [ 1, 1 ]
-            Chef: [ 2, 3 ]
-            Clown: [ 1, 1 ]
-            Janitor: [ 2, 3 ]
-            Librarian: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 2 ]
-            Reporter: [ 1, 2 ]
-            RadioHost: [ 1, 1 ] # Omu
-            ServiceWorker: [ 3, 4 ]
-            Zookeeper: [ 1, 1 ]
-            Passenger: [ -1, -1 ]
-            # silicon
-            StationAi: [ 1, 1 ]
-            Borg: [ 2, 3 ]
-
-      # Goobstation blob-config-start HUGE
-        - type: StationBlobConfig
-          stageBegin: 40
-          stageCritical: 450
-          stageTheEnd: 900
-      # backmen blob-config-end
+#- type: gameMap
+#  id: Chloris
+#  mapName: 'Chloris'
+#  mapPath: /Maps/_Omu/chloris.yml # Omu - Prisoner role mapping
+#  minPlayers: 80
+#  stations:
+#    Chloris:
+#      stationProto: StandardNanotrasenStation
+#      components:
+#        - type: StationNameSetup
+#          mapNameTemplate: '{0} Chloris {1}'
+#          nameGenerator:
+#            !type:NanotrasenNameGenerator
+#            prefixCreator: 'LPK'
+#        - type: StationEmergencyShuttle
+#          emergencyShuttlePath: /Maps/Shuttles/emergency_wode.yml
+#        - type: StationJobs
+#          availableJobs:
+#            # command
+#            Captain: [ 1, 1 ]
+#            AdministrativeAssistant: [ 1, 1 ] # Delta V
+#            NanotrasenRepresentative: [ 1, 1 ]
+#            BlueshieldOfficer: [ 1, 1 ]
+#            NanotrasenCareerTrainer: [ 2, 2] # Omu
+#            # cargo
+#            Quartermaster: [ 1, 1 ]
+#            SalvageSpecialist: [ 4, 4 ]
+#            ShaftMiner: [ 3, 3 ] # Omu, needs mapping
+#            CargoTechnician: [ 5, 6 ]
+#            Courier: [ 2, 2 ] #Omu
+#            # engineering
+#            ChiefEngineer: [ 1, 1 ]
+#            AtmosphericTechnician: [ 2, 3 ]
+#            StationEngineer: [ 6, 8 ]
+#            TechnicalAssistant: [ 3, 4 ]
+#            # medical
+#            ChiefMedicalOfficer: [ 1, 1 ]
+#            MedicalDoctor: [ 6, 8 ]
+#            MedicalIntern: [ 3, 4 ]
+#            Psychologist: [ 1, 1 ]
+#            Paramedic: [ 2, 2 ] # Omu 1 -> 2
+#            Chemist: [ 2, 2 ]
+#            Virologist: [ 1, 1 ] # Omu
+#            # science
+#            ResearchDirector: [ 1, 1 ]
+#            Scientist: [ 6, 8 ]
+#            ResearchAssistant: [ 3, 4 ]
+#            Roboticist: [ 2, 2 ] #Omu
+#            # security
+#            HeadOfSecurity: [ 1, 1 ]
+#            Warden: [ 1, 1 ]
+#            SecurityOfficer: [ 7, 9 ]
+#            SecurityCadet: [ 3, 4 ]
+#            Detective: [ 1, 1 ]
+#            Brigmedic: [ 1, 1 ]
+#            TransitPrisoner: [2, 2] # Omu - Prisoner role
+#            SecuritySergeant: [ 1, 1 ] #Omu
+#            # service
+#            HeadOfPersonnel: [ 1, 1 ]
+#            Bartender: [ 1, 1 ]
+#            Botanist: [ 3, 4 ]
+#            Chaplain: [ 1, 1 ]
+#            Chef: [ 2, 3 ]
+#            Clown: [ 1, 1 ]
+#            Janitor: [ 2, 3 ]
+#            Librarian: [ 1, 1 ]
+#            Mime: [ 1, 1 ]
+#            Musician: [ 1, 2 ]
+#            Reporter: [ 1, 2 ]
+#            RadioHost: [ 1, 1 ] # Omu
+#            ServiceWorker: [ 3, 4 ]
+#            Zookeeper: [ 1, 1 ]
+#            Passenger: [ -1, -1 ]
+#            # silicon
+#            StationAi: [ 1, 1 ]
+#            Borg: [ 2, 3 ]
+#
+#      # Goobstation blob-config-start HUGE
+#        - type: StationBlobConfig
+#          stageBegin: 40
+#          stageCritical: 450
+#          stageTheEnd: 900
+#      # backmen blob-config-end


### PR DESCRIPTION
## About the PR
Derotates chloris, also updates tests to remove maps we don't have in rotation.

## Why / Balance
This map is coated in issues, from a gimmicky temperature control system that does not even function properly, to wires and pipes running under walls constantly, among a list of other issues.

Lessening the number of maps allows us to update them faster as well.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- remove: Removed Chloris from map rotation.
