### PR TITLE
Medical autoinjector cartridge changes

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Medical/hypospray.yml
@@ -203,7 +203,7 @@
     layers:
     - state: base
     - state: filling
-      color: "#c5932d"
+      color: "#eda920" # Omu
   - type: SolutionCartridge
     targetSolution: hypospray
     solution:
@@ -229,7 +229,7 @@
     layers:
     - state: base
     - state: filling
-      color: "#956960"
+      color: "#d74a2e" # Omu
   - type: SolutionCartridge
     targetSolution: hypospray
     solution:
@@ -253,7 +253,7 @@
     layers:
     - state: base
     - state: filling
-      color: "#572757"
+      color: "#832783" # Omu
   - type: SolutionCartridge
     targetSolution: hypospray
     solution:
@@ -272,7 +272,7 @@
     layers:
     - state: base
     - state: filling
-      color: "#b9bf93"
+      color: "#dae97e" # Omu
   - type: SolutionCartridge
     targetSolution: hypospray
     solution:
@@ -310,7 +310,7 @@
     layers:
     - state: base
     - state: filling
-      color: "#415130"
+      color: "#4d6b2d" # Omu
   - type: SolutionCartridge
     targetSolution: hypospray
     solution:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Medical/hypospray.yml
@@ -152,7 +152,7 @@
       - SecBeltEquip
 
 - type: entity
-  name: adrenaline autoinjector cartridge
+  name: autoinjector cartridge (adrenaline) # Omu
   parent: [ BaseSecurityMedicalContraband , BaseAutoinjectorCartridge ]
   description: Contains 7u of epinephrine and 3u of tranexamic acid, used in a cartridge autoinjector.
   id: CartridgeEpinephrine
@@ -173,7 +173,7 @@
         Quantity: 3 # Fully stops bleeding
 
 - type: entity
-  name: airloss autoinjector cartridge
+  name: autoinjector cartridge (airloss) # Omu
   parent: [ BaseSecurityMedicalContraband , BaseAutoinjectorCartridge ]
   description: Contains 7u of saline and 3u of dexalin plus, used in a cartridge autoinjector.
   id: CartridgeSaline
@@ -194,7 +194,7 @@
         Quantity: 3
 
 - type: entity
-  name: brute autoinjector cartridge
+  name: autoinjector cartridge (brute) # Omu
   parent: [ BaseSecurityMedicalContraband , BaseAutoinjectorCartridge ]
   description: Contains 4u of bicaridine, 4u of ibuprofen, 1 unit of salicylic acid and 1u of tranexamic acid, used in a cartridge autoinjector.
   id: CartridgeBicaridine
@@ -220,7 +220,7 @@
   #If you have a full dmg spread, it'll heal ~60 dmg , down from previous 96
   #It will heal 20 dmg if you only have one dmg type and you have more than 25 dmg (see salicylic acid)
 - type: entity
-  name: burn autoinjector cartridge
+  name: autoinjector cartridge (burn) # Omu
   parent: [ BaseSecurityMedicalContraband , BaseAutoinjectorCartridge ]
   description: Contains 5u of kelotane, 4u of dermaline 1u of leporazine, used in a cartridge autoinjector.
   id: CartridgeDermaline
@@ -244,7 +244,7 @@
 #what were they cooking here before, 114 total possible dmg heal was crazyyy
 #~21 dmg healed/dmg type (unless its cold, then its a lil more), doesnt heal caustic all that well
 - type: entity
-  name: emergency autoinjector cartridge
+  name: autoinjector cartridge (emergency) # Omu
   parent: [ BaseSecurityMedicalContraband , BaseAutoinjectorCartridge ]
   description: Contains 10u of atropine, used in a cartridge autoinjector.
   id: CartridgeAtropine
@@ -263,7 +263,7 @@
         Quantity: 10
 
 - type: entity
-  name: piercing autoinjector cartridge
+  name: autoinjector cartridge (piercing) # Omu
   parent: [ BaseSyndicateContraband , BaseAutoinjectorCartridge ]
   description: Contains 10u of puncturase, used in a cartridge autoinjector.
   id: CartridgePuncturase
@@ -282,7 +282,7 @@
         Quantity: 10
 
 - type: entity
-  name: stimulant autoinjector cartridge
+  name: autoinjector cartridge (stimulant) # Omu
   parent: [ BaseSyndicateContraband , BaseAutoinjectorCartridge ]
   description: Contains 10u of ephedrine, used in a cartridge autoinjector.
   id: CartridgeEphedrine
@@ -301,7 +301,7 @@
         Quantity: 10
 
 - type: entity
-  name: sedative autoinjector cartridge
+  name: autoinjector cartridge (sedative) # Omu
   parent: [ BaseSyndicateContraband , BaseAutoinjectorCartridge ]
   description: Contains 4u of tirizene, 3u of impedrezene and 3u of haloperidol, used in a cartridge autoinjector.
   id: CartridgeTirizene
@@ -326,7 +326,7 @@
 # Q - Why is this edible?
 # A - Because the dispenser reminded me of a pez dispenser, and it'd be funny if you could eat them.
 - type: entity
-  name: amnestic autoinjector cartridge
+  name: autoinjector cartridge (amnestic) # Omu
   parent: [ BaseCentcommContraband , BaseAutoinjectorCartridge, EdibleBase ]
   description: Contains 10u of dimtremethic-neuramincyl acid, used in a cartridge autoinjector.
   id: CartridgeAmnestic

--- a/Resources/Prototypes/_Omu/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/_Omu/Entities/Objects/Specific/Medical/hypospray.yml
@@ -8,26 +8,28 @@
     layers:
     - state: base
     - state: filling
-      color: "#572757"
+      color: "#8dce15"
   - type: SolutionCartridge
     targetSolution: hypospray
     solution:
       maxVol: 10
       reagents:
+      - ReagentId: Hyronalin
+        Quantity: 5
       - ReagentId: Arithrazine
-        Quantity: 10
+        Quantity: 5
 
 - type: entity
   name: poison autoinjector cartridge
   parent: [ BaseSecurityMedicalContraband , BaseAutoinjectorCartridge ]
-  description: Contains 10u of dylovene, used in a cartridge autoinjector.
+  description: Contains 8u of dylovene, and 1u of multiver, used in a cartridge autoinjector.
   id: CartridgeDylo
   components:
   - type: Sprite
     layers:
     - state: base
     - state: filling
-      color: "#572757"
+      color: "#3c2097"
   - type: SolutionCartridge
     targetSolution: hypospray
     solution:

--- a/Resources/Prototypes/_Omu/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/_Omu/Entities/Objects/Specific/Medical/hypospray.yml
@@ -1,5 +1,5 @@
 - type: entity
-  name: radiation autoinjector cartridge
+  name: autoinjector cartridge (radiation) # Omu
   parent: [ BaseSecurityMedicalContraband , BaseAutoinjectorCartridge ]
   description: Contains 10u of arithrazine, used in a cartridge autoinjector.
   id: CartridgeArith
@@ -8,7 +8,7 @@
     layers:
     - state: base
     - state: filling
-      color: "#8dce15"
+      color: "#15ce5c"
   - type: SolutionCartridge
     targetSolution: hypospray
     solution:
@@ -20,7 +20,7 @@
         Quantity: 5
 
 - type: entity
-  name: poison autoinjector cartridge
+  name: autoinjector cartridge (poison) # Omu
   parent: [ BaseSecurityMedicalContraband , BaseAutoinjectorCartridge ]
   description: Contains 8u of dylovene, and 1u of multiver, used in a cartridge autoinjector.
   id: CartridgeDylo

--- a/Resources/Prototypes/_Omu/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/_Omu/Entities/Objects/Specific/Medical/hypospray.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: autoinjector cartridge (radiation) # Omu
   parent: [ BaseSecurityMedicalContraband , BaseAutoinjectorCartridge ]
-  description: Contains 10u of arithrazine, used in a cartridge autoinjector.
+  description: Contains 5u of arithrazine, and 5u of hyronalin used in a cartridge autoinjector.
   id: CartridgeArith
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Omu/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/_Omu/Entities/Objects/Specific/Medical/hypospray.yml
@@ -22,7 +22,7 @@
 - type: entity
   name: autoinjector cartridge (poison) # Omu
   parent: [ BaseSecurityMedicalContraband , BaseAutoinjectorCartridge ]
-  description: Contains 8u of dylovene, and 1u of multiver, used in a cartridge autoinjector.
+  description: Contains 8u of dylovene, and 2u of multiver, used in a cartridge autoinjector.
   id: CartridgeDylo
   components:
   - type: Sprite
@@ -36,4 +36,6 @@
       maxVol: 10
       reagents:
       - ReagentId: Dylovene
-        Quantity: 10
+        Quantity: 8
+      - ReagentId: Multiver
+        Quantity: 2


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Changes the colours of the medical autoinjector cartridges to be easier to tell apart. (see media)
Also changes the naming convention for them from `[type] autoinjector cartridge` to `autoinjector cartridge ([type])` similar to other 'ammo/cartridges' this also groups them together in the medical techfab.

Additionally tweaks our forks custom medical cartridges, radiation and poison to be slightly more useful.

## Why / Balance
a lot of them were very hard to tell apart, there could be some sentiment here to consider for colorblind players, though not much is done in regards to that for chemicals elsewhere.

As for the changes to the radiation and poison cartridges:
Radiaton:
The arith cartridges were pretty strong, this brings them to 40rads from 60, however their healing rate is now slightly faster at 4/s for 10s rather than 3/s for 20s, its ok though people will just be using 5u pent or something i don't know.
Poison:
10 dylo -> 8u dylo 2u multiver
should now be more effective at stopping an active poisoning from say; vent spiders, removing 12u poisons 12u narcotics, in cases of this it would also be purging its dylovene basically acting as a neturalization.
in cases of a clean bloodstream these should be healing 32 poison total.


## Technical details
yaml stuff

## Media
<img width="440" height="338" alt="image" src="https://github.com/user-attachments/assets/6bb2d571-efa3-47ad-b917-29958687fc43" />

left to right top to bottom:
brute burn airloss rads poison emergency adrenaline
sedative stimulant piercing
amnestic

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Medical's autoinjector cartridges now have more vibrant colours to better tell them apart.
- tweak: poison autoinjector cartridges now contain 2u multiver, 8u dylovene to aid in active field poisonings.
- tweak: radiation autoinjector cartridges now contain 5u arithrazine, 5u hyronlin.
- tweak: autoinjector cartridges are now named so that they group together in the medical techfabs list of items.
