### PR TITLE
Give CE a experimental RPD

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -335,7 +335,7 @@
     - id: CargoRequestEngineeringComputerCircuitboard
     # - id: RCD # Goobstation
     - id: RCDAmmo
-    - id: RPD
+    - id: RPDRechargingCE # Omu, replace with recharging RPD
     - id: RCDAmmo
     - id: RubberStampCE
     - id: MetalFoamGrenade

--- a/Resources/Prototypes/_Omu/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/_Omu/Entities/Objects/Tools/tools.yml
@@ -49,3 +49,15 @@
       map: [ "enum.FaxMachineVisuals.VisualState" ]
     - state: scanner
       shader: unshaded
+
+- type: entity
+  id: RPDRechargingCE
+  parent: RPD
+  name: experimental RPD
+  description: A bluespace-enhanced rapid piping device that passively generates its own compressed matter.
+  suffix: AutoRecharge
+  components:
+  - type: LimitedCharges
+    maxCharges: 40
+  - type: AutoRecharge
+    rechargeDuration: 5


### PR DESCRIPTION
## About the PR
Gives CE an experimental RPD (faster recharge and higher capacity of charges than a standard experimental RPD as its unique)

## Why / Balance
Fitting for CE to have both a experimental RPD and RCD

## Technical details
Adds a new proto for the RPD, and replaces the RPD in CE's locker with it.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Changed the RPD in CE's locker to a unique experimental version