### PR TITLE
Remove luxury medipen

### DIFF
--- a/Resources/Prototypes/_DV/Catalog/VendingMachines/Inventories/salvage_points.yml
+++ b/Resources/Prototypes/_DV/Catalog/VendingMachines/Inventories/salvage_points.yml
@@ -103,8 +103,8 @@
     cost: 1200
   - id: ClothingBackpackDuffelSalvageConscription
     cost: 1250
-  - id: LuxuryMedipen
-    cost: 1500
+#  - id: LuxuryMedipen # Omu, remove this.
+#    cost: 1500
   - id: WeaponPlasmaCutter
     cost: 1500
   - id: BorgModuleAdvancedMining


### PR DESCRIPTION
## About the PR
Removes the luxury medipen from the points vend.

## Why / Balance
This thing is a balance nightmare, and doesn't even work as intended.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- remove: Removed the luxury medipen
