### PR TITLE
[PORT] Radial menu for Janicart & Survival Kits

### DIFF
--- a/Content.Client/_Imp/ItemSlotsMenu/ItemSlotsBoundUserInterface.cs
+++ b/Content.Client/_Imp/ItemSlotsMenu/ItemSlotsBoundUserInterface.cs
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 Space Station 14 Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.Containers.ItemSlots;
+using JetBrains.Annotations;
+using Robust.Client.Graphics;
+using Robust.Client.Input;
+
+namespace Content.Client._Imp.ItemSlotsMenu;
+
+[UsedImplicitly]
+public sealed class ItemSlotsBoundUserInterface : BoundUserInterface
+{
+    [Dependency] private readonly IClyde _displayManager = default!;
+    [Dependency] private readonly IInputManager _inputManager = default!;
+
+    private ItemSlotsMenu? _menu;
+
+    public ItemSlotsBoundUserInterface(EntityUid owner, Enum uiKey) : base(owner, uiKey)
+    {
+        IoCManager.InjectDependencies(this);
+    }
+
+    protected override void Open()
+    {
+        base.Open();
+
+        _menu = new(Owner, this);
+        _menu.OnClose += Close;
+
+        // Open the menu, centered on the mouse
+        var vpSize = _displayManager.ScreenSize;
+        _menu.OpenCenteredAt(_inputManager.MouseScreenPosition.Position / vpSize);
+    }
+
+    public void SendItemSlotsEjectMessage(string e)
+    {
+        SendMessage(new ItemSlotButtonPressedEvent(e));
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        if (!disposing) return;
+
+        _menu?.Parent?.RemoveChild(_menu);
+    }
+}

--- a/Content.Client/_Imp/ItemSlotsMenu/ItemSlotsMenu.xaml
+++ b/Content.Client/_Imp/ItemSlotsMenu/ItemSlotsMenu.xaml
@@ -1,0 +1,11 @@
+﻿<ui:RadialMenu xmlns="https://spacestation14.io"
+                xmlns:ui="clr-namespace:Content.Client.UserInterface.Controls"
+                BackButtonStyleClass="RadialMenuBackButton"
+                CloseButtonStyleClass="RadialMenuCloseButton"
+                VerticalExpand="True"
+                HorizontalExpand="True"
+                MinSize="450 450">
+
+
+    <ui:RadialContainer Name="Main" VerticalExpand="True" HorizontalExpand="True" InitialRadius="100" ReserveSpaceForHiddenChildren="False"></ui:RadialContainer>
+</ui:RadialMenu>

--- a/Content.Client/_Imp/ItemSlotsMenu/ItemSlotsMenu.xaml.cs
+++ b/Content.Client/_Imp/ItemSlotsMenu/ItemSlotsMenu.xaml.cs
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 Space Station 14 Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Linq;
+using System.Numerics;
+using Content.Client.UserInterface.Controls;
+using Content.Shared.Containers.ItemSlots;
+using Robust.Client.GameObjects;
+using Robust.Client.Player;
+using Robust.Client.UserInterface.Controls;
+using Robust.Client.UserInterface.XAML;
+
+namespace Content.Client._Imp.ItemSlotsMenu;
+
+public sealed partial class ItemSlotsMenu: RadialMenu
+{
+    [Dependency] private readonly EntityManager _entManager = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+
+    private readonly ItemSlotsSystem _itemSlots;
+
+    private const string MainString = "Main";
+
+    public event Action<string>? ItemSlotEjectMessageAction;
+
+    public ItemSlotsMenu(EntityUid owner, ItemSlotsBoundUserInterface bui)
+    {
+        IoCManager.InjectDependencies(this);
+        RobustXamlLoader.Load(this);
+
+        _itemSlots = _entManager.System<ItemSlotsSystem>();
+
+        // Find the main radial container
+        var main = FindControl<RadialContainer>(MainString);
+
+        if (!_entManager.TryGetComponent<ItemSlotsComponent>(owner, out var slotsComp))
+            return;
+
+        if (slotsComp.Slots.All(x => x.Value.Item == null))
+            Close();
+
+        foreach (var itemSlot in slotsComp.Slots)
+        {
+            if (_playerManager.LocalSession == null)
+                continue;
+
+            var item = itemSlot.Value.Item;
+            string itemName;
+
+            if (item == null)
+                continue;
+
+            if (!_entManager.TryGetComponent<MetaDataComponent>(item, out var metadata))
+                continue;
+
+            itemName = metadata.EntityName;
+
+            var button = new ItemSlotButton()
+            {
+                SetSize = new Vector2(64f, 64f),
+                ToolTip = itemName,
+            };
+
+            if (!_entManager.TryGetComponent<SpriteComponent>(item, out var sprite))
+                continue;
+
+            if (sprite.Icon == null)
+                continue;
+
+            var tex = new TextureRect()
+            {
+                VerticalAlignment = VAlignment.Center,
+                HorizontalAlignment = HAlignment.Center,
+                Texture = sprite.Icon?.Default,
+                TextureScale = new Vector2(2f, 2f),
+            };
+
+            button.AddChild(tex);
+            main.AddChild(button);
+
+            button.OnButtonUp += _ =>
+            {
+                ItemSlotEjectMessageAction?.Invoke(itemSlot.Key);
+                _itemSlots.TryEjectToHands(item.Value, itemSlot.Value, owner);
+                Close();
+            };
+        }
+
+        ItemSlotEjectMessageAction += bui.SendItemSlotsEjectMessage;
+    }
+}
+
+public sealed class ItemSlotButton : RadialMenuTextureButtonWithSector
+{
+    public ItemSlotButton()
+    {
+
+    }
+}

--- a/Content.Shared/Containers/ItemSlot/ItemSlotsComponent.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsComponent.cs
@@ -339,4 +339,13 @@ namespace Content.Shared.Containers.ItemSlots
     /// </summary>
     [ByRefEvent]
     public record struct ItemSlotEjectAttemptEvent(EntityUid SlotEntity, EntityUid Item, EntityUid? User, ItemSlot Slot, bool Cancelled = false);
+
+    /// <summary>
+    /// Imp edit. For the radial menu.
+    /// </summary>
+    [Serializable, NetSerializable]
+    public enum ItemSlotsUiKey : byte
+    {
+        Key
+    }
 }

--- a/Resources/Prototypes/Entities/Structures/Specific/Janitor/janicart.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Janitor/janicart.yml
@@ -231,6 +231,12 @@
         density: 60
         mask:
         - MachineMask
+  - type: UserInterface # imp
+    interfaces:
+      enum.ItemSlotsUiKey.Key:
+        type: ItemSlotsBoundUserInterface
+  - type: ActivatableUI # imp
+    key: enum.ItemSlotsUiKey.Key
 
 - type: entity
   name: mop bucket
@@ -474,6 +480,8 @@
       interfaces:
         enum.StorageUiKey.Key:
           type: StorageBoundUserInterface
+        enum.ItemSlotsUiKey.Key: # imp
+          type: ItemSlotsBoundUserInterface
     - type: Drink
       solution: bucket
     - type: ContainerContainer
@@ -495,3 +503,5 @@
       guides:
       - Janitorial
     - type: DnaSubstanceTrace
+    - type: ActivatableUI # imp
+      key: enum.ItemSlotsUiKey.Key

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/emergencybox.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/emergencybox.yml
@@ -178,6 +178,12 @@
         whitelist:
           tags:
           - CableCoil
+  - type: UserInterface # Gabystation - ItemSlotUI
+    interfaces:
+      enum.ItemSlotsUiKey.Key:
+        type: ItemSlotsBoundUserInterface
+  - type: ActivatableUI # Gabystation - ItemSlotUI
+    key: enum.ItemSlotsUiKey.Key
 
 
 - type: entity


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

Radial menu added to janicarts, trolleys, mop buckets and survival boxes.

ported from: https://github.com/impstation/imp-station-14/pull/3585, https://github.com/impstation/imp-station-14/pull/3622, and https://github.com/Project-Dumont/Dumont-Station/pull/612 


## Why / Balance

Simple QOL

## Technical details


## Media


https://github.com/user-attachments/assets/7999444f-a16b-40d3-bc7e-e614e6785bf7



## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl: Anui-ElXx
- add: Radial menu added to Janitorial Trolleys and Survival boxes