### PR TITLE
[BOUNTY] Xelthia Diet Changes

### DIFF
--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -606,6 +606,9 @@
           - !type:OrganType # Goobstation - XenobioSlime
             type: XenobioSlime
             shouldHave: false
+          - !type:OrganType # Omu, Letting xelthia eat more things
+            type: Xelthia
+            shouldHave: false
         type: Local
         visualType: MediumCaution
         messages: [ "generic-reagent-effect-sick" ]
@@ -624,6 +627,9 @@
             shouldHave: false
           - !type:OrganType # Goobstation - XenobioSlime
             type: XenobioSlime # slimes shouldn't vomit from blood and raw meat
+            shouldHave: false
+          - !type:OrganType # Omu, Letting xelthia eat more things
+            type: Xelthia
             shouldHave: false
       - !type:HealthChange
         conditions:

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -645,6 +645,9 @@
         - !type:OrganType # Goobstation - XenobioSlime
           type: XenobioSlime
           shouldHave: false
+        - !type:OrganType # Omu, Letting xelthia eat more things
+          type: Xelthia
+          shouldHave: false
         damage:
           types:
             Poison: 1
@@ -652,6 +655,12 @@
         conditions:
         - !type:OrganType
           type: Animal
+        reagent: Protein
+        amount: 0.5
+      - !type:AdjustReagent # Omu, letting xelthia eat more things
+        conditions:
+        - !type:OrganType
+          type: Xelthia
         reagent: Protein
         amount: 0.5
       - !type:AdjustReagent # Goobstation - XenobioSlime

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -606,7 +606,7 @@
           - !type:OrganType # Goobstation - XenobioSlime
             type: XenobioSlime
             shouldHave: false
-          - !type:OrganType # Omu, Letting xelthia eat more things
+          - !type:OrganType # Omu, Letting xelthia eat raw meat
             type: Xelthia
             shouldHave: false
         type: Local
@@ -628,7 +628,7 @@
           - !type:OrganType # Goobstation - XenobioSlime
             type: XenobioSlime # slimes shouldn't vomit from blood and raw meat
             shouldHave: false
-          - !type:OrganType # Omu, Letting xelthia eat more things
+          - !type:OrganType # Omu, Letting xelthia eat raw meat
             type: Xelthia
             shouldHave: false
       - !type:HealthChange

--- a/Resources/Prototypes/_EinsteinEngines/Body/Organs/xelthia.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Body/Organs/xelthia.yml
@@ -3,7 +3,7 @@
   name: xelthia stomach
   parent: OrganHumanStomach
   categories: [ HideSpawnMenu ]
-  components:
+  components: # Omu, Removed special digestion so that xelthia can properly eat chocolate and other things
   - type: SolutionContainerManager
     solutions:
       stomach:

--- a/Resources/Prototypes/_EinsteinEngines/Body/Organs/xelthia.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Body/Organs/xelthia.yml
@@ -4,14 +4,6 @@
   parent: OrganHumanStomach
   categories: [ HideSpawnMenu ]
   components:
-  - type: Stomach
-    specialDigestible:
-      tags:
-      - ReptilianFood # Omu, lets xelthia eat chocolate, cant figure out what makes the "you cant digest this" pop up so its this for
-      - Meat
-      - Pill
-      - Crayon
-      - Paper
   - type: SolutionContainerManager
     solutions:
       stomach:

--- a/Resources/Prototypes/_EinsteinEngines/Body/Organs/xelthia.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Body/Organs/xelthia.yml
@@ -7,6 +7,7 @@
   - type: Stomach
     specialDigestible:
       tags:
+      - ReptilianFood # Omu, lets xelthia eat chocolate, cant figure out what makes the "you cant digest this" pop up so its this for
       - Meat
       - Pill
       - Crayon
@@ -14,7 +15,7 @@
   - type: SolutionContainerManager
     solutions:
       stomach:
-        maxVol: 50
+        maxVol: 70 # Omu, xelthia fatty
       food:
         maxVol: 5
         reagents:

--- a/Resources/Prototypes/_EinsteinEngines/Body/Organs/xelthia.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Body/Organs/xelthia.yml
@@ -3,11 +3,18 @@
   name: xelthia stomach
   parent: OrganHumanStomach
   categories: [ HideSpawnMenu ]
-  components: # Omu, Removed special digestion so that xelthia can properly eat chocolate and other things
+  components:
+  - type: Stomach
+    specialDigestible:
+      tags:
+      - Meat
+      - Pill
+      - Crayon
+      - Paper
   - type: SolutionContainerManager
     solutions:
       stomach:
-        maxVol: 70 # Omu, xelthia fatty
+        maxVol: 65 # Omu, Xelitha fatty
       food:
         maxVol: 5
         reagents:

--- a/Resources/Prototypes/_EinsteinEngines/Body/Prototypes/xelthia.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Body/Prototypes/xelthia.yml
@@ -13,7 +13,7 @@
     chest:
       part: ChestXelthia
       organs:
-        heart: OrganAnimalHeart
+        heart: OrganHumanHeart
         lungs: OrganHumanLungs
       connections:
       - right arm

--- a/Resources/Prototypes/_EinsteinEngines/Body/Prototypes/xelthia.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Body/Prototypes/xelthia.yml
@@ -13,7 +13,7 @@
     chest:
       part: ChestXelthia
       organs:
-        heart: OrganHumanHeart
+        heart: OrganHumanHeart # Omu, removed theobromine allergy
         lungs: OrganHumanLungs
       connections:
       - right arm

--- a/Resources/ServerInfo/_EinsteinEngines/Guidebook/Mobs/Xelthia.xml
+++ b/Resources/ServerInfo/_EinsteinEngines/Guidebook/Mobs/Xelthia.xml
@@ -4,24 +4,25 @@
   <Box>
     <GuideEntityEmbed Entity="MobXelthia" Caption=""/>
   </Box>
-  
+
   ## Gameplay Information
-  
+
   [color=#00cc00][bold]Positives:[/bold][/color]
-  
-  - Due to having tentacles, are able to drop and regrow their arms as needed; dropped arms can be cooked and eaten if desired.
+
+  - Due to having tentacles, are able to drop and regrow their arms as needed; dropped arms can be eaten if desired.
   - Have a higher-than-average heat tolerance, and take [color=#ffa500]less Heat damage[/color] overall.
   - Have slippery, [color=#bbff00]Acidic blood[/color].
   - Immune to most sources of [color=#bbff00]Caustic damage[/color].
-  
+  - Can eat raw food without any negative consequences, and don't suffer a theobromine allergy.
+
   [color=red][bold]Negatives:[/bold][/color]
-  
+
   - Carnivores; can only eat foods containing meat.
   - Thanks to having tentacles for arms, they [color=red]can't wear gloves[/color]. If you want [color=yellow]electrical insulation[/color], you'll have to track down an [color=yellow]insulated jacket[/color]!
   - Have worse-than average cold tolerance, and take more [color=#1e90ff]Cold damage[/color] overall.
-  
+
   ## Background Information
-  To sum them up briefly, Xelthia are a species that have only had their first contact with humans around 100 years ago. They tend to be foodies, and aren't fans of wasting things, going as far with it as to often eat their own dead— though cooked. Xelthia generally tend to fall into two camps: those who are extremely driven to do things and accomplish their own goals, and those who just want to blend in with the crowd, sometimes lacking a drive to do much more than simply work as a janitor.
-  
+  To sum them up briefly, Xelthia are a species that have only had their first contact with humans around 100 years ago. They tend to be foodies, and aren't fans of wasting things, going as far with it as to often eat their own dead— even raw. Xelthia generally tend to fall into two camps: those who are extremely driven to do things and accomplish their own goals, and those who just want to blend in with the crowd, sometimes lacking a drive to do much more than simply work as a janitor.
+
   [color=#878787](More in-depth lore is to be written at a later date, though some details include that they're originally from a swamp world and the specific year of their first contact is likely around 2347. This existing summary will stay regardless for those who aren't as interested or are in a rush.)[/color]
 </Document>


### PR DESCRIPTION
## About the PR
Changes Xelthia diet to be able to drink coffee and not die from theobromine, eat raw meat freely, and eat more before becoming full.

## Why / Balance
Made as a bounty. These changes both add to the "foodiness" of xelthia as a species as the guidebook states, and also just makes gameplay nicer.

## Technical details
yamlslop

## Media
not applicable, I don't think this needs a demo

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Xelthia can now freely drink coffee and eat raw meat.
