### PR TITLE
Adds subtle radiation health warnings

### DIFF
--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml
@@ -45,6 +45,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                 <CheckBox Name="OpaqueStorageWindowCheckBox" Text="{Loc 'ui-options-opaque-storage-window'}" />
                 <CheckBox Name="StaticStorageUI" Text="{Loc 'ui-options-static-storage-ui'}" />
                 <!-- Goobstation Edit Start -->
+
+                <Label Text="{Loc 'ui-options-visuals-header'}"
+                       StyleClasses="LabelHeading" />
+                <CheckBox Name="RadiationVisualsCheckBox"
+                          Text="{Loc 'ui-options-radiation-visuals'}"
+                          ToolTip="{Loc 'ui-options-radiation-visuals-tooltip'}" />
                 <Label Text="{Loc 'ui-options-preferences'}"
                        StyleClasses="LabelKeyText"/>
                 <CheckBox Name="AutoFocusSearchOnBuildMenuCheckBox" Text="{Loc 'ui-options-auto-focus-search-on-build-menu'}" />

--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
@@ -140,6 +140,7 @@ public sealed partial class MiscTab : Control
         Control.AddOptionCheckBox(CCVars.ChatFancyNameBackground, FancyNameBackgroundsCheckBox);
         Control.AddOptionCheckBox(CCVars.StaticStorageUI, StaticStorageUI);
 
+        Control.AddOptionCheckBox(CCVars.OmuRadiationVisualsEnabled, RadiationVisualsCheckBox);
         Control.Initialize();
     }
 }

--- a/Content.Client/Radiation/RadiationVisualOverlay.cs
+++ b/Content.Client/Radiation/RadiationVisualOverlay.cs
@@ -1,3 +1,6 @@
+using Content.Shared.CCVar;
+using Robust.Shared.Configuration;
+using Robust.Shared.IoC;
 // SPDX-FileCopyrightText: 2026 puntsss <bex.ish.aholic@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
@@ -34,6 +37,9 @@ public sealed class RadiationVisualOverlay : Overlay
 
     protected override void Draw(in OverlayDrawArgs args)
     {
+        if (!IoCManager.Resolve<IConfigurationManager>().GetCVar(CCVars.OmuRadiationVisualsEnabled))
+            return;
+
         var deltaSeconds = _lastDrawTime == default
             ? 0f
             : Math.Clamp((float) (_timing.CurTime - _lastDrawTime).TotalSeconds, 0f, 0.1f);

--- a/Content.Client/Radiation/RadiationVisualOverlay.cs
+++ b/Content.Client/Radiation/RadiationVisualOverlay.cs
@@ -1,0 +1,212 @@
+// SPDX-FileCopyrightText: 2026 puntsss <bex.ish.aholic@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Robust.Client.Graphics;
+using Robust.Shared.Enums;
+using Robust.Shared.Maths;
+using Robust.Shared.Timing;
+using System.Numerics;
+
+namespace Content.Client.Radiation;
+
+public sealed class RadiationVisualOverlay : Overlay
+{
+    private readonly IGameTiming _timing;
+
+    private float _currentIntensity;
+    private float _targetIntensity;
+    private TimeSpan _endTime;
+    private TimeSpan _lastDrawTime;
+
+    public override OverlaySpace Space => OverlaySpace.ScreenSpace;
+
+    public RadiationVisualOverlay(IGameTiming timing)
+    {
+        _timing = timing;
+    }
+
+    public void Show(float intensity, TimeSpan duration)
+    {
+        _targetIntensity = Math.Clamp(intensity, 0f, 1f);
+        _endTime = _timing.CurTime + duration;
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        var deltaSeconds = _lastDrawTime == default
+            ? 0f
+            : Math.Clamp((float) (_timing.CurTime - _lastDrawTime).TotalSeconds, 0f, 0.1f);
+
+        _lastDrawTime = _timing.CurTime;
+
+        var wantedIntensity = _timing.CurTime < _endTime ? _targetIntensity : 0f;
+        var speed = wantedIntensity > _currentIntensity ? 18f : 2.5f;
+        _currentIntensity = MathHelper.Lerp(_currentIntensity, wantedIntensity, Math.Clamp(deltaSeconds * speed, 0f, 1f));
+
+        if (_currentIntensity <= 0.005f)
+            return;
+
+        var handle = args.ScreenHandle;
+        var bounds = args.ViewportBounds;
+        var width = bounds.Width;
+        var height = bounds.Height;
+        var intensity = _currentIntensity;
+
+        var seed = (int) (_timing.CurTime.TotalMilliseconds / 8);
+        var random = new Random(seed);
+
+        var dimAlpha = Math.Clamp(0.004f + 0.020f * intensity, 0.004f, 0.030f);
+        handle.DrawRect(bounds, new Color(0f, 0f, 0f, dimAlpha));
+
+        var deadPixels = (int) (65 + 250 * intensity);
+        for (var i = 0; i < deadPixels; i++)
+        {
+            var x = bounds.Left + (float) random.NextDouble() * width;
+            var y = bounds.Top + (float) random.NextDouble() * height;
+
+            float w;
+            float h;
+            var r = random.NextDouble();
+            if (r < 0.80)
+            {
+                w = 1f + (float) random.NextDouble() * (1.3f + 0.8f * intensity);
+                h = 1f + (float) random.NextDouble() * (1.3f + 0.8f * intensity);
+            }
+            else if (r < 0.95)
+            {
+                w = 1.5f + (float) random.NextDouble() * (2.0f + 1.3f * intensity);
+                h = 1.5f + (float) random.NextDouble() * (2.0f + 1.3f * intensity);
+            }
+            else
+            {
+                w = 3f + (float) random.NextDouble() * (4f + 3f * intensity);
+                h = 1.5f + (float) random.NextDouble() * (2.5f + 2f * intensity);
+            }
+
+            var alpha = 0.18f + 0.40f * intensity * (0.45f + (float) random.NextDouble() * 0.75f);
+            handle.DrawRect(UIBox2.FromDimensions(new Vector2(x, y), new Vector2(w, h)),
+                new Color(0f, 0f, 0f, Math.Clamp(alpha, 0f, 0.70f)));
+        }
+
+        var hotPixels = (int) (24 + 120 * intensity);
+        for (var i = 0; i < hotPixels; i++)
+        {
+            var x = bounds.Left + (float) random.NextDouble() * width;
+            var y = bounds.Top + (float) random.NextDouble() * height;
+            var roll = random.NextDouble();
+
+            float w;
+            float h;
+            if (roll < 0.84)
+            {
+                w = 0.8f + (float) random.NextDouble() * (1.1f + 1.1f * intensity);
+                h = w;
+            }
+            else
+            {
+                w = 2f + (float) random.NextDouble() * (4f + 8f * intensity);
+                h = 1f + (float) random.NextDouble() * 1.1f;
+            }
+
+            var alpha = 0.14f + 0.28f * intensity * (0.40f + (float) random.NextDouble() * 0.80f);
+            var shade = 0.84f + (float) random.NextDouble() * 0.16f;
+            handle.DrawRect(UIBox2.FromDimensions(new Vector2(x, y), new Vector2(w, h)),
+                new Color(shade, shade, shade, Math.Clamp(alpha, 0f, 0.44f)));
+        }
+
+        // More noticeable blueish-grey sensor specks.
+        var blueGreyDots = (int) (18 + 80 * intensity);
+        for (var i = 0; i < blueGreyDots; i++)
+        {
+            var x = bounds.Left + (float) random.NextDouble() * width;
+            var y = bounds.Top + (float) random.NextDouble() * height;
+            var size = 1f + (float) random.NextDouble() * (1.8f + 1.7f * intensity);
+            var alpha = 0.16f + 0.24f * intensity * (0.45f + (float) random.NextDouble() * 0.80f);
+            var color = new Color(0.60f, 0.68f, 0.80f, Math.Clamp(alpha, 0f, 0.34f));
+            handle.DrawRect(UIBox2.FromDimensions(new Vector2(x, y), new Vector2(size, size)), color);
+        }
+
+        var burstCount = (int) (4 + 16 * intensity);
+        for (var i = 0; i < burstCount; i++)
+        {
+            var centerX = bounds.Left + (float) random.NextDouble() * width;
+            var centerY = bounds.Top + (float) random.NextDouble() * height;
+            var radius = 5f + (float) random.NextDouble() * (10f + 18f * intensity);
+            var dots = random.Next(5, 12);
+
+            for (var j = 0; j < dots; j++)
+            {
+                var x = centerX + ((float) random.NextDouble() - 0.5f) * radius;
+                var y = centerY + ((float) random.NextDouble() - 0.5f) * radius;
+                var size = 1f + (float) random.NextDouble() * (1.6f + 1.8f * intensity);
+                var alpha = 0.16f + 0.32f * intensity;
+                var roll = random.NextDouble();
+
+                Color color;
+                if (roll < 0.52)
+                    color = new Color(0f, 0f, 0f, alpha);
+                else if (roll < 0.78)
+                    color = new Color(1f, 1f, 1f, alpha * 0.82f);
+                else
+                    color = new Color(0.60f, 0.68f, 0.80f, alpha * 0.72f);
+
+                handle.DrawRect(UIBox2.FromDimensions(new Vector2(x, y), new Vector2(size, size)), color);
+            }
+        }
+
+        var streakCount = (int) (3 + 10 * intensity);
+        for (var i = 0; i < streakCount; i++)
+        {
+            var horizontal = random.NextDouble() < 0.72;
+            var bright = random.NextDouble() < 0.55;
+            var shade = bright ? 1f : 0f;
+            var baseAlpha = 0.08f + 0.18f * intensity;
+
+            if (horizontal)
+            {
+                var x = bounds.Left + (float) random.NextDouble() * width;
+                var y = bounds.Top + (float) random.NextDouble() * height;
+                var w = 4f + (float) random.NextDouble() * (10f + 18f * intensity);
+                var h = 1f + (float) random.NextDouble() * 0.9f;
+                handle.DrawRect(UIBox2.FromDimensions(new Vector2(x, y), new Vector2(w, h)),
+                    new Color(shade, shade, shade, baseAlpha));
+                handle.DrawRect(UIBox2.FromDimensions(new Vector2(x + w, y), new Vector2(w * 0.6f, h)),
+                    new Color(shade, shade, shade, baseAlpha * 0.35f));
+            }
+            else
+            {
+                var x = bounds.Left + (float) random.NextDouble() * width;
+                var y = bounds.Top + (float) random.NextDouble() * height;
+                var w = 1f + (float) random.NextDouble() * 0.9f;
+                var h = 4f + (float) random.NextDouble() * (10f + 18f * intensity);
+                handle.DrawRect(UIBox2.FromDimensions(new Vector2(x, y), new Vector2(w, h)),
+                    new Color(shade, shade, shade, baseAlpha));
+                handle.DrawRect(UIBox2.FromDimensions(new Vector2(x, y + h), new Vector2(w, h * 0.6f)),
+                    new Color(shade, shade, shade, baseAlpha * 0.35f));
+            }
+        }
+
+        if (intensity >= 0.24f)
+        {
+            var dropoutCount = (int) (1 + 5 * intensity);
+            for (var i = 0; i < dropoutCount; i++)
+            {
+                var x = bounds.Left + (float) random.NextDouble() * width;
+                var y = bounds.Top + (float) random.NextDouble() * height;
+                var w = 5f + (float) random.NextDouble() * (12f + 22f * intensity);
+                var h = 2f + (float) random.NextDouble() * (4f + 8f * intensity);
+                var alpha = 0.04f + 0.08f * intensity;
+                handle.DrawRect(UIBox2.FromDimensions(new Vector2(x, y), new Vector2(w, h)),
+                    new Color(0f, 0f, 0f, alpha));
+            }
+        }
+
+        if (intensity >= 0.20f)
+        {
+            var flicker = (float) (Math.Sin(_timing.CurTime.TotalSeconds * 37f) + 1f) / 2f;
+            var flickerAlpha = flicker * 0.022f * intensity;
+            handle.DrawRect(bounds, new Color(0f, 0f, 0f, flickerAlpha));
+        }
+    }
+}

--- a/Content.Client/Radiation/RadiationVisualSystem.cs
+++ b/Content.Client/Radiation/RadiationVisualSystem.cs
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 puntsss <bex.ish.aholic@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.Radiation.Events;
+using Robust.Client.Graphics;
+using Robust.Shared.Timing;
+
+namespace Content.Client.Radiation;
+
+public sealed class RadiationVisualSystem : EntitySystem
+{
+    [Dependency] private readonly IOverlayManager _overlayManager = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    private RadiationVisualOverlay? _overlay;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _overlay = new RadiationVisualOverlay(_timing);
+        _overlayManager.AddOverlay(_overlay);
+
+        SubscribeNetworkEvent<RadiationVisualsEvent>(OnRadiationVisuals);
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+
+        if (_overlay != null)
+            _overlayManager.RemoveOverlay(_overlay);
+    }
+
+    private void OnRadiationVisuals(RadiationVisualsEvent ev)
+    {
+        _overlay?.Show(ev.Intensity, TimeSpan.FromSeconds(ev.Duration));
+    }
+}

--- a/Content.Server/Omu/RadiationEffects/OmuRadiationSicknessSystem.cs
+++ b/Content.Server/Omu/RadiationEffects/OmuRadiationSicknessSystem.cs
@@ -1,0 +1,393 @@
+
+using System.Reflection;
+using System.Linq;
+using Content.Shared.CCVar;
+using Content.Shared.Popups;
+using Content.Shared.Radiation.Events;
+using Robust.Shared.Configuration;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Server.Omu.RadiationEffects;
+
+public sealed class OmuRadiationSicknessSystem : EntitySystem
+{
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+
+    private readonly Dictionary<EntityUid, TimeSpan> _nextMinorMessage = new();
+    private readonly Dictionary<EntityUid, TimeSpan> _nextMajorEffect = new();
+
+    private static readonly string[] MinorMessages =
+    {
+        "You taste metal in your mouth.",
+        "Your stomach twists.",
+        "You feel nauseous...",
+        "Your skin prickles.",
+        "You feel a strange warmth under your skin.",
+        "Your head pounds.",
+        "Your vision swims for a moment.",
+        "Your hands tremble.",
+        "Your throat feels dry.",
+        "You feel suddenly weak.",
+        "You feel your skin burning.",
+        "Your heart races, and then slows.",
+        "A wave of sickness rolls through you.",
+        "Your mouth fills with a bitter taste.",
+        "You feel like something is very wrong.",
+        "A cold sweat breaks over your skin.",
+        "Your bones ache.",
+        "Your guts churn.",
+        "You feel lightheaded.",
+        "Your vision flickers with static."
+    };
+
+    private static readonly string[] MajorMessages =
+    {
+        "Your stomach lurches violently!",
+        "You feel like you are going to throw up!",
+        "The world spins around you!",
+        "Your knees almost give out!",
+        "A hot, sick feeling crawls through your body!",
+        "Your body rejects something inside you!",
+        "Your vision blurs as radiation sickness takes hold!",
+        "You stagger as nausea washes over you!",
+        "Your body feels poisoned!"
+    };
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<OnIrradiatedEvent>(OnIrradiated);
+    }
+
+    private void OnIrradiated(OnIrradiatedEvent args)
+    {
+        if (!_cfg.GetCVar(CCVars.OmuRadiationSicknessEnabled))
+            return;
+
+        if (!TryGetTarget(args, out var target))
+            return;
+
+        if (!Exists(target))
+            return;
+
+        var severity = GetSeverity(args);
+        if (severity < 0.01f)
+            severity = 0.25f;
+
+        var now = _timing.CurTime;
+
+        if (!_nextMinorMessage.TryGetValue(target, out var nextMsg) || now >= nextMsg)
+        {
+            _nextMinorMessage[target] = now + TimeSpan.FromSeconds(_random.NextFloat(4f, 8f));
+            Popup(target, _random.Pick(MinorMessages));
+        }
+
+        var chance = Math.Clamp(0.08f + severity * 0.18f, 0.08f, 0.55f);
+
+        if (_nextMajorEffect.TryGetValue(target, out var nextMajor) && now < nextMajor)
+            return;
+
+        if (!_random.Prob(chance))
+            return;
+
+        _nextMajorEffect[target] = now + TimeSpan.FromSeconds(_random.NextFloat(8f, 16f));
+
+        Popup(target, _random.Pick(MajorMessages));
+        TrySpawnVomit(target);
+        TryApplyDrunkDizzyStutter(target);
+    }
+
+    private void Popup(EntityUid target, string message)
+    {
+        try { _popup.PopupEntity(message, target, target); }
+        catch { }
+    }
+
+    private void TrySpawnVomit(EntityUid target)
+    {
+        foreach (var proto in new[] { "PuddleVomit", "VomitPuddle", "Vomit", "PuddleWater" })
+        {
+            try
+            {
+                if (!_proto.HasIndex<EntityPrototype>(proto))
+                    continue;
+
+                Spawn(proto, Transform(target).Coordinates);
+                return;
+            }
+            catch { }
+        }
+    }
+
+    private void TryApplyDrunkDizzyStutter(EntityUid target)
+    {
+        TryApplyStatusEffectByReflection(target, "Drunk", TimeSpan.FromSeconds(20));
+        TryApplyStatusEffectByReflection(target, "Dizzy", TimeSpan.FromSeconds(16));
+        TryApplyStatusEffectByReflection(target, "Stutter", TimeSpan.FromSeconds(12));
+
+        foreach (var componentName in new[]
+        {
+            "DrunkComponent",
+            "DizzyComponent",
+            "DizzinessComponent",
+            "StutteringComponent",
+            "StutterComponent"
+        })
+        {
+            var type = FindType(componentName);
+            if (type != null)
+                TryAddComponentByType(target, type);
+        }
+    }
+
+    private void TryApplyStatusEffectByReflection(EntityUid uid, string effectId, TimeSpan duration)
+    {
+        try
+        {
+            var statusSystemType = AppDomain.CurrentDomain.GetAssemblies()
+                .SelectMany(SafeTypes)
+                .FirstOrDefault(t => t.Name.Contains("StatusEffectsSystem"));
+
+            if (statusSystemType == null)
+                return;
+
+            var iocType = FindType("IoCManager");
+            var resolve = iocType?.GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .FirstOrDefault(m => m.Name == "Resolve" && m.IsGenericMethodDefinition);
+
+            var systemManagerType = AppDomain.CurrentDomain.GetAssemblies()
+                .SelectMany(SafeTypes)
+                .FirstOrDefault(t => t.Name.Contains("IEntitySystemManager"));
+
+            if (resolve == null || systemManagerType == null)
+                return;
+
+            var mgr = resolve.MakeGenericMethod(systemManagerType).Invoke(null, Array.Empty<object>());
+            var getSys = mgr?.GetType().GetMethods()
+                .FirstOrDefault(m => m.Name.Contains("GetEntitySystem") && m.GetParameters().Length == 1);
+
+            var statusSystem = getSys?.Invoke(mgr, new object[] { statusSystemType });
+            if (statusSystem == null)
+                return;
+
+            foreach (var method in statusSystemType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+            {
+                if (!method.Name.Contains("StatusEffect") && !method.Name.Contains("Effect"))
+                    continue;
+
+                var parameters = method.GetParameters();
+                var values = new object?[parameters.Length];
+
+                for (var i = 0; i < parameters.Length; i++)
+                {
+                    var p = parameters[i].ParameterType;
+
+                    if (p == typeof(EntityUid))
+                        values[i] = uid;
+                    else if (p == typeof(string))
+                        values[i] = effectId;
+                    else if (p == typeof(TimeSpan))
+                        values[i] = duration;
+                    else if (p == typeof(bool))
+                        values[i] = true;
+                    else if (p.IsValueType)
+                        values[i] = Activator.CreateInstance(p);
+                    else
+                        values[i] = null;
+                }
+
+                try
+                {
+                    method.Invoke(statusSystem, values);
+                    return;
+                }
+                catch { }
+            }
+        }
+        catch { }
+    }
+
+    private void TryAddComponentByType(EntityUid uid, Type type)
+    {
+        try
+        {
+            if (!typeof(Component).IsAssignableFrom(type))
+                return;
+
+            var entityManagerType = EntityManager.GetType();
+
+            var hasComponent = entityManagerType.GetMethods()
+                .FirstOrDefault(m =>
+                    m.Name == "HasComponent" &&
+                    m.GetParameters().Length == 2 &&
+                    m.GetParameters()[0].ParameterType == typeof(EntityUid) &&
+                    m.GetParameters()[1].ParameterType == typeof(Type));
+
+            if (hasComponent?.Invoke(EntityManager, new object[] { uid, type }) is true)
+                return;
+
+            var addComponent = entityManagerType.GetMethods()
+                .FirstOrDefault(m =>
+                    m.Name == "AddComponent" &&
+                    m.GetParameters().Length == 2 &&
+                    m.GetParameters()[0].ParameterType == typeof(EntityUid) &&
+                    m.GetParameters()[1].ParameterType == typeof(Type));
+
+            var comp = addComponent?.Invoke(EntityManager, new object[] { uid, type });
+            if (comp == null)
+                return;
+
+            foreach (var name in new[] { "Intensity", "Drunkness", "Drunkenness", "BoozePower", "Duration", "Time" })
+            {
+                var field = type.GetField(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                if (field != null)
+                    SetCommonValue(field.FieldType, value => field.SetValue(comp, value));
+
+                var prop = type.GetProperty(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                if (prop is { CanWrite: true })
+                    SetCommonValue(prop.PropertyType, value => prop.SetValue(comp, value));
+            }
+        }
+        catch { }
+    }
+
+    private static void SetCommonValue(Type valueType, Action<object> setter)
+    {
+        if (valueType == typeof(float))
+            setter(2.5f);
+        else if (valueType == typeof(double))
+            setter(2.5d);
+        else if (valueType == typeof(int))
+            setter(3);
+        else if (valueType == typeof(TimeSpan))
+            setter(TimeSpan.FromSeconds(20));
+    }
+
+    private static Type? FindType(string shortName)
+    {
+        foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            foreach (var type in SafeTypes(asm))
+            {
+                if (type.Name == shortName)
+                    return type;
+            }
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<Type> SafeTypes(Assembly asm)
+    {
+        try { return asm.GetTypes(); }
+        catch { return Array.Empty<Type>(); }
+    }
+
+    private static bool TryGetTarget(OnIrradiatedEvent args, out EntityUid uid)
+    {
+        uid = default;
+
+        var boxed = (object) args;
+        var type = boxed.GetType();
+
+        foreach (var name in new[] { "Entity", "Uid", "Target", "Receiver", "Victim" })
+        {
+            var prop = type.GetProperty(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            if (prop?.GetValue(boxed) is EntityUid propUid)
+            {
+                uid = propUid;
+                return true;
+            }
+
+            var field = type.GetField(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            if (field?.GetValue(boxed) is EntityUid fieldUid)
+            {
+                uid = fieldUid;
+                return true;
+            }
+        }
+
+        foreach (var prop in type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+        {
+            if (prop.PropertyType != typeof(EntityUid))
+                continue;
+
+            if (prop.GetValue(boxed) is EntityUid found)
+            {
+                uid = found;
+                return true;
+            }
+        }
+
+        foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+        {
+            if (field.FieldType != typeof(EntityUid))
+                continue;
+
+            if (field.GetValue(boxed) is EntityUid found)
+            {
+                uid = found;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static float GetSeverity(OnIrradiatedEvent args)
+    {
+        var boxed = (object) args;
+        var type = boxed.GetType();
+
+        foreach (var name in new[] { "RadsPerSecond", "Radiation", "Rads", "Amount", "Intensity", "Dose", "Severity" })
+        {
+            var prop = type.GetProperty(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            if (TryFloat(prop?.GetValue(boxed), out var propValue))
+                return MathF.Abs(propValue);
+
+            var field = type.GetField(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            if (TryFloat(field?.GetValue(boxed), out var fieldValue))
+                return MathF.Abs(fieldValue);
+        }
+
+        foreach (var prop in type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+        {
+            if (TryFloat(prop.GetValue(boxed), out var value))
+                return MathF.Abs(value);
+        }
+
+        foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+        {
+            if (TryFloat(field.GetValue(boxed), out var value))
+                return MathF.Abs(value);
+        }
+
+        return 0.25f;
+    }
+
+    private static bool TryFloat(object? obj, out float value)
+    {
+        value = 0f;
+
+        switch (obj)
+        {
+            case float f:
+                value = f;
+                return true;
+            case double d:
+                value = (float) d;
+                return true;
+            case int i:
+                value = i;
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/Content.Server/Radiation/Components/RadiationWarningComponent.cs
+++ b/Content.Server/Radiation/Components/RadiationWarningComponent.cs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: 2026 puntsss <bex.ish.aholic@gmail.com>
+//
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 namespace Content.Server.Radiation.Components;

--- a/Content.Server/Radiation/Components/RadiationWarningComponent.cs
+++ b/Content.Server/Radiation/Components/RadiationWarningComponent.cs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Content.Server.Radiation.Components;
+
+[RegisterComponent]
+public sealed partial class RadiationWarningComponent : Component
+{
+    public TimeSpan NextWarningTime = TimeSpan.Zero;
+
+    public int LastWarningStage = 0;
+}

--- a/Content.Server/Radiation/Systems/RadiationSystem.cs
+++ b/Content.Server/Radiation/Systems/RadiationSystem.cs
@@ -13,6 +13,9 @@ using Content.Server.Radiation.Components;
 using Content.Shared.Radiation.Components;
 using Content.Shared.Radiation.Events;
 using Content.Shared.Stacks;
+using Content.Shared.Damage;
+using Content.Shared.Popups;
+using Robust.Shared.Timing;
 using Robust.Shared.Configuration;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
@@ -25,6 +28,8 @@ public sealed partial class RadiationSystem : EntitySystem
     [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedStackSystem _stack = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
 
     private EntityQuery<RadiationBlockingContainerComponent> _blockerQuery;
     private EntityQuery<RadiationGridResistanceComponent> _resistanceQuery;
@@ -63,6 +68,66 @@ public sealed partial class RadiationSystem : EntitySystem
     {
         var msg = new OnIrradiatedEvent(time, radsPerSecond, uid);
         RaiseLocalEvent(uid, msg);
+
+        TryWarnRadiationHealth(uid, radsPerSecond);
+    }
+
+    private void TryWarnRadiationHealth(EntityUid uid, float radsPerSecond)
+    {
+        // Only run this when the entity is actively receiving radiation.
+        if (radsPerSecond <= 0f)
+            return;
+
+        if (!TryComp<DamageableComponent>(uid, out var damageable))
+            return;
+
+        var totalDamage = damageable.TotalDamage.Float();
+
+        var stage = totalDamage switch
+        {
+            >= 90f => 5,
+            >= 70f => 4,
+            >= 45f => 3,
+            >= 25f => 2,
+            >= 10f => 1,
+            _ => 0
+        };
+
+        if (stage == 0)
+            return;
+
+        var warning = EnsureComp<RadiationWarningComponent>(uid);
+
+        // If their condition gets worse, warn immediately.
+        // If they stay in the same condition, use the cooldown so it doesn't spam.
+        var worsened = stage > warning.LastWarningStage;
+        if (!worsened && _timing.CurTime < warning.NextWarningTime)
+            return;
+
+        var message = stage switch
+        {
+            1 => "You feel uneasy.",
+            2 => "Your skin prickles faintly.",
+            3 => "Your stomach twists slightly.",
+            4 => "You feel lightheaded.",
+            5 => "A sudden wave of nausea hits you.",
+            _ => null
+        };
+
+        if (message == null)
+            return;
+
+        var cooldown = stage switch
+        {
+            >= 5 => TimeSpan.FromSeconds(15),
+            >= 4 => TimeSpan.FromSeconds(20),
+            _ => TimeSpan.FromSeconds(35)
+        };
+
+        warning.LastWarningStage = Math.Max(warning.LastWarningStage, stage);
+        warning.NextWarningTime = _timing.CurTime + cooldown;
+
+        _popup.PopupEntity(message, uid, uid);
     }
 
     public void SetSourceEnabled(Entity<RadiationSourceComponent?> entity, bool val)

--- a/Content.Server/Radiation/Systems/RadiationSystem.cs
+++ b/Content.Server/Radiation/Systems/RadiationSystem.cs
@@ -6,19 +6,21 @@
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Thomas <87614336+Aeshus@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 puntsss <bex.ish.aholic@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using Content.Server.Radiation.Components;
+using Content.Shared.Damage;
+using Robust.Shared.Player;
+using Content.Shared.Popups;
 using Content.Shared.Radiation.Components;
 using Content.Shared.Radiation.Events;
 using Content.Shared.Stacks;
-using Content.Shared.Damage;
-using Content.Shared.Popups;
-using Robust.Shared.Timing;
 using Robust.Shared.Configuration;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
+using Robust.Shared.Timing;
 
 namespace Content.Server.Radiation.Systems;
 
@@ -69,12 +71,12 @@ public sealed partial class RadiationSystem : EntitySystem
         var msg = new OnIrradiatedEvent(time, radsPerSecond, uid);
         RaiseLocalEvent(uid, msg);
 
+        TrySendRadiationVisuals(uid, radsPerSecond);
         TryWarnRadiationHealth(uid, radsPerSecond);
     }
 
     private void TryWarnRadiationHealth(EntityUid uid, float radsPerSecond)
     {
-        // Only run this when the entity is actively receiving radiation.
         if (radsPerSecond <= 0f)
             return;
 
@@ -97,9 +99,6 @@ public sealed partial class RadiationSystem : EntitySystem
             return;
 
         var warning = EnsureComp<RadiationWarningComponent>(uid);
-
-        // If their condition gets worse, warn immediately.
-        // If they stay in the same condition, use the cooldown so it doesn't spam.
         var worsened = stage > warning.LastWarningStage;
         if (!worsened && _timing.CurTime < warning.NextWarningTime)
             return;
@@ -130,6 +129,23 @@ public sealed partial class RadiationSystem : EntitySystem
         _popup.PopupEntity(message, uid, uid);
     }
 
+    private void TrySendRadiationVisuals(EntityUid uid, float radsPerSecond)
+    {
+        // Do not start the visual effect until about 1 rad/sec.
+        if (radsPerSecond < 1f)
+            return;
+
+        if (!TryComp<ActorComponent>(uid, out var actor))
+            return;
+
+        // Scale off the CURRENT radiation being received.
+        // 1 rad/sec = subtle start, 6+ rads/sec = strong camera damage effect.
+        var normalized = Math.Clamp((radsPerSecond - 1f) / 5f, 0f, 1f);
+        var intensity = Math.Clamp(0.12f + MathF.Sqrt(normalized) * 0.88f, 0.12f, 1f);
+
+        RaiseNetworkEvent(new RadiationVisualsEvent(intensity, 3.25f), actor.PlayerSession);
+    }
+
     public void SetSourceEnabled(Entity<RadiationSourceComponent?> entity, bool val)
     {
         if (!Resolve(entity, ref entity.Comp, false))
@@ -138,18 +154,11 @@ public sealed partial class RadiationSystem : EntitySystem
         entity.Comp.Enabled = val;
     }
 
-    /// <summary>
-    ///     Marks entity to receive/ignore radiation rays.
-    /// </summary>
     public void SetCanReceive(EntityUid uid, bool canReceive)
     {
         if (canReceive)
-        {
             EnsureComp<RadiationReceiverComponent>(uid);
-        }
         else
-        {
             RemComp<RadiationReceiverComponent>(uid);
-        }
     }
 }

--- a/Content.Shared/CVar/OmuRadiationCVars.cs
+++ b/Content.Shared/CVar/OmuRadiationCVars.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared.CCVar;
+
+public sealed partial class CCVars
+{
+    public static readonly CVarDef<bool> OmuRadiationVisualsEnabled =
+        CVarDef.Create("omu.radiation_visuals_enabled", true, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    public static readonly CVarDef<bool> OmuRadiationSicknessEnabled =
+        CVarDef.Create("omu.radiation_sickness_enabled", true, CVar.SERVERONLY);
+
+}

--- a/Content.Shared/Radiation/Events/RadiationVisualsEvent.cs
+++ b/Content.Shared/Radiation/Events/RadiationVisualsEvent.cs
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2026 puntsss <bex.ish.aholic@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Radiation.Events;
+
+[Serializable, NetSerializable]
+public sealed class RadiationVisualsEvent : EntityEventArgs
+{
+    public float Intensity { get; }
+    public float Duration { get; }
+
+    public RadiationVisualsEvent(float intensity, float duration)
+    {
+        Intensity = intensity;
+        Duration = duration;
+    }
+}

--- a/Resources/Locale/en-US/_white/escape-menu/options-menu.ftl
+++ b/Resources/Locale/en-US/_white/escape-menu/options-menu.ftl
@@ -6,3 +6,7 @@
 ui-options-log-in-chat = Log actions in the chat
 
 ui-options-hud-theme-xenomorph = Xenomorph
+
+ui-options-radiation-visuals = Enable radiation visual effects
+ui-options-radiation-visuals-tooltip = Shows the radiation dots/static overlay when exposed to radiation.
+ui-options-visuals-header = Visuals


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Added subtle symptom-based popup messages for radiation damage.
## Why / Balance
This gives players some feedback that something is wrong without making radiation instantly obvious. The messages only appear after the player has reached certain damage thresholds, and they use cooldowns so players are not spammed with popups. The intent is to make radiation feel more natural while still giving players a chance to notice symptoms.
## Technical details
Added RadiationWarningComponent to track warning cooldowns/states. Updated RadiationSystem to check the player's current damage after irradiation. Added staged popup messages based on damage thresholds. Higher damage stages produce stronger symptom messages.
## Media
<img width="201" height="80" alt="image" src="https://github.com/user-attachments/assets/ae97a227-950d-40e0-81f7-8ea5bdce4e22" /> 

https://github.com/user-attachments/assets/992e65a5-42b7-4978-a2e7-011553c5733b

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None, however this is my first PR so I am expecting some backlash! ~-~
**Changelog**
:cl:

- add: Added subtle symptom messages when suffering from radiation exposure!