### PR TITLE
Reducing the Abductor's EMP Gland effects

### DIFF
--- a/Content.Shared/_Shitmed/StatusEffects/SpawnEmpComponent.cs
+++ b/Content.Shared/_Shitmed/StatusEffects/SpawnEmpComponent.cs
@@ -14,6 +14,6 @@ namespace Content.Shared._Shitmed.StatusEffects;
 [RegisterComponent, NetworkedComponent]
 public sealed partial class SpawnEmpComponent : SpawnEntityEffectComponent
 {
-    public override string EntityPrototype { get; set; } = "AdminInstantEffectEMP7";
+    public override string EntityPrototype { get; set; } = "DubiousOrganEMPEffect"; // Omu, replaced with lesser emp.
     public override bool AttachToParent { get; set; } = true;
 }

--- a/Resources/Prototypes/_Omu/Entities/StatusEffects/misc.yml
+++ b/Resources/Prototypes/_Omu/Entities/StatusEffects/misc.yml
@@ -7,3 +7,13 @@
   - type: MovementModStatusEffect
     sprintSpeedModifier: 1.2
     walkSpeedModifier: 1.2
+
+- type: entity
+  id: DubiousOrganEMPEffect
+  categories: [ HideSpawnMenu ]
+  parent: AdminInstantEffectBase
+  components:
+  - type: EmpOnTrigger
+    range: 4
+    energyConsumption: 12500
+    disableDuration: 15

--- a/Resources/Prototypes/_Omu/Entities/StatusEffects/misc.yml
+++ b/Resources/Prototypes/_Omu/Entities/StatusEffects/misc.yml
@@ -14,6 +14,6 @@
   parent: AdminInstantEffectBase
   components:
   - type: EmpOnTrigger
-    range: 4
-    energyConsumption: 12500
-    disableDuration: 15
+    range: 2
+    energyConsumption: 25000
+    disableDuration: 30


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Reduces the range of the dubious organ EMP from 7 to 2, and reduces its disable duration to 20s from 60s
if i could i'd make this deal less ion damage but it seems to always deal 500ion to IPC regardless, i assume initially it would be based on how many joules it sapped but apparently not, it just does a fixed 500...

if you know what is responsible for determining EMP damage to IPC and know if its able to be reduced for this specific EMP let me know, also if theres a better place to put the new prototype added for the emp effect.

## Why / Balance
getting given this organ forces you to get cloned to remove it due to how damning it is to the station, it doesnt deserve to be commented out of the pool like the other organs, its a 'good' bad organ but too destructive for our environment to allow for its existence.

## Technical details
adds new EMP trigger entity proto in _Omu/Entities/StatusEffects/misc.yml, and changes the component used by the dubious organ to spawn this new prototype.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Abductor's EMP glands have less range potency and effect duration