### PR TITLE
Fixed Harpy wings

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/harpy.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/harpy.yml
@@ -83,6 +83,7 @@
       - map: [ "enum.HumanoidVisualLayers.Head" ]
       - map: [ "enum.HumanoidVisualLayers.Snout" ]
       - map: [ "enum.HumanoidVisualLayers.Eyes" ]
+      - map: [ "enum.HumanoidVisualLayers.RArm" ] # Omu - moved wings from RArm to Wings bodypart.
       - map: [ "enum.HumanoidVisualLayers.LArm" ]
       - map: [ "enum.HumanoidVisualLayers.RLeg" ]
       - map: [ "enum.HumanoidVisualLayers.LLeg" ]
@@ -120,8 +121,7 @@
         sprite: "Effects/creampie.rsi"
         state: "creampie_human"
         visible: false
-# Yes, RArm has to be down here
-      - map: [ "enum.HumanoidVisualLayers.RArm" ]
+      - map: [ "enum.HumanoidVisualLayers.Wings" ] #Omu - moved harpy wings from RArm to wings
       - map: [ "maskalt" ]
       - map: [ "enum.HumanoidVisualLayers.Hair" ]
       - map: [ "mask" ]

--- a/Resources/Prototypes/_DV/Species/harpy.yml
+++ b/Resources/Prototypes/_DV/Species/harpy.yml
@@ -58,7 +58,8 @@
     RLeg: MobHarpyRLeg
     LFoot: MobHarpyLFoot
     RFoot: MobHarpyRFoot
-
+    Wings: MobHumanoidAnyMarking
+ 
 - type: markingPoints
   id: MobHarpyMarkingLimits
   points:
@@ -71,6 +72,12 @@
     Snout:
       points: 1
       required: false
+ # Omu Start - Goat
+    Wings:
+      points: 1
+      required: true
+      defaultMarkings: [ HarpyWingDefaultHuescale ]
+ # Omu End - Goat
     Tail:
       points: 1
       required: true
@@ -104,10 +111,6 @@
     LeftFoot:
       points: 2
       required: false
-    RightArm:
-      points: 1
-      required: false
-      defaultMarkings: [ HarpyWingDefaultHuescale ]
     RightHand:
       points: 3
       required: false

--- a/Resources/Prototypes/_DV/Species/harpy.yml
+++ b/Resources/Prototypes/_DV/Species/harpy.yml
@@ -108,9 +108,15 @@
     LeftLeg:
       points: 2
       required: false
+#Omu start - harpy wings moved to wings body part
 #    LeftFoot:
 #      points: 2
 #      required: false
+#    RightArm:
+#      points: 1
+#      required: false
+#      defaultMarkings: [ HarpyWingDefaultHuescale ]
+# Omu End - harpy wings moved to wings body part
     RightHand:
       points: 3
       required: false

--- a/Resources/Prototypes/_DV/Species/harpy.yml
+++ b/Resources/Prototypes/_DV/Species/harpy.yml
@@ -108,15 +108,13 @@
     LeftLeg:
       points: 2
       required: false
-#Omu start - harpy wings moved to wings body part
-#    LeftFoot:
-#      points: 2
-#      required: false
-#    RightArm:
-#      points: 1
-#      required: false
-#      defaultMarkings: [ HarpyWingDefaultHuescale ]
-# Omu End - harpy wings moved to wings body part
+    LeftFoot:
+      points: 2
+      required: false
+    RightArm:
+      points: 1
+      required: false
+      #defaultMarkings: [ HarpyWingDefaultHuescale ] # Omu - moved to Wings slot
     RightHand:
       points: 3
       required: false

--- a/Resources/Prototypes/_DV/Species/harpy.yml
+++ b/Resources/Prototypes/_DV/Species/harpy.yml
@@ -108,9 +108,9 @@
     LeftLeg:
       points: 2
       required: false
-    LeftFoot:
-      points: 2
-      required: false
+#    LeftFoot:
+#      points: 2
+#      required: false
     RightHand:
       points: 3
       required: false

--- a/Resources/Prototypes/_DV/Species/harpy.yml
+++ b/Resources/Prototypes/_DV/Species/harpy.yml
@@ -58,7 +58,7 @@
     RLeg: MobHarpyRLeg
     LFoot: MobHarpyLFoot
     RFoot: MobHarpyRFoot
-    Wings: MobHumanoidAnyMarking
+    Wings: MobHumanoidAnyMarking #Omu - Goat
  
 - type: markingPoints
   id: MobHarpyMarkingLimits

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Customization/Markings/harpy.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Customization/Markings/harpy.yml
@@ -13,7 +13,7 @@
 # Ears Markings
 - type: marking
   id: HarpyWingDefaultHuescale
-  bodyPart: RArm
+  bodyPart: Wings # Omu - Goat
   markingCategory: Wings # Goob - Wings category
   speciesRestriction: [Harpy]
   coloring:
@@ -30,8 +30,8 @@
 
 - type: marking
   id: HarpyWingDefaultWhitescale
-  bodyPart: RArm
-  markingCategory: Wings # Goob - Wings category
+  bodyPart: Wings # Omu - Goat
+  markingCategory: Chest # Goob - Wings category
   speciesRestriction: [Harpy]
   coloring:
     default:
@@ -47,7 +47,7 @@
 
 - type: marking
   id: HarpyWingClassic
-  bodyPart: RArm
+  bodyPart: Wings # Omu - Goat
   markingCategory: Wings # Goob - Wings category
   speciesRestriction: [Harpy]
   coloring:
@@ -64,7 +64,7 @@
 
 - type: marking
   id: HarpyWingFoldedHuescale
-  bodyPart: RArm
+  bodyPart: Wings # Omu - Goat
   markingCategory: Wings # Goob - Wings category
   speciesRestriction: [Harpy]
   coloring:
@@ -81,7 +81,7 @@
 
 - type: marking
   id: HarpyWingFoldedWhitescale
-  bodyPart: RArm
+  bodyPart: Wings # Omu - Goat
   markingCategory: Wings # Goob - Wings category
   speciesRestriction: [Harpy]
   coloring:
@@ -98,7 +98,7 @@
 
 - type: marking
   id: HarpyWingOwlHuescale
-  bodyPart: RArm
+  bodyPart: Wings # Omu - Goat
   markingCategory: Wings # Goob - Wings category
   speciesRestriction: [Harpy]
   coloring:
@@ -115,7 +115,7 @@
 
 - type: marking
   id: HarpyWingOwlWhitescale
-  bodyPart: RArm
+  bodyPart: Wings # Omu - Goat
   markingCategory: Wings # Goob - Wings category
   speciesRestriction: [Harpy]
   coloring:
@@ -249,7 +249,7 @@
 
 - type: marking
   id: HarpyWing2ToneClassic
-  bodyPart: RArm
+  bodyPart: Wings # Omu - Goat
   markingCategory: Wings # Goob - Wings category
   speciesRestriction: [Harpy]
   sprites:
@@ -260,7 +260,7 @@
 
 - type: marking
   id: HarpyWing3ToneClassic
-  bodyPart: RArm
+  bodyPart: Wings # Omu - Goat
   markingCategory: Wings # Goob - Wings category
   speciesRestriction: [Harpy]
   sprites:
@@ -273,7 +273,7 @@
 
 - type: marking
   id: HarpyWingSpeckledClassic
-  bodyPart: RArm
+  bodyPart: Wings # Omu - Goat
   markingCategory: Wings # Goob - Wings category
   speciesRestriction: [Harpy]
   sprites:
@@ -284,7 +284,7 @@
 
 - type: marking
   id: HarpyWingUndertoneClassic
-  bodyPart: RArm
+  bodyPart: Wings # Omu - Goat
   markingCategory: Wings # Goob - Wings category
   speciesRestriction: [Harpy]
   sprites:
@@ -295,7 +295,7 @@
 
 - type: marking
   id: HarpyWingTipsClassic
-  bodyPart: RArm
+  bodyPart: Wings # Omu - Goat
   markingCategory: Wings # Goob - Wings category
   speciesRestriction: [Harpy]
   sprites:
@@ -306,7 +306,7 @@
 
 - type: marking
   id: HarpyWingBat
-  bodyPart: RArm
+  bodyPart: Wings # Omu - Goat
   markingCategory: Wings # Goob - Wings category
   speciesRestriction: [Harpy]
   sprites:
@@ -317,7 +317,7 @@
 
 - type: marking
   id: HarpyWingBionic
-  bodyPart: RArm
+  bodyPart: Wings # Omu - Goat
   markingCategory: Wings # Goob - Wings category
   speciesRestriction: [Harpy]
   sprites:

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Customization/Markings/harpy.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Customization/Markings/harpy.yml
@@ -31,7 +31,7 @@
 - type: marking
   id: HarpyWingDefaultWhitescale
   bodyPart: Wings # Omu - Goat
-  markingCategory: Chest # Goob - Wings category
+  markingCategory: Wings # Omu - Goat
   speciesRestriction: [Harpy]
   coloring:
     default:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
- Fixed it so that harpy default wings disappear when choosing a different wing
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Because the default wing didn't disappear so it looked like harpies had multiple sets of wings
## Technical details
<!-- Summary of code changes for easier review. -->
- In harpy.yml species files added Wings as a body part category and moved the wings to display from Right arm to wings.
- in Harpy.yml markings files changed the body part from RArm to Wings
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1576" height="511" alt="image" src="https://github.com/user-attachments/assets/70d9bfe4-c946-44c3-ac39-177f62836999" />
<img width="221" height="308" alt="image" src="https://github.com/user-attachments/assets/3e9221be-1281-4675-8871-d84d350fcec4" />
<img width="247" height="301" alt="image" src="https://github.com/user-attachments/assets/7a73a0d4-ba45-4a43-8124-c094513ea06b" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fixed default wings for Harpy not disappearing when selecting a different type of wing.