### PR TITLE
[FIX] Fix a bug that allowed for infinite chems using the medical assembler.

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/mirowave_recipe_assemblers.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/mirowave_recipe_assemblers.yml
@@ -230,7 +230,10 @@
     key: MedicalAssemblerKey
     microwaveBlacklist: # Omu start
       components:
-      - Hypospray # NOTE: Will need fixing with upstream, Omu end
+      - Hypospray # NOTE: Will need fixing with upstream
+      tags:
+      - Syringe
+      - Dropper # Omu end
   - type: GenericVisualizer
     visuals:
       enum.PowerDeviceVisuals.VisualState:

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/mirowave_recipe_assemblers.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/mirowave_recipe_assemblers.yml
@@ -231,6 +231,7 @@
     microwaveBlacklist: # Omu start
       components:
       - Hypospray # NOTE: Will need fixing with upstream
+      - Edible
       tags:
       - Syringe
       - Dropper # Omu end


### PR DESCRIPTION
## About the PR
I hate bug abuse i hate bug abuse... Anyway, fixes a bug where people were using syringes to make the medical assembler not consume chems.

## Why / Balance
Can people stop abusing bugs for five minutes.

## Technical details
Blacklist droppers and syringes from the medical assembler.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed the medical assembler making things for free.