### PR TITLE
[FIX] Fland high pop no cargo techs

### DIFF
--- a/Resources/Prototypes/_Goobstation/Maps/flandhighpop.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/flandhighpop.yml
@@ -99,6 +99,7 @@
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 4, 4 ]
             ShaftMiner: [ 4, 4 ] # Omu
+            CargoTechnician: [ 5, 5 ]
             Courier: [ 2, 2 ] #Omu
             #civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/_Goobstation/Maps/flandhighpop.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/flandhighpop.yml
@@ -99,7 +99,7 @@
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 4, 4 ]
             ShaftMiner: [ 4, 4 ] # Omu
-            CargoTechnician: [ 5, 5 ]
+            CargoTechnician: [ 5, 5 ] # Omu
             Courier: [ 2, 2 ] #Omu
             #civilian
             Passenger: [ -1, -1 ]


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->


## About the PR
Fixes lack of cargo techs on high pop fland

## Why / Balance
Fix

## Technical details
One line of ymal

## Media
none

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**

:cl:
- fix: Lack of cargo techs jobs on high pop fland

