### PR TITLE
[Bounty] Bingle tweaks

### DIFF
--- a/Content.Goobstation.Common/Bingle/BinglePitComponent.cs
+++ b/Content.Goobstation.Common/Bingle/BinglePitComponent.cs
@@ -68,7 +68,7 @@ public sealed partial class BinglePitComponent : Component
     public SoundSpecifier FallingSound = new SoundPathSpecifier("/Audio/Effects/falling.ogg");
 
     [DataField]
-    public EntProtoId GhostRoleToSpawn = "SpawnPointGhostBingle";
+    public EntProtoId GhostRoleToSpawn = "MobBingleRandom"; // Omu
 
     /// <summary>
     /// how many bingles to spawn on pit spawn

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/Player/bingle.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/Player/bingle.yml
@@ -53,7 +53,7 @@
     mindRoles:
     - MindRoleGhostRoleTeamAntagonist
     raffle:
-      settings: default
+      settings: short
   - type: Sprite
     drawdepth: Mobs
     sprite: _Goobstation/Mobs/Bingle/bingle.rsi

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/Player/bingle.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/Player/bingle.yml
@@ -53,7 +53,7 @@
     mindRoles:
     - MindRoleGhostRoleTeamAntagonist
     raffle:
-      settings: short
+      settings: short    # Omu
   - type: Sprite
     drawdepth: Mobs
     sprite: _Goobstation/Mobs/Bingle/bingle.rsi

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Specific/Binglepit.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Specific/Binglepit.yml
@@ -53,7 +53,7 @@
   - type: InteractionOutline
   - type: Clickable
   - type: Damageable
-    damageContainer: StructuralInorganic
+    damageContainer: Inorganic
     damageModifierSet: Metallic
   - type: Destructible
     thresholds:

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Specific/Binglepit.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Specific/Binglepit.yml
@@ -53,7 +53,7 @@
   - type: InteractionOutline
   - type: Clickable
   - type: Damageable
-    damageContainer: Inorganic
+    damageContainer: Inorganic   # Omu
     damageModifierSet: Metallic
   - type: Destructible
     thresholds:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
* Bingle pit now spawns bingles directly when previously you had to request the bingle via ghost roles
* Changed the ghost role raffle time to become a bingle to be 10 seconds
* Bingle pit no longer takes structural/caustic damage (changed to Inorganic instead of StructuralInorganic)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The discussion I've been a part of is [here in the relevant bounty thread in the Omu discord](https://discord.com/channels/1406768242843979816/1517044154876563497) but it wouldn't surprise me if there has been more.

For the pit spawning bingles directly and ghost role raffle time change, the idea is to make it easier and quicker to enter the game as a bingle. A few people in the bounty thread expressed the feeling that the default 25 second timer is too long. Also, the short raffle timer is intended for spammed roles like carp as noted [here](https://github.com/ProjectOmu/OmuStation/blob/master/Resources/Prototypes/GhostRoleRaffles/settings.yml#L43).

There was also some frustration about how easy it is to destroy a bingle pit with a single explosive. This is why the damage container was changed. This part is a buff to bingles, as it doesn't take structural or caustic damage anymore and so would be harder to deal with. In my test, a breaching charge now does just the 50 of each brute, so 150/600 health that it has. This shouldn't affect the other ways people have of dealing with it, though.

## Technical details
<!-- Summary of code changes for easier review. -->
Changed the damage container in Binglepit.yml from `StructuralInorganic` to `Inorganic`
Changed the raffle settings in bingle.yml from `default` to `short`

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://www.youtube.com/watch?v=wdTY4araQlw

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Derg
- tweak: Bingle ghost roles no longer need to be requested and raffle time shortened.
- tweak: Bingle pit no longer takes structural damage.