### PR TITLE
[FIX] Fix mountain rock having the wrong damage modifier

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Structures/Walls/mountain.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Walls/mountain.yml
@@ -76,7 +76,7 @@
     sprite: _DV/Structures/Walls/mountain_rock.rsi
     state: full
   - type: Damageable
-    damageContainer: Inorganic
+    damageContainer: StructuralInorganic
     damageModifierSet: StructuralMetallicStrong # Omu
   - type: Destructible
     thresholds:

--- a/Resources/Prototypes/_DV/Entities/Structures/Walls/mountain.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Walls/mountain.yml
@@ -76,7 +76,7 @@
     sprite: _DV/Structures/Walls/mountain_rock.rsi
     state: full
   - type: Damageable
-    damageContainer: StructuralInorganic
+    damageContainer: StructuralInorganic # Omu
     damageModifierSet: StructuralMetallicStrong # Omu
   - type: Destructible
     thresholds:

--- a/Resources/Prototypes/_DV/Entities/Structures/Walls/mountain.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Walls/mountain.yml
@@ -77,7 +77,7 @@
     state: full
   - type: Damageable
     damageContainer: Inorganic
-    damageModifierSet: StrongMetallic
+    damageModifierSet: StructuralMetallicStrong # Omu
   - type: Destructible
     thresholds:
     - trigger:


### PR DESCRIPTION
## About the PR
Fixes mountain rock being unable to take structural damage.

## Why / Balance
Its a bug.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed being unable to break mountain rock