### PR TITLE
[FIX] Fix betrayal knife causing server crash.

### DIFF
--- a/Content.Shared/_White/Standing/TelefragSystem.cs
+++ b/Content.Shared/_White/Standing/TelefragSystem.cs
@@ -37,7 +37,7 @@ public sealed class TelefragSystem : EntitySystem
                 continue;
 
             if (_stun.TryCrawling(ent) && autoStandUp)
-                _stun.TryStand(ent!);
+                _stun.TryStanding(ent); // Omu, change TryStand(ent!) to TryStanding(ent)
         }
     }
 }


### PR DESCRIPTION
## About the PR
Fix a server crash

fixes #948 

## Technical details
change `TryStand(ent!)` to` TryStanding(ent)` in `Content.Shared\_White\Standing\TelefragSystem.cs`

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed Betrayal knife causing a server crash.
