### PR TITLE
[FIX] Remove the one spawner for plague mouse that I forgot about.

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mail/mail_fun.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mail/mail_fun.yml
@@ -261,9 +261,9 @@
       - id: MobMouse2
         orGroup: Critter
         prob: 0.33
-      - id: MobMousePlague
-        orGroup: Critter
-        prob: 0.05
+#      - id: MobMousePlague # Omu, disable this
+#        orGroup: Critter
+#        prob: 0.05
       - id: MobMouseCancer
         orGroup: Critter
         prob: 0.01 # Rare


### PR DESCRIPTION
## About the PR
Removes the spawner for plague mice in mail, as I forgot about it in my other PR.

## Why / Balance
I did not intend for this one to remain.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- remove: Removed one leftover unintended spawner for plague mice.
