### PR TITLE
[FIX] Fix people being able to print medipens for zero cost.

### DIFF
--- a/Content.Server/Kitchen/Components/MicrowaveComponent.cs
+++ b/Content.Server/Kitchen/Components/MicrowaveComponent.cs
@@ -69,6 +69,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom; // Fro
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 using Content.Shared.Kitchen.Components; // Frontier
 using Content.Shared.Kitchen; // Frontier
+using Content.Shared.Whitelist; // Omu
 
 namespace Content.Server.Kitchen.Components
 {
@@ -213,6 +214,14 @@ namespace Content.Server.Kitchen.Components
         [DataField]
         public MicrowaveUiKey Key = MicrowaveUiKey.Key;
         // End Frontier
+
+        // Begin Omu
+        /// <summary>
+        /// A blacklist of components/tags that should not be allowed to be inserted into a microwave.
+        /// </summary>
+        [DataField, ViewVariables(VVAccess.ReadWrite)]
+        public EntityWhitelist MicrowaveBlacklist = new();
+        // End Omu
     }
 
     public sealed class BeingMicrowavedEvent : HandledEntityEventArgs

--- a/Content.Server/Kitchen/Components/MicrowaveComponent.cs
+++ b/Content.Server/Kitchen/Components/MicrowaveComponent.cs
@@ -219,7 +219,7 @@ namespace Content.Server.Kitchen.Components
         /// <summary>
         /// A blacklist of components/tags that should not be allowed to be inserted into a microwave.
         /// </summary>
-        [DataField, ViewVariables(VVAccess.ReadWrite)]
+        [DataField]
         public EntityWhitelist MicrowaveBlacklist = new();
         // End Omu
     }

--- a/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
@@ -95,6 +95,7 @@ using Content.Shared.Stacks;
 using Content.Server.Construction.Components;
 using Content.Shared.Chat;
 using Content.Shared.Damage;
+using Content.Shared.Whitelist; // Omu
 
 namespace Content.Server.Kitchen.EntitySystems
 {
@@ -122,6 +123,7 @@ namespace Content.Server.Kitchen.EntitySystems
         [Dependency] private readonly IPrototypeManager _prototype = default!;
         [Dependency] private readonly IAdminLogManager _adminLogger = default!;
         [Dependency] private readonly SharedSuicideSystem _suicide = default!;
+        [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!; // Omu
 
         private static readonly EntProtoId MalfunctionSpark = "Spark";
 
@@ -443,6 +445,14 @@ namespace Content.Server.Kitchen.EntitySystems
                 _popupSystem.PopupEntity(Loc.GetString("microwave-component-interact-using-transfer-fail"), ent, args.User);
                 return;
             }
+
+            // Omu start
+            if (_whitelistSystem.IsBlacklistPass(ent.Comp.MicrowaveBlacklist, args.Used))
+            {
+                _popupSystem.PopupEntity(Loc.GetString("microwave-component-interact-using-blacklist-fail", ("item", args.Used), ("microwave", ent)), ent, args.User);
+                return;
+            }
+            // Omu end
 
             if (ent.Comp.Storage.Count >= ent.Comp.Capacity)
             {

--- a/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
@@ -447,7 +447,7 @@ namespace Content.Server.Kitchen.EntitySystems
             }
 
             // Omu start
-            if (_whitelistSystem.IsBlacklistPass(ent.Comp.MicrowaveBlacklist, args.Used))
+            if (_whitelistSystem.IsWhitelistPass(ent.Comp.MicrowaveBlacklist, args.Used))
             {
                 _popupSystem.PopupEntity(Loc.GetString("microwave-component-interact-using-blacklist-fail", ("item", args.Used), ("microwave", ent)), ent, args.User);
                 return;

--- a/Resources/Locale/en-US/_Omu/kitchen/components/microwave-component.ftl
+++ b/Resources/Locale/en-US/_Omu/kitchen/components/microwave-component.ftl
@@ -1,0 +1,1 @@
+microwave-component-interact-using-blacklist-fail = { CAPITALIZE(THE($item)) } can't fit in the { $microwave }!

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/mirowave_recipe_assemblers.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/mirowave_recipe_assemblers.yml
@@ -228,6 +228,9 @@
     foodDoneSound: /Audio/Effects/Shuttle/radar_ping.ogg
     loopingSound: /Audio/_NF/Machines/medical-assembler.ogg
     key: MedicalAssemblerKey
+    microwaveBlacklist: # Omu start
+      components:
+      - Hypospray # Omu end
   - type: GenericVisualizer
     visuals:
       enum.PowerDeviceVisuals.VisualState:

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/mirowave_recipe_assemblers.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/mirowave_recipe_assemblers.yml
@@ -230,7 +230,7 @@
     key: MedicalAssemblerKey
     microwaveBlacklist: # Omu start
       components:
-      - Hypospray # Omu end
+      - Hypospray # NOTE: Will need fixing with upstream, Omu end
   - type: GenericVisualizer
     visuals:
       enum.PowerDeviceVisuals.VisualState:


### PR DESCRIPTION
## About the PR
Prevent anything with hypospray component from being inserted into a medical assembler as it causes it to bug out.

## Why / Balance
No more infinite medipens.

## Technical details
Adds a entity whitelist (blacklist) to microwave component, if it has anything in it then check if the item being inserted should be blacklisted, if it should be, display to the user that it doesn't fit, and don't insert it. (if blacklist is null then allow insertion as usual)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed being able to make infinite medipens for free.
