### PR TITLE
nerf the brick and tins

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
@@ -104,10 +104,10 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 15 #omu edit
         reagents:
         - ReagentId: Nutriment
-          Quantity: 7.5
+          Quantity: 7.5 #omu edit
   - type: Openable
     openableByHand: false
     sound:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
@@ -104,10 +104,10 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 20
+        maxVol: 15
         reagents:
         - ReagentId: Nutriment
-          Quantity: 15
+          Quantity: 7.5
   - type: Openable
     openableByHand: false
     sound:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
@@ -590,10 +590,10 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 15 #omu edit
         reagents:
         - ReagentId: Nutriment
-          Quantity: 7.5
+          Quantity: 7.5 #omu edit
 
 - type: entity
   id: FoodSnackMREBrownie

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
@@ -590,10 +590,10 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 25
+        maxVol: 15
         reagents:
         - ReagentId: Nutriment
-          Quantity: 20
+          Quantity: 7.5
 
 - type: entity
   id: FoodSnackMREBrownie


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
nerfed the Nutriment brick and meat tin from 20u to 7.5u

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
this is to make the kitchen and chefs more important to a round as currently the brink can take you through a whole round 
7.5 is enough Nutriment to move you one stage of hunger 

## Technical details
<!-- Summary of code changes for easier review. -->
just some YAML

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: nerfed the Nutriment brick and meat tin
