### PR TITLE
Importent Xelthia bugfix

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/Body/Parts/xelthia.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Body/Parts/xelthia.yml
@@ -18,8 +18,9 @@
         color: "#00FF69"
       Burn:
         sprite: _Shitmed/Mobs/Effects/burn_damage.rsi
-  - type: Damageable # Omu edit end
-    damageContainer: Xelthia # Omu edit end - shitmed moment
+  - type: Damageable # Omustation
+    damageContainer: Biological
+    damageModifierSet: Xelthia
 
 - type: entity
   id: ChestXelthia

--- a/Resources/Prototypes/_EinsteinEngines/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Damage/modifier_sets.yml
@@ -67,4 +67,4 @@
   coefficients:
     Cold: 1.5
     Heat: 0.5
-    #Caustic: 0 #Omu edit, redundant since there damage container no longer holds caustic
+    Caustic: 0

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Species/xelthia.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Species/xelthia.yml
@@ -43,7 +43,7 @@
   #- type: FootPrints #Omu EE slop todo
   - type: Xelthia
   - type: Damageable
-    damageContainer: Xelthia #Omu edit - so they don't take caustic damage from chems among other things
+    damageContainer: Biological
     damageModifierSet: Xelthia
   - type: Temperature
     heatDamageThreshold: 360

--- a/Resources/Prototypes/_Omu/Damage/containers.yml
+++ b/Resources/Prototypes/_Omu/Damage/containers.yml
@@ -9,16 +9,3 @@
     - Electronic
   supportedTypes: # Goobstation
     - Holy
-
-- type: damageContainer
-  id: Xelthia #same as Biological except it can't store caustic
-  supportedGroups:
-  - Brute
-  - Toxin
-  - Airloss
-  - Genetic
-  supportedTypes:
-  - Holy
-  - Heat
-  - Shock
-  - Cold


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
changed the base Xelthia mob to use Biological damage container rather then the Xelthia one
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
- So turns out Medical HUDs and tropicals use damage containers for checking if they can do there respective things. Not like you know... Tags? WHY doesn't just look for a tag on damage containers or the mob itself is beyond me.
- Xelthia are still fully immune to caustic damage because of how shitmed works with the body parts using the Xelthia damage container.
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed a bug that stopped Xelthia from using topicals and being read by medical HUDs