### PR TITLE
removes echems from lathes

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
@@ -108,7 +108,7 @@
   - ChemMasterMachineCircuitboard
   - CondenserMachineCircuitBoard
   - HotplateMachineCircuitboard
-  - EnergyChemDispenserMachineCircuitboard #Goob edit - all things that get base med boards get E-Chem
+  # - EnergyChemDispenserMachineCircuitboard #omu edit
 
 ## Dynamic
 

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/medical.yml
@@ -158,13 +158,13 @@
     Plastic: 500
     Cloth: 500
 
-# - type: latheRecipe
+# - type: latheRecipe #omu edit start
 #   id: EnergyChemDispenserMachineCircuitboard
 #   parent: BaseGoldCircuitboardRecipe
 #   result: EnergyChemDispenserMachineCircuitboard
 #   icon:
 #     sprite: Structures/dispensers.rsi
-#     state: industrial-working
+#     state: industrial-working #omu edit end
 
 - type: latheRecipe
   parent: [BaseGoldCircuitboardRecipe, BaseMedicalMachineRecipeCategory]

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/medical.yml
@@ -158,13 +158,13 @@
     Plastic: 500
     Cloth: 500
 
-- type: latheRecipe
-  id: EnergyChemDispenserMachineCircuitboard
-  parent: BaseGoldCircuitboardRecipe
-  result: EnergyChemDispenserMachineCircuitboard
-  icon:
-    sprite: Structures/dispensers.rsi
-    state: industrial-working
+# - type: latheRecipe
+#   id: EnergyChemDispenserMachineCircuitboard
+#   parent: BaseGoldCircuitboardRecipe
+#   result: EnergyChemDispenserMachineCircuitboard
+#   icon:
+#     sprite: Structures/dispensers.rsi
+#     state: industrial-working
 
 - type: latheRecipe
   parent: [BaseGoldCircuitboardRecipe, BaseMedicalMachineRecipeCategory]

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -1138,4 +1138,4 @@ FoodDonutJellySlugcat: FoodDonutJellyScurret
 DVSmartFridgeMedical: SmartFridgeMedical
 
 # 2026-01-10 Goobstation Change Mapped Chem to Energy Chem by default
-ChemDispenser: EnergyChemDispenser
+# ChemDispenser: EnergyChemDispenser #omu edit


### PR DESCRIPTION
## About the PR
removes the echem from lathes

## Why / Balance
makes the echem that are mapped in chem more special and increase reliance on the chem dept in rounds 

## Technical details
just commenting out shit

## Media
<img width="569" height="363" alt="image" src="https://github.com/user-attachments/assets/8b3861af-6560-43fa-9f9b-a3b403175336" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- remove: Removed the energy chem board from lathes so keep your dispensers safe chem 
