### PR TITLE
increase cost by 1000 of that one specific shuttle failing tests

### DIFF
--- a/Resources/Prototypes/DeltaV/Catalog/Shipyard/civilian.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/Shipyard/civilian.yml
@@ -25,7 +25,7 @@
   id: Helix
   name: NTMC Helix
   description: A large mobile health clinic for servicing distant outposts.
-  price: 71000 # Omu
+  price: 72000 # Omu
   path: /Maps/_DV/Shuttles/helix.yml
   categories:
   - Civilian


### PR DESCRIPTION
making echem mapped only has made it so that chemical dispensers mapped on shuttles do not get replaced by echem and thus cost more and thus we fail arbitrage because we actually contain the chemicals rather than having power

fixed by increasing cost by 1000 of that one specific shuttle youll never see this because im selfmerging because we all want tests to pass after a meet and whatnot

<img width="496" height="212" alt="image" src="https://github.com/user-attachments/assets/2ee72f3d-980f-4451-b786-4860e3980595" />