### PR TITLE
Make Malign rift spawn more common

### DIFF
--- a/Resources/Prototypes/_DV/GameRules/events.yml
+++ b/Resources/Prototypes/_DV/GameRules/events.yml
@@ -36,7 +36,7 @@
   - type: StationEvent
     earliestStart: 15
     minimumPlayers: 15
-    weight: 0.4 #this should be rare to throw people off, otherwise it happens every shift
+    weight: 4 # Omu, DV has this at 6
     eventType: Neutral
     startAnnouncement: cosmiccult-announce-tier2-warning
     startAnnouncementColor: "#cae8e8"


### PR DESCRIPTION
## About the PR
Makes malign rift spawning outside of coscult more common, however still more rare than what DV has it at (dv has the weight set to 6).

## Why / Balance
Security loves metagaming. Also gives chaplain something that isn't valid hunting to do.

## Technical details
Change 0.4 to 4

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Changed the weighting for Malign rift spawning from 0.4 to 4, you should see them more often now.