### PR TITLE
Decrease emergency shuttle auto-call timer to 90

### DIFF
--- a/Resources/ConfigPresets/_Omu/OmuCore.toml
+++ b/Resources/ConfigPresets/_Omu/OmuCore.toml
@@ -112,7 +112,7 @@ loginlocal = false # Never change, we are not connecting from the server to itse
 [shuttle]
 emergency_early_launch_allowed = true # Changed to allow early leaving (due to increased time)
 emergency_dock_time = 300 # Increased from 180
-auto_call_time = 120 # Increased from 90
+auto_call_time = 90 # Decreased from 120
 mass_limit = 2000 # Changed for event shuttles
 
 [lavaland]

--- a/Resources/ConfigPresets/_Omu/OmuCore.toml
+++ b/Resources/ConfigPresets/_Omu/OmuCore.toml
@@ -112,7 +112,7 @@ loginlocal = false # Never change, we are not connecting from the server to itse
 [shuttle]
 emergency_early_launch_allowed = true # Changed to allow early leaving (due to increased time)
 emergency_dock_time = 300 # Increased from 180
-auto_call_time = 90 # Decreased from 120
+auto_call_time = 90
 mass_limit = 2000 # Changed for event shuttles
 
 [lavaland]


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Decreased the emergency shuttle auto-call timer from 120 to 90
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Server lag has become a major issue as of late and is particularly noticeable after 90 minutes on most rounds, where it becomes near unbearable to play. This causes some rounds to last almost 3 hours due to a progressively degrading tickrate. There are more reasons why this should be decreased to 90 minutes in my opinion, but this should at least be considered as a temporary solution until the underlying server lag issues have been solved.
## Technical details
<!-- Summary of code changes for easier review. -->
1 line toml change
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:bnuuy
- tweak: The emergency shuttle now gets auto-called after 90 minutes instead of 120.

