### PR TITLE
[FIX] Comment out abductor artifact organ due to it causing heavy lag.

### DIFF
--- a/Resources/Prototypes/_Shitmed/Body/Organs/dubious.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Organs/dubious.yml
@@ -112,18 +112,18 @@
     - type: PressureImmunity
     - type: BreathingImmunity
 
-- type: entity
-  id: OrganDubiousArtifact
-  parent: OrganDubiousBase
-  components:
-  - type: Sprite
-    state: mindshock
-  - type: Organ
-    onAdd:
-    - type: XenoArtifact
-    - type: RandomStatusActivation
-      statusEffects:
-        ActivateArtifactEffect: ActivateArtifactEffect
+#- type: entity # Omu, this thing lags the server to death at random.
+#  id: OrganDubiousArtifact
+#  parent: OrganDubiousBase
+#  components:
+#  - type: Sprite
+#    state: mindshock
+#  - type: Organ
+#    onAdd:
+#    - type: XenoArtifact
+#    - type: RandomStatusActivation
+#      statusEffects:
+#        ActivateArtifactEffect: ActivateArtifactEffect
 
 - type: entity
   id: OrganDubiousScrambleDna

--- a/Resources/Prototypes/_Shitmed/Entities/Markers/Spawners/Random/dubious.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Markers/Spawners/Random/dubious.yml
@@ -22,7 +22,7 @@
       - id: OrganDubiousSpaceAdaptation
   #    - id: OrganDubiousScrambleDna # omu
   #    - id: OrganDubiousScrambleLocation # Omu
-      - id: OrganDubiousArtifact
+      #- id: OrganDubiousArtifact # Omu, this thing lags the server to death at random.
       - id: OrganDubiousVentcrawler
       - id: OrganDubiousSteptriggerImmune
       - id: OrganDubiousRepairable


### PR DESCRIPTION
## About the PR
For some reason this abductor organ is capable of bringing the server to its knees at random, until that is fixed it should not be enabled at all.

## Why / Balance
I do not wish to play powerpoint simulator.

## Technical details
Comment out the organ and its entry in the spawner table.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- remove: Removed the artifact abductor gland due to it causing heavy server lag at random.
