### PR TITLE
fix no-cost traits being unselectable when at max trait count

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -797,7 +797,7 @@ namespace Content.Client.Lobby.UI
                 selector.PreferenceChanged += preference =>
                 {
                     if (preference &&
-                    (_selectedTraitCount < _maxTraits || _maxTraits <= 0)) // make sure the player isn't selecting more traits than they're allowed
+                    (_selectedTraitCount < _maxTraits || _maxTraits <= 0 || !trait.CountsTowardsMaxTraits)) // make sure the player isn't selecting more traits than they're allowed
                     {
                         Profile = Profile?.WithTraitPreference(trait.ID, _prototypeManager);
                         _selectedTraitPointCount -= trait.GlobalCost;


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
Previously, you would be prevented from selecting a trait if you had 5/5 traits selected and then tried to select a trait which doesn't contribute to the trait total. This should fix that.

## Technical details
Added an extra disjunction to a condition.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

