### PR TITLE
Change HOS Belt to Grant Kung Fu Dragon instead of Capoeira

### DIFF
--- a/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.KungFuDragon.cs
+++ b/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.KungFuDragon.cs
@@ -6,12 +6,17 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Goobstation.Common.MartialArts; // Omu
+using Content.Goobstation.Maths.FixedPoint; // Omu
 using Content.Goobstation.Shared.MartialArts.Components;
 using Content.Goobstation.Shared.MartialArts.Events;
 using Content.Shared._Shitmed.Targeting;
+using Content.Shared.Clothing; // Omu
+using Content.Shared.Damage; // Omu
 using Content.Shared.Interaction.Events;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Stunnable;
+using Content.Shared.Weapons.Melee; // Omu
 using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Prototypes;
 
@@ -27,8 +32,49 @@ public abstract partial class SharedMartialArtsSystem
 
         SubscribeLocalEvent<GrantKungFuDragonComponent, UseInHandEvent>(OnGrantCQCUse);
 
+        // Omu start
+        SubscribeLocalEvent<GrantKungFuDragonComponent, ClothingGotEquippedEvent>(OnWear);
+        SubscribeLocalEvent<GrantKungFuDragonComponent, ClothingGotUnequippedEvent>(OnRemove);
+        // Omu end
+
         SubscribeLocalEvent<DragonPowerBuffComponent, AttackedEvent>(OnAttacked);
     }
+
+    // Omu start
+    private void OnWear(EntityUid ent, GrantKungFuDragonComponent component, ref ClothingGotEquippedEvent args)
+    {
+        if (!_netManager.IsServer)
+            return;
+
+        var user = args.Wearer;
+        TryGrantMartialArt(user, component);
+    }
+
+    private void OnRemove(Entity<GrantKungFuDragonComponent> ent, ref ClothingGotUnequippedEvent args)
+    {
+        var user = args.Wearer;
+
+        // Omu Station
+        // Don't proceed if the user has non-removable Martial Arts knowledge
+        if (HasManualCqcKnowledge(user))
+            return;
+
+        if (!TryComp<MartialArtsKnowledgeComponent>(user, out var martialartsknowcomp)
+            || !TryComp<MeleeWeaponComponent>(user, out var meleeweaponcomp))
+            return;
+
+        if (martialartsknowcomp.MartialArtsForm != MartialArtsForms.KungFuDragon)
+            return;
+
+        var originalDamage = new DamageSpecifier();
+        originalDamage.DamageDict[martialartsknowcomp.OriginalFistDamageType]
+            = FixedPoint2.New(martialartsknowcomp.OriginalFistDamage);
+        meleeweaponcomp.Damage = originalDamage;
+
+        RemComp<MartialArtsKnowledgeComponent>(user);
+        RemComp<CanPerformComboComponent>(user);
+    }
+    // Omu end
 
     private void OnAttacked(Entity<DragonPowerBuffComponent> ent, ref AttackedEvent args)
     {

--- a/Resources/Prototypes/_Omu/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_Omu/Entities/Clothing/Belt/belts.yml
@@ -57,7 +57,7 @@
     sprite: _Omu/Clothing/Belt/clothingbelthoscqc.rsi
   - type: Clothing
     sprite: _Omu/Clothing/Belt/clothingbelthoscqc.rsi
-  - type: GrantCapoeira
+  - type: GrantGrantKungFuDragon
   - type: Storage
     whitelist:
       tags:

--- a/Resources/Prototypes/_Omu/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_Omu/Entities/Clothing/Belt/belts.yml
@@ -57,7 +57,7 @@
     sprite: _Omu/Clothing/Belt/clothingbelthoscqc.rsi
   - type: Clothing
     sprite: _Omu/Clothing/Belt/clothingbelthoscqc.rsi
-  - type: GrantGrantKungFuDragon
+  - type: GrantKungFuDragon
   - type: Storage
     whitelist:
       tags:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Per title, this PR implements the event handlers to allow Kung Fu Dragon to be granted by wearable entities and also changes the Head of Security's belt so that it grants Kung Fu Dragon instead of Capoeira.

## Why / Balance
I was told that Capoeira was too strong. The change to Kung Fu Dragon is intended to nerf the CQC abilities of the Head of Security.

## Technical details
Two event handlers were copied verbatim from Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.Capoeira.cs and transplanted into Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.KungFuDragon.cs to allow for granting Kung Fu Dragon via clothing items. This, IMO, is a poor implementation because it's 99.9% the exact same code as in Capoeira and could potentially be duplicated around other martial arts implementations. Ideally, the OnWear and OnRemove handlers *for all martial arts* could be factored out into their own private helper methods to lessen the needless duplication of the code.

The component on the HOS belt was changed to the one that grants Kung Fu Dragon.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Though some exceedingly lax testing was performed, I would very much appreciate it if a maintainer who is more familiar with CQC/martial arts could yoink this branch and do more extensive testing to make sure there aren't any obvious breakages in this PR.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: HOS belt now grants Kung Fu instead of Capoeira
- add: Kung Fu could now, in theory, be granted by other articles of clothing besides the HOS belt
