### PR TITLE
Re-disable instigator

### DIFF
--- a/Resources/Prototypes/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/GameRules/unknown_shuttles.yml
@@ -54,7 +54,7 @@
     children:
     - id: LoneOpsSpawn
     #- id: UnknownShuttleManOWar # Goob - Nuke the man-o-war
-    - id: UnknownShuttleInstigator
+    #- id: UnknownShuttleInstigator # Omu, disable this
 
 # Shuttle Game Rules
 

--- a/Resources/Prototypes/_Goobstation/threats.yml
+++ b/Resources/Prototypes/_Goobstation/threats.yml
@@ -3,7 +3,7 @@
   id: NumberStationThreats
   weights:
     LoneOperative: 1
-    ShuttleInstigator: 0.8
+    #ShuttleInstigator: 0.8 # Omu, disable this
     VoxRaiders: 0.8
     #GreyTide: 0.65
     #TODO When Slasher is ready Slasher: 0.6 # Goobstation
@@ -40,10 +40,10 @@
   announcement: terror-slaughter-demon
   rule: LaughterDemonSummon
 
-- type: ninjaHackingThreat
-  id: ShuttleInstigator
-  announcement: terror-lone-operative
-  rule: UnknownShuttleInstigator
+#- type: ninjaHackingThreat # Omu, disable this
+#  id: ShuttleInstigator
+#  announcement: terror-lone-operative
+#  rule: UnknownShuttleInstigator
 
 - type: ninjaHackingThreat
   id: WizardMidRoundThreat


### PR DESCRIPTION
## About the PR
Disabled the syndicate instigator gamerule from rolling

## Why / Balance
It's literally a team of three people who have no objective beyond murderbone, have zero win condition either. We have loneop for this kind of thing, wraiths better designed than this shit and yet wraith is disabled while this isn't.

## Technical details
Comment out some lines of yaml.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- remove: Removed the syndicate instigator gamerule from rotation.