### PR TITLE
Make Pun Pun's ID unremovable

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -199,6 +199,7 @@
     controlsLocked: false
     randomMode: false
     mode: SensorCords
+  - type: Unremovable # Omu - Make Pun Pun's ID card unremovable
 
 - type: entity
   parent: ClothingUniformBase

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -189,7 +189,7 @@
   parent: ClothingUniformBase
   id: ClothingUniformJumpsuitJacketMonkey
   name: bartender's jacket monkey
-  description: A decent jacket, for a decent monkey.
+  description: A decent jacket, for a decent monkey. It seems to be firmly attached to the monkey. # Omu
   components:
   - type: Sprite
     sprite: Clothing/Uniforms/Jumpsuit/punpun.rsi

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -199,7 +199,7 @@
     controlsLocked: false
     randomMode: false
     mode: SensorCords
-  - type: Unremovable # Omu - Make Pun Pun's ID card unremovable
+  - type: Unremoveable # Omu - Make Pun Pun's ID card unremoveable
 
 - type: entity
   parent: ClothingUniformBase

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -483,6 +483,7 @@
   parent: IDCardStandard
   id: PunPunIDCard
   name: pun pun ID card
+  description: A card necessary to access various areas aboard the station. It seems firmly attached to the jumpsuit. # Omu
   components:
     - type: Sprite
       layers:
@@ -494,6 +495,7 @@
     - type: Tag #  Ignore Chameleon tags
       tags:
       - DoorBumpOpener
+    - type: Unremovable # Omu - Make Pun Pun's ID card unremovable
 
 - type: entity
   parent: IDCardStandard

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -495,7 +495,7 @@
     - type: Tag #  Ignore Chameleon tags
       tags:
       - DoorBumpOpener
-    - type: Unremovable # Omu - Make Pun Pun's ID card unremovable
+    - type: Unremoveable # Omu - Make Pun Pun's ID card unremoveable
 
 - type: entity
   parent: IDCardStandard


### PR DESCRIPTION
## About the PR
Maks pun puns jumpsuit and ID unremovable, to make them unable to switch jobs. As they will do anything but be a bartender (the only reason pun pun even exists is to be a bartender...)

## Why / Balance
Pun pun players take the role to be a shit with a gun rather than to actually act as a bartending monkey, this makes then unable to go change their id.

## Technical details
Add unremovable comp to pun puns jumpsuit and id, and change the description of both to clarify this.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Pun Pun's jumpsuit and ID are now unremovable. Pun is a bartender.