### PR TITLE
Fix: IPCs now reboot based on vital dmg

### DIFF
--- a/Content.Server/_EinsteinEngines/Silicon/DeadStartupButton/DeadStartupButtonSystem.cs
+++ b/Content.Server/_EinsteinEngines/Silicon/DeadStartupButton/DeadStartupButtonSystem.cs
@@ -66,10 +66,10 @@ public sealed class DeadStartupButtonSystem : SharedDeadStartupButtonSystem
             || !TryComp<MobThresholdsComponent>(uid, out var mobThresholdsComponent)
             || !TryComp<DamageableComponent>(uid, out var damageable))
             return;
-        var vitalDamage = _mobThreshold.CheckVitalDamage(uid, damageable);
+        var vitalDamage = _mobThreshold.CheckVitalDamage(uid, damageable); // OmuStation: reboot based on vital dmg
         // Check if entity have critical state
         if (_mobThreshold.TryGetThresholdForState(uid, MobState.Critical, out var criticalThreshold, mobThresholdsComponent)
-            && vitalDamage < criticalThreshold)
+            && vitalDamage < criticalThreshold) // Omu: vitalDamage
         {
             _mobState.ChangeMobState(uid, MobState.Alive, mobStateComponent);
             return;
@@ -77,7 +77,7 @@ public sealed class DeadStartupButtonSystem : SharedDeadStartupButtonSystem
 
         // Check if entity have dead state
         if (_mobThreshold.TryGetThresholdForState(uid, MobState.Dead, out var deadThreshold, mobThresholdsComponent)
-            && vitalDamage < deadThreshold)
+            && vitalDamage < deadThreshold) // Omu: vitalDamage
         {
             _mobState.ChangeMobState(uid, MobState.Alive, mobStateComponent);
             return;

--- a/Content.Server/_EinsteinEngines/Silicon/DeadStartupButton/DeadStartupButtonSystem.cs
+++ b/Content.Server/_EinsteinEngines/Silicon/DeadStartupButton/DeadStartupButtonSystem.cs
@@ -66,10 +66,10 @@ public sealed class DeadStartupButtonSystem : SharedDeadStartupButtonSystem
             || !TryComp<MobThresholdsComponent>(uid, out var mobThresholdsComponent)
             || !TryComp<DamageableComponent>(uid, out var damageable))
             return;
-
+        var vitalDamage = _mobThreshold.CheckVitalDamage(uid, damageable);
         // Check if entity have critical state
         if (_mobThreshold.TryGetThresholdForState(uid, MobState.Critical, out var criticalThreshold, mobThresholdsComponent)
-            && damageable.TotalDamage < criticalThreshold)
+            && vitalDamage < criticalThreshold)
         {
             _mobState.ChangeMobState(uid, MobState.Alive, mobStateComponent);
             return;
@@ -77,7 +77,7 @@ public sealed class DeadStartupButtonSystem : SharedDeadStartupButtonSystem
 
         // Check if entity have dead state
         if (_mobThreshold.TryGetThresholdForState(uid, MobState.Dead, out var deadThreshold, mobThresholdsComponent)
-            && damageable.TotalDamage < deadThreshold)
+            && vitalDamage < deadThreshold)
         {
             _mobState.ChangeMobState(uid, MobState.Alive, mobStateComponent);
             return;


### PR DESCRIPTION

## About the PR
Fixed a bug that made IPCs unable to be rebooted when vital damage would be <100.
Why hasn't anyone fixed this earlier.

This should make rebooting IPCs that we're EMPed more easier. ~~(IMO the IPC EMP vuln right now is stupid af. MKCs NAO!!!1111!)~~

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
[stupid-fucking-ipc-vital-dmg-reboot-fix.webm](https://github.com/user-attachments/assets/114ef21a-693d-43f3-af64-c2dd5d5d7eec)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: IPCs can now be rebooted when Vital Damage is below 100 as opposed to total damage.

