### PR TITLE
NTR Buff: Station Report is now 1×1 and fits in the CentComm Clipboard

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/folders.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/folders.yml
@@ -243,6 +243,14 @@
     sprite: Objects/Misc/cc-clipboard.rsi
   - type: Clothing
     sprite: Objects/Misc/cc-clipboard.rsi
+  - type: Storage
+    grid:
+    - 0,0,5,3
+    whitelist:
+      tags:
+      - Document
+      components:
+      - StationReport
 
 - type: entity
   id: BoxFolderQmClipboard

--- a/Resources/Prototypes/Entities/Objects/Misc/folders.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/folders.yml
@@ -243,14 +243,14 @@
     sprite: Objects/Misc/cc-clipboard.rsi
   - type: Clothing
     sprite: Objects/Misc/cc-clipboard.rsi
-  - type: Storage
-    grid:
-    - 0,0,5,3
-    whitelist:
-      tags:
-      - Document
-      components:
-      - StationReport
+  - type: Storage     # Omu (component respecify needed for holding the station report)
+    grid:             # Omu
+    - 0,0,5,3         # Omu
+    whitelist:        # Omu
+      tags:           # Omu
+      - Document      # Omu
+      components:     # Omu
+      - StationReport # Omu
 
 - type: entity
   id: BoxFolderQmClipboard

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/paper.yml
@@ -4,8 +4,8 @@
   id: NanoRepStationReport
   description: The document is made out of gold, but somehow you are still able to write on it.
   components:
-  - type: Item
-    size: Tiny
+  - type: Item # Omu
+    size: Tiny # Omu
   - type: Sprite
     sprite: Objects/Misc/bureaucracy.rsi
     layers:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/paper.yml
@@ -4,6 +4,8 @@
   id: NanoRepStationReport
   description: The document is made out of gold, but somehow you are still able to write on it.
   components:
+  - type: Item
+    size: Tiny
   - type: Sprite
     sprite: Objects/Misc/bureaucracy.rsi
     layers:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
As title. The station report is now tiny-sized, as other papers are. Furthermore, it fits in the CentComm Clipboard.

## Why / Balance
It seemed right.

## Technical details
Yaml changes:
- NanoRepStationReport: ItemComponent.Size = Tiny
- BoxFolderCentComClipboard: replicated StorageComponent over from its parent prototype, BoxFolderClipboard, except that items with StationReportComponent are now on the whitelist.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
There were no breaking changes observed in the quick testing I did.
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: NTR report is now 1×1 and fits in the CC clipboard
