### PR TITLE
Outer Commander TerraGov to UGN

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/hats.yml
@@ -461,7 +461,7 @@
   parent: ClothingHeadHatCentcomcap
   id: ClothingHeadHatOuterCommandcap
   name: outer command cap
-  description: Purple gilded cap with Terra-Gov insignia.
+  description: Purple gilded cap with UGN insignia. #omu edit
   components: 
   - type: Sprite
     sprite: _Goobstation/Clothing/Head/Hats/outcommcap.rsi

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Neck/cloaks.yml
@@ -101,7 +101,7 @@
   parent: [ClothingNeckBase, BaseCommandContraband]
   id: ClothingNeckCloakOuterCommand
   name: outer command cloak
-  description: A stylish purple cloak with Terra-Gov insignia.
+  description: A stylish purple cloak with UGN insignia. #omu edit
   components:
   - type: Sprite
     sprite: _Goobstation/Clothing/Neck/Cloaks/outcommcloak.rsi

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/coats.yml
@@ -141,7 +141,7 @@
   parent: [ ClothingOuterArmorCaptainCarapace, ClothingOuterStorageBase, BaseCentcommContraband ]
   id: ClothingOuterArmoredJacketOuterCommand
   name: outer command jacket
-  description: A purple jacket with very fancy elements. There is a Terra-Gov insignia on the back.
+  description: A purple jacket with very fancy elements. There is a UGN insignia on the back. # omu edit
   components:
   - type: Sprite
     sprite: _Goobstation/Clothing/OuterClothing/Coats/outcommjacket.rsi

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -413,7 +413,7 @@
   parent: [ ClothingUniformJumpsuitNavyGold, BaseCentcommContraband ]
   id: ClothingUniformJumpsuitOuterCommand
   name: outer command jumpsuit
-  description: A fancy purple suit with a Terra-Gov insignia.
+  description: A fancy purple suit with a UGN insignia. #omu edit
   components:
   - type: Sprite
     sprite: _Goobstation/Clothing/Uniforms/Jumpsuit/Centcom/outcommsuit.rsi

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Devices/pda.yml
@@ -360,7 +360,7 @@
   parent: CentcomPDA
   id: OuterCommandPDA
   name: outer command PDA
-  description: Purple pda for outer command members.
+  description: Purple pda for UGN Officials. #Omu Edit
   components:
   - type: Appearance
     appearanceDataInit:


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
changed the description for the outercommander gear to use UGN (United Galactic Nations) instead of TerraGov

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
using UGN will better fit with the upcoming Omu lore and links the outfit to a group that is less human focused like terragov is in lore

## Technical details
just some yaml

## Media
<img width="280" height="148" alt="image" src="https://github.com/user-attachments/assets/2713686a-bfa8-4867-86fd-29fa0b63d154" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Outer Commanders now work for the UGN
