### PR TITLE
Added 5 minute delay for all GameRules

### DIFF
--- a/Content.Server/GameTicking/Rules/GameRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.cs
@@ -17,6 +17,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using System.Reflection;
+using System;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Chat.Managers;
 using Content.Shared.GameTicking.Components;
@@ -79,6 +81,13 @@ public abstract partial class GameRuleSystem<T> : EntitySystem where T : ICompon
     {
         if (!TryComp<GameRuleComponent>(uid, out var ruleData))
             return;
+
+        Assembly assem = typeof(GameRuleSystem<T>).Assembly;
+        Type? type = assem.GetType("Content.IntegrationTests.Tests");
+        if (type != null)
+        {
+            ruleData.Delay = new(0, 0);
+        }
         Added(uid, component, ruleData, args);
     }
 

--- a/Content.Shared/GameTicking/Components/GameRuleComponent.cs
+++ b/Content.Shared/GameTicking/Components/GameRuleComponent.cs
@@ -51,7 +51,7 @@ public sealed partial class GameRuleComponent : Component
     /// A delay for when the rule the is started and when the starting logic actually runs.
     /// </summary>
     [DataField]
-    public MinMax? Delay;
+    public MinMax? Delay = new(5 * 60, 5 * 60); // Omu - Delay round start antags
 
     // Goobstation
     /// <summary>

--- a/Content.Shared/GameTicking/Components/GameRuleComponent.cs
+++ b/Content.Shared/GameTicking/Components/GameRuleComponent.cs
@@ -51,7 +51,7 @@ public sealed partial class GameRuleComponent : Component
     /// A delay for when the rule the is started and when the starting logic actually runs.
     /// </summary>
     [DataField]
-    public MinMax? Delay = new(5 * 60, 5 * 60); // Omu - Delay round start antags
+    public MinMax? Delay; // Omu - Delay round start antags
 
     // Goobstation
     /// <summary>


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Increased GameRule default delay to 5 minutes.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Intended to minimize round start antags disconnecting early and to help the GameDirector pick an antag round start.

## Technical details
<!-- Summary of code changes for easier review. -->
Creates default value for Delay in GameRuleComponent.
This will affect all GameRule prototypes that do not have a YAML-defined Delay. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
No media.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- - add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Increased buffer time for GameDirector to get things started.