### PR TITLE
Fixes shitmed bloodied/brute overlay on ported species

### DIFF
--- a/Resources/Prototypes/_DV/Body/Parts/feroxi.yml
+++ b/Resources/Prototypes/_DV/Body/Parts/feroxi.yml
@@ -14,13 +14,13 @@
       sprite: _Goobstation/Mobs/Species/Feroxi/parts.rsi #RedTerror Goob Resprite
     - type: Damageable # Shitmed
       damageModifierSet: Feroxi
-    - type: WoundableVisuals
-      damageOverlayGroups:
-        Brute:
-          sprite: _Shitmed/Mobs/Effects/brute_damage.rsi
-          color: "#3d909c"
-        Burn:
-          sprite: _Shitmed/Mobs/Effects/burn_damage.rsi
+    #- type: WoundableVisuals # Omu, reverts injurys back to red, they have regular blood.
+    #  damageOverlayGroups:
+    #    Brute:
+    #      sprite: _Shitmed/Mobs/Effects/brute_damage.rsi
+    #      color: "#3d909c"
+    #    Burn:
+    #      sprite: _Shitmed/Mobs/Effects/burn_damage.rsi
 
 - type: entity
   parent: [ PartFeroxiBase, BaseChest ]

--- a/Resources/Prototypes/_EinsteinEngines/Body/Parts/shadowkin.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Body/Parts/shadowkin.yml
@@ -27,6 +27,13 @@
   - type: Damageable
     damageContainer: Biological # Shadowkin
     damageModifierSet: Shadowkin
+  - type: WoundableVisuals # Omu
+    damageOverlayGroups:
+      Brute:
+        sprite: _Shitmed/Mobs/Effects/brute_damage.rsi
+        color: "#6C3BAA"
+      Burn:
+        sprite: _Shitmed/Mobs/Effects/burn_damage.rsi
 
 - type: entity
   id: ChestShadowkin

--- a/Resources/Prototypes/_EinsteinEngines/Body/Parts/xelthia.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Body/Parts/xelthia.yml
@@ -11,6 +11,13 @@
         Quantity: 3
       - ReagentId: Blood
         Quantity: 10
+  - type: WoundableVisuals # Omu
+    damageOverlayGroups:
+      Brute:
+        sprite: _Shitmed/Mobs/Effects/brute_damage.rsi
+        color: "#00FF69"
+      Burn:
+        sprite: _Shitmed/Mobs/Effects/burn_damage.rsi
 
 - type: entity
   id: ChestXelthia

--- a/Resources/Prototypes/_Floofstation/Body/Parts/resomi.yml
+++ b/Resources/Prototypes/_Floofstation/Body/Parts/resomi.yml
@@ -20,6 +20,13 @@
     damageModifierSet: Resomi
   - type: Woundable # Goobstation
     boneEntity: BoneWeak
+  - type: WoundableVisuals # Omu
+    damageOverlayGroups:
+      Brute:
+        sprite: _Shitmed/Mobs/Effects/brute_damage.rsi
+        color: "#6C3BAA"
+      Burn:
+        sprite: _Shitmed/Mobs/Effects/burn_damage.rsi
 
 - type: entity
   id: ChestResomi

--- a/Resources/Prototypes/_Impstation/Body/Parts/allulalo.yml
+++ b/Resources/Prototypes/_Impstation/Body/Parts/allulalo.yml
@@ -11,6 +11,13 @@
         Quantity: 3
       - ReagentId: BloodAllulalo
         Quantity: 10
+  - type: WoundableVisuals # Omu
+    damageOverlayGroups:
+      Brute:
+        sprite: _Shitmed/Mobs/Effects/brute_damage.rsi
+        color: "#c1c7d3"
+      Burn:
+        sprite: _Shitmed/Mobs/Effects/burn_damage.rsi
 
 - type: entity
   id: ChestAllulalo

--- a/Resources/Prototypes/_Impstation/Body/Parts/thaven.yml
+++ b/Resources/Prototypes/_Impstation/Body/Parts/thaven.yml
@@ -14,7 +14,7 @@
     damageOverlayGroups:
       Brute:
         sprite: _Shitmed/Mobs/Effects/brute_damage.rsi
-        color: "#3d909c"
+        color: "#ff624a" # Omu
       Burn:
         sprite: _Shitmed/Mobs/Effects/burn_damage.rsi
   - type: Extractable # gds add more stuff in it or something

--- a/Resources/Prototypes/_StarLight/Body/Parts/avali.yml
+++ b/Resources/Prototypes/_StarLight/Body/Parts/avali.yml
@@ -15,6 +15,13 @@
             Quantity: 1.5
           - ReagentId: AmmoniaBlood
             Quantity: 5
+    - type: WoundableVisuals # Omu
+      damageOverlayGroups:
+        Brute:
+          sprite: _Shitmed/Mobs/Effects/brute_damage.rsi
+          color: "#6C3BAA"
+        Burn:
+          sprite: _Shitmed/Mobs/Effects/burn_damage.rsi
 
 - type: entity
   parent: [PartAvali, BaseChest] # Omu, split torso into chest and


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Fixes species with mismatching bloodied overlays (see media)

## Why / Balance
its meant to be

## Technical details
yaml slop

## Media
(ignore orange on allulalo, used sarin to kill them off for the screenshot)
<img width="675" height="674" alt="image" src="https://github.com/user-attachments/assets/59ca3248-ccf8-40e1-8b8f-ae42ee9e8176" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: All species now accurately get bloodied from brute damage in their respective blood's colour
