### PR TITLE
Syndicate thaven rapier damage ajustment

### DIFF
--- a/Resources/Prototypes/_Omu/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Omu/Catalog/uplink_catalog.yml
@@ -96,7 +96,7 @@
   icon: { sprite: _Omu/Objects/Weapons/Melee/syndieswordfish.rsi, state: icon }
   productEntity: ThavenSyndieRapier
   cost:
-    Telecrystal: 40
+    Telecrystal: 35
   categories:
   - UplinkWeaponry
   conditions:

--- a/Resources/Prototypes/_Omu/Entities/Objects/Weapons/Melee/rapier.yml
+++ b/Resources/Prototypes/_Omu/Entities/Objects/Weapons/Melee/rapier.yml
@@ -13,8 +13,7 @@
     heavyStaminaCost: 2.5
     damage:
       types:
-        Piercing: 25
-      armorPenetration: 0.3
+        Piercing: 20
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
   - type: Item


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Removes the AP and makes the damage of the thaven rapier in line with the wardens rapier, lowers TC cost to 35.

## Why / Balance
Inicial requested cahnges where ignored this fixes it

## Technical details
YML canges:
- removed AP
- lowered damage form 25 to 20

## Media
NONE

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
NONE

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: ajusted Syndicate thaven rapier damage values, changes where demanded on initial but not adressed

