### PR TITLE
Reduce IPC EMP Damage

### DIFF
--- a/Content.Omu.Server/Cybernetics/IPCEmpVulnerableSystem.cs
+++ b/Content.Omu.Server/Cybernetics/IPCEmpVulnerableSystem.cs
@@ -35,7 +35,7 @@ internal sealed class CyberneticsSystem : EntitySystem
             if (TryComp(cyberEnt, out DamageableComponent? damageable))
             {
                 var ion = new DamageSpecifier(_prototypes.Index<DamageTypePrototype>("Ion"), 75); // 75 ion damage, 75 vital damage -> 19 wires to heal
-                _damageable.TryChangeDamage(cyberEnt, ion, ignoreResistances: true, targetPart: TargetBodyPart.All, splitDamage: SplitDamageBehavior.SplitEnsureAll, damageable: damageable);
+                _damageable.TryChangeDamage(cyberEnt, ion, ignoreResistances: true, targetPart: TargetBodyPart.Vital, splitDamage: SplitDamageBehavior.SplitEnsureAll, damageable: damageable);
                 Dirty(cyberEnt, damageable);
             }
         }

--- a/Content.Omu.Server/Cybernetics/IPCEmpVulnerableSystem.cs
+++ b/Content.Omu.Server/Cybernetics/IPCEmpVulnerableSystem.cs
@@ -34,7 +34,7 @@ internal sealed class CyberneticsSystem : EntitySystem
 
             if (TryComp(cyberEnt, out DamageableComponent? damageable))
             {
-                var ion = new DamageSpecifier(_prototypes.Index<DamageTypePrototype>("Ion"), 120); // 120 ion damage, 30 vital damage -> one stack of wires to heal
+                var ion = new DamageSpecifier(_prototypes.Index<DamageTypePrototype>("Ion"), 75); // 75 ion damage, 75 vital damage -> 19 wires to heal
                 _damageable.TryChangeDamage(cyberEnt, ion, ignoreResistances: true, targetPart: TargetBodyPart.All, splitDamage: SplitDamageBehavior.SplitEnsureAll, damageable: damageable);
                 Dirty(cyberEnt, damageable);
             }

--- a/Content.Omu.Server/Cybernetics/IPCEmpVulnerableSystem.cs
+++ b/Content.Omu.Server/Cybernetics/IPCEmpVulnerableSystem.cs
@@ -34,7 +34,7 @@ internal sealed class CyberneticsSystem : EntitySystem
 
             if (TryComp(cyberEnt, out DamageableComponent? damageable))
             {
-                var ion = new DamageSpecifier(_prototypes.Index<DamageTypePrototype>("Ion"), 500); // Something something, vital damage, this is spread across every limb.
+                var ion = new DamageSpecifier(_prototypes.Index<DamageTypePrototype>("Ion"), 120); // 120 ion damage, 30 vital damage -> one stack of wires to heal
                 _damageable.TryChangeDamage(cyberEnt, ion, ignoreResistances: true, targetPart: TargetBodyPart.All, splitDamage: SplitDamageBehavior.SplitEnsureAll, damageable: damageable);
                 Dirty(cyberEnt, damageable);
             }

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -138,7 +138,7 @@ namespace Content.Shared.Damage
         public float UniversalTopicalsHealModifier { get; private set; } = 1f;
         public float UniversalMobDamageModifier { get; private set; } = 1f;
 
-        private ProtoId<DamageGroupPrototype>[] _vitalOnlyDamageTypes = { "Airloss", "Toxin", "Genetic", "Metaphysical" }; // Goobstation
+        private ProtoId<DamageGroupPrototype>[] _vitalOnlyDamageTypes = { "Airloss", "Toxin", "Genetic", "Metaphysical", "Electronic"}; // Goobstation
         public override void Initialize()
         {
             SubscribeLocalEvent<DamageableComponent, ComponentInit>(DamageableInit);

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -138,7 +138,7 @@ namespace Content.Shared.Damage
         public float UniversalTopicalsHealModifier { get; private set; } = 1f;
         public float UniversalMobDamageModifier { get; private set; } = 1f;
 
-        private ProtoId<DamageGroupPrototype>[] _vitalOnlyDamageTypes = { "Airloss", "Toxin", "Genetic", "Metaphysical"}; // Goobstation
+        private ProtoId<DamageGroupPrototype>[] _vitalOnlyDamageTypes = { "Airloss", "Toxin", "Genetic", "Metaphysical" }; // Goobstation
         public override void Initialize()
         {
             SubscribeLocalEvent<DamageableComponent, ComponentInit>(DamageableInit);

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -138,7 +138,7 @@ namespace Content.Shared.Damage
         public float UniversalTopicalsHealModifier { get; private set; } = 1f;
         public float UniversalMobDamageModifier { get; private set; } = 1f;
 
-        private ProtoId<DamageGroupPrototype>[] _vitalOnlyDamageTypes = { "Airloss", "Toxin", "Genetic", "Metaphysical", "Electronic"}; // Goobstation
+        private ProtoId<DamageGroupPrototype>[] _vitalOnlyDamageTypes = { "Airloss", "Toxin", "Genetic", "Metaphysical", "Electronic"}; // Goobstation, Omu added Electronic to vital damage for EMP damage
         public override void Initialize()
         {
             SubscribeLocalEvent<DamageableComponent, ComponentInit>(DamageableInit);

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -138,7 +138,7 @@ namespace Content.Shared.Damage
         public float UniversalTopicalsHealModifier { get; private set; } = 1f;
         public float UniversalMobDamageModifier { get; private set; } = 1f;
 
-        private ProtoId<DamageGroupPrototype>[] _vitalOnlyDamageTypes = { "Airloss", "Toxin", "Genetic", "Metaphysical", "Electronic"}; // Goobstation, Omu added Electronic to vital damage for EMP damage
+        private ProtoId<DamageGroupPrototype>[] _vitalOnlyDamageTypes = { "Airloss", "Toxin", "Genetic", "Metaphysical"}; // Goobstation
         public override void Initialize()
         {
             SubscribeLocalEvent<DamageableComponent, ComponentInit>(DamageableInit);


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Reduced total ION damage received by IPCs from EMPs while keeping vital damage high.
Previous Numbers:
500 ION Damage + 130 Vital Damage

New Numbers:
75 ION Damage + 75 Vital Damage

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
IPCs getting one shot by EMPs and receiving enough damage requiring 125 wires was too extreme. 
This change will no longer one-shot IPCs but will still make them very vulnerable.

## Technical details
<!-- Summary of code changes for easier review. -->
Changed bodypart target to only vital areas, so the damage is all vital.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/4719d268-5ec7-4514-b466-294abf3dcb0c

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: EMPs don't one-shot IPCs anymore.