### PR TITLE
Avali Pounce Ability

### DIFF
--- a/Resources/Prototypes/_StarLight/Actions/avali.yml
+++ b/Resources/Prototypes/_StarLight/Actions/avali.yml
@@ -27,3 +27,16 @@
     - type: InstantAction
       event: !type:ExitStasisActionEvent
 
+- type: entity
+  parent: BaseAction
+  id: ActionPounce
+  name: Pounce
+  description: Pounce in the direction of your gaze with your strong legs.
+  components:
+  - type: Action
+    useDelay: 8
+    icon:
+      sprite: _Starlight/Interface/Action/actions_avali.rsi
+      state: empty
+  - type: InstantAction
+    event: !type:GravityJumpEvent

--- a/Resources/Prototypes/_StarLight/Actions/avali.yml
+++ b/Resources/Prototypes/_StarLight/Actions/avali.yml
@@ -36,7 +36,7 @@
   - type: Action
     useDelay: 8
     icon:
-      sprite: _Starlight/Interface/Action/actions_avali.rsi
+      sprite: _Starlight/Interface/Actions/actions_avali.rsi
       state: empty
   - type: InstantAction
-    event: !type:GravityJumpEvent
+    event: !type:GravityJumpEvent {}

--- a/Resources/Prototypes/_StarLight/Actions/avali.yml
+++ b/Resources/Prototypes/_StarLight/Actions/avali.yml
@@ -36,7 +36,7 @@
   - type: Action
     useDelay: 8
     icon:
-      sprite: _Starlight/Interface/Actions/actions_avali.rsi
-      state: empty
+      sprite: Interface/Actions/jump.rsi
+      state: icon
   - type: InstantAction
     event: !type:GravityJumpEvent {}

--- a/Resources/Prototypes/_StarLight/Body/Parts/avali.yml
+++ b/Resources/Prototypes/_StarLight/Body/Parts/avali.yml
@@ -99,13 +99,13 @@
   id: LeftLegAvali
   name: "left avali leg"
   components:
-    - type: Sprite
-      state: "l_leg"
-    - type: BodyPart
+  - type: BodyPart
     onAdd:
-      - type: JumpAbility
-        JumpDistance: 3
-        JumpThrowSpeed: 15
+    - type: JumpAbility
+      JumpDistance: 3
+      JumpThrowSpeed: 15
+  - type: Sprite
+    state: "l_leg"
 
 - type: entity
   parent: [PartAvali, BaseRightLeg]

--- a/Resources/Prototypes/_StarLight/Body/Parts/avali.yml
+++ b/Resources/Prototypes/_StarLight/Body/Parts/avali.yml
@@ -101,6 +101,11 @@
   components:
     - type: Sprite
       state: "l_leg"
+    - type: BodyPart
+    onAdd:
+      - type: JumpAbility
+        JumpDistance: 3
+        JumpThrowSpeed: 15
 
 - type: entity
   parent: [PartAvali, BaseRightLeg]

--- a/Resources/Prototypes/_StarLight/Body/Parts/avali.yml
+++ b/Resources/Prototypes/_StarLight/Body/Parts/avali.yml
@@ -102,8 +102,11 @@
   - type: BodyPart
     onAdd:
     - type: JumpAbility
-      JumpDistance: 3
-      JumpThrowSpeed: 15
+      jumpDistance: 3
+      jumpThrowSpeed: 15
+    - type: ActionGrant
+      actions:
+      - ActionPounce
   - type: Sprite
     state: "l_leg"
 

--- a/Resources/Prototypes/_StarLight/Body/Parts/avali.yml
+++ b/Resources/Prototypes/_StarLight/Body/Parts/avali.yml
@@ -99,12 +99,13 @@
   id: LeftLegAvali
   name: "left avali leg"
   components:
-  - type: BodyPart
+  - type: BodyPart # shoved together by Kazuno
     onAdd:
-    - type: JumpAbility
+    - type: JumpAbility # "nerfed" jump ability for the pounce
       jumpDistance: 3
       jumpThrowSpeed: 15
-    - type: ActionGrant
+      jumpSound: /Audio/Effects/thudswoosh.ogg # this took over 2 hours to find and im mad about that
+    - type: ActionGrant # i feel kinda stupid for not granting the action first but ActionPounce is whats used for its action
       actions:
       - ActionPounce
   - type: Sprite


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Added an ability for the Avali called Pounce which springs you forward in the direction your looking at just like jump boots but in a shorter distance
## Why / Balance
i though avali could use its own movement tool to go with the other species like harpys and moths
## Technical details
Their ability is linked to their left leg in their parts file like how harpy have their flight linked to their right arm and functions like jump boots but instead of being 4 distance and 10 speed its 3 distance and 15 speed to compensate while also keeping the same cooldown time.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).

https://github.com/user-attachments/assets/557ecd29-33ef-460d-a57d-67ecbe263291



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
Added: Avali's now have the ability to pounce. This works like integrated jump boots but has a slightly shorter distance and same cooldown