### PR TITLE
Add Admin Alerts for RiggableComponent Rigging and Explosions

### DIFF
--- a/Content.Server/Power/EntitySystems/RiggableSystem.cs
+++ b/Content.Server/Power/EntitySystems/RiggableSystem.cs
@@ -15,6 +15,7 @@ using Content.Server.Power.Components;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Database;
 using Content.Shared.Rejuvenate;
+using Content.Server.Chat.Managers;
 
 namespace Content.Server.Power.EntitySystems;
 
@@ -25,6 +26,7 @@ public sealed class RiggableSystem : EntitySystem
 {
     [Dependency] private readonly ExplosionSystem _explosionSystem = default!;
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
+    [Dependency] private readonly IChatManager _chat = default!;
 
     public override void Initialize()
     {
@@ -65,6 +67,7 @@ public sealed class RiggableSystem : EntitySystem
         if (entity.Comp.IsRigged && !wasRigged)
         {
             _adminLogger.Add(LogType.Explosion, LogImpact.Medium, $"{ToPrettyString(entity.Owner)} has been rigged up to explode when used.");
+            _chat.SendAdminAlert($"{ToPrettyString(entity.Owner)} has been rigged up (with {entity.Comp.RequiredQuantity}) to explode when used.");
         }
     }
 
@@ -75,6 +78,7 @@ public sealed class RiggableSystem : EntitySystem
 
         var radius = MathF.Min(5, MathF.Sqrt(battery.CurrentCharge) / 9);
 
+        _chat.SendAdminAlert($"Rigged entity {ToPrettyString(uid)} exploded.");
         _explosionSystem.TriggerExplosive(uid, radius: radius, user:cause);
         QueueDel(uid);
     }

--- a/Content.Server/Power/EntitySystems/RiggableSystem.cs
+++ b/Content.Server/Power/EntitySystems/RiggableSystem.cs
@@ -15,7 +15,7 @@ using Content.Server.Power.Components;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Database;
 using Content.Shared.Rejuvenate;
-using Content.Server.Chat.Managers;
+using Content.Server.Chat.Managers; // omu
 
 namespace Content.Server.Power.EntitySystems;
 
@@ -26,7 +26,7 @@ public sealed class RiggableSystem : EntitySystem
 {
     [Dependency] private readonly ExplosionSystem _explosionSystem = default!;
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
-    [Dependency] private readonly IChatManager _chat = default!;
+    [Dependency] private readonly IChatManager _chat = default!; // omu
 
     public override void Initialize()
     {
@@ -67,7 +67,7 @@ public sealed class RiggableSystem : EntitySystem
         if (entity.Comp.IsRigged && !wasRigged)
         {
             _adminLogger.Add(LogType.Explosion, LogImpact.Medium, $"{ToPrettyString(entity.Owner)} has been rigged up to explode when used.");
-            _chat.SendAdminAlert($"{ToPrettyString(entity.Owner)} has been rigged up (with {entity.Comp.RequiredQuantity}) to explode when used.");
+            _chat.SendAdminAlert($"{ToPrettyString(entity.Owner)} has been rigged up (with {entity.Comp.RequiredQuantity}) to explode when used."); // omu
         }
     }
 
@@ -78,7 +78,7 @@ public sealed class RiggableSystem : EntitySystem
 
         var radius = MathF.Min(5, MathF.Sqrt(battery.CurrentCharge) / 9);
 
-        _chat.SendAdminAlert($"Rigged entity {ToPrettyString(uid)} exploded.");
+        _chat.SendAdminAlert($"Rigged entity {ToPrettyString(uid)} exploded."); // omu
         _explosionSystem.TriggerExplosive(uid, radius: radius, user:cause);
         QueueDel(uid);
     }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
This PR adds two admin alerts:
- when entities with the RiggableComponent are rigged.
- when rigged entities explode.

## Why / Balance
This information could be useful for the admins.

## Technical details
Added two chat alerts to RiggableSystem.cs.

## Media
[2026-05-24_15-33-50.webm](https://github.com/user-attachments/assets/5eea59a5-9b11-40b2-89c9-b286c544b466)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
There should be no breaking changes.

<!--
**Changelog**
I don't think a changelog is needed for this, but here it is in case you wanted one
:cl:
- tweak: admins now get alerts when riggable entities are rigged and when they later explode
-->