### PR TITLE
[BOUNTY] Xelthia Can Eat Raw Meat

### DIFF
--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -606,6 +606,9 @@
           - !type:OrganType # Goobstation - XenobioSlime
             type: XenobioSlime
             shouldHave: false
+          - !type:OrganType # Omu, Letting xelthia eat more things
+            type: Xelthia
+            shouldHave: false
         type: Local
         visualType: MediumCaution
         messages: [ "generic-reagent-effect-sick" ]
@@ -624,6 +627,9 @@
             shouldHave: false
           - !type:OrganType # Goobstation - XenobioSlime
             type: XenobioSlime # slimes shouldn't vomit from blood and raw meat
+            shouldHave: false
+          - !type:OrganType # Omu, Letting xelthia eat more things
+            type: Xelthia
             shouldHave: false
       - !type:HealthChange
         conditions:

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -645,6 +645,9 @@
         - !type:OrganType # Goobstation - XenobioSlime
           type: XenobioSlime
           shouldHave: false
+        - !type:OrganType # Omu, Letting xelthia eat more things
+          type: Xelthia
+          shouldHave: false
         damage:
           types:
             Poison: 1
@@ -652,6 +655,12 @@
         conditions:
         - !type:OrganType
           type: Animal
+        reagent: Protein
+        amount: 0.5
+      - !type:AdjustReagent # Omu, letting xelthia eat more things
+        conditions:
+        - !type:OrganType
+          type: Xelthia
         reagent: Protein
         amount: 0.5
       - !type:AdjustReagent # Goobstation - XenobioSlime


### PR DESCRIPTION
## About the PR
Bounty. Lets xelthians eat raw meat without getting poisoned

## Why / Balance
Made as a bounty. The xelthians are supposed to be foodies and it just makes sense for them to be able to eat raw meat, especially with their cannibalism culture.

## Technical details
yamlslop

## Media
not applicable

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: PickelSilly
- tweak: Let xelthians eat raw meat with no downsides