### PR TITLE
Unrevivable comp changes

### DIFF
--- a/Content.Server/_EinsteinEngines/Medical/CPR/CPRSystem.cs
+++ b/Content.Server/_EinsteinEngines/Medical/CPR/CPRSystem.cs
@@ -134,9 +134,8 @@ public sealed class CPRSystem : EntitySystem
             && TryComp<MobStateComponent>(args.Target, out var state)
             && _mobThreshold.CheckVitalDamage(args.Target.Value, damageableComponent) < threshold)// GoobStation
         {//OMU start
-            if (HasComp<UnrevivableComponent>(args.Target))
+            if (TryComp<UnrevivableComponent>(args.Target, out var unrevComp))
             {
-                TryComp<UnrevivableComponent>(args.Target, out var unrevComp);
                 if (!unrevComp!.CPRBlock)
                 {
                     _mobStateSystem.ChangeMobState(args.Target.Value, MobState.Critical, state, performer);

--- a/Content.Server/_EinsteinEngines/Medical/CPR/CPRSystem.cs
+++ b/Content.Server/_EinsteinEngines/Medical/CPR/CPRSystem.cs
@@ -132,9 +132,21 @@ public sealed class CPRSystem : EntitySystem
             && _mobThreshold.TryGetThresholdForState((EntityUid)args.Target, MobState.Dead, out var threshold)
             && TryComp<DamageableComponent>(args.Target, out var damageableComponent)
             && TryComp<MobStateComponent>(args.Target, out var state)
-            && !HasComp<UnrevivableComponent>(args.Target)
-            && _mobThreshold.CheckVitalDamage(args.Target.Value, damageableComponent) < threshold) // GoobStation
-            _mobStateSystem.ChangeMobState(args.Target.Value, MobState.Critical, state, performer);
+            && _mobThreshold.CheckVitalDamage(args.Target.Value, damageableComponent) < threshold)// GoobStation
+        {//OMU start
+            if (HasComp<UnrevivableComponent>(args.Target))
+            {
+                TryComp<UnrevivableComponent>(args.Target, out var unrevComp);
+                if (!unrevComp!.CPRBlock)
+                {
+                    _mobStateSystem.ChangeMobState(args.Target.Value, MobState.Critical, state, performer);
+                }
+            }
+            else
+            {
+                _mobStateSystem.ChangeMobState(args.Target.Value, MobState.Critical, state, performer);
+            }
+        }//OMU end
 
         var isAlive = _mobStateSystem.IsAlive(args.Target.Value);
         args.Repeat = !isAlive;

--- a/Content.Shared/Traits/Assorted/UnrevivableComponent.cs
+++ b/Content.Shared/Traits/Assorted/UnrevivableComponent.cs
@@ -25,6 +25,13 @@ public sealed partial class UnrevivableComponent : Component
     [DataField, AutoNetworkedField]
     public bool Cloneable = false;
 
+    /// <summary><OMU>
+    /// Make it a variable if CPR works
+    /// </summary>
+    [DataField]
+    public bool CPRBlock = false;
+    ///</OMU>
+
     /// <summary>
     /// The loc string used to provide a reason for being unrevivable
     /// </summary>


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Adds a new datafield to the unreivable component and adapts the CPR system

## Why / Balance
Makes unrevivable work in line with how the heath analyser descibes it to weak for the defib

## Technical details
Adds a new datafield to the unreivable component and adapts the CPR system

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
- Adds a new datafiled to the Unrevivable component
- Touces the CPR system

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: CPR can revive unreviable trait again.
