### PR TITLE
[FIX] Make bingles actually take ion damage.

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/Player/bingle.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/Player/bingle.yml
@@ -108,7 +108,7 @@
     overtime: 15
     sound: /Audio/Weapons/egloves.ogg
   - type: Damageable
-    damageContainer: Biological
+    damageContainer: BiologicalElectrical # Omu, was Biological
     damageModifierSet: Bingle
   - type: FootstepModifier
     footstepSoundCollection:
@@ -191,7 +191,7 @@
         Structural: 28
         Ion: 7
   - type: Damageable
-    damageContainer: Biological
+    damageContainer: BiologicalElectrical # Omu, was Biological
     damageModifierSet: BingleUpgraded
 
 # Skin - turkle

--- a/Resources/Prototypes/_Omu/Damage/containers.yml
+++ b/Resources/Prototypes/_Omu/Damage/containers.yml
@@ -1,0 +1,11 @@
+- type: damageContainer
+  id: BiologicalElectrical
+  supportedGroups:
+    - Brute
+    - Burn
+    - Toxin
+    - Airloss
+    - Genetic
+    - Electronic
+  supportedTypes: # Goobstation
+    - Holy


### PR DESCRIPTION
## About the PR
When looking at bingles damage modifier i noticed they were meant to take 2x ion damage, however their damage container doesn't support ion damage. So this adds a new damage container that is the same as biological, but with electronic (ion) damage added to it.

## Why / Balance
If their damage modifier says they are meant to take 2x ion damage, they should be able to take ion damage.

## Technical details
Add a new damage container, swap bingles to use the new damage container.

## Media
bingle's damage modifier:
<img width="469" height="431" alt="image" src="https://github.com/user-attachments/assets/29189f44-5d09-43b9-ba21-96fadb59c2f4" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed bingles being unable to take ion damage.
