### PR TITLE
Giving Moths and Reptilians hair.

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -128,6 +128,7 @@
     species: Moth
     hideLayersOnEquip:
     - HeadTop
+    - Hair #Omu - Giving reptilians and moth hair
   - type: Hunger
   - type: Thirst
   - type: Icon

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -139,6 +139,7 @@
     hideLayersOnEquip:
     - Snout
 #    - HeadTop # WWDP - Because visible horns its cool
+    - Hair #Omu - Giving reptilians and moth hair
     - HeadSide
   - type: Hunger
   - type: Puller
@@ -253,6 +254,7 @@
     hideLayersOnEquip: # WWDP
     - Snout
 #    - HeadTop # WWDP - Because visible horns its cool
+    - Hair #Omu - Giving reptilians and moth hair
     - HeadSide
   - type: Inventory
     speciesId: reptilian

--- a/Resources/Prototypes/Species/moth.yml
+++ b/Resources/Prototypes/Species/moth.yml
@@ -45,6 +45,10 @@
   id: MobMothSprites
   sprites:
     Head: MobMothHead
+    #Omu Start - Giving reptilians and moth hair
+    Hair: MobHumanoidAnyMarking
+    #FacialHair: MobHumanoidAnyMarking // Facial hair doesn't work with the neck fluff of moths
+    #Omu End - Giving reptilians and moth hair
     Face: MobHumanoidAnyMarking
     Snout: MobHumanoidAnyMarking
     Underwear: MobHumanoidAnyMarking
@@ -72,14 +76,16 @@
 
 - type: markingPoints
   id: MobMothMarkingLimits
-  onlyWhitelisted: true
+  # onlyWhitelisted: true //Omu - Giving reptilians and moth hair
   points:
     Hair:
-      points: 0
+      points: 1 #Omu - Giving reptilians and moth hair
       required: false
-    FacialHair:
-      points: 0
-      required: false
+    #Omu start - commented so that the menu doesn't show up.
+ #   FacialHair:
+ #     points: 0
+  #    required: false
+    #Omu end - commented so that the menu doesn't show up.
     Tail:
       points: 1
       required: true

--- a/Resources/Prototypes/Species/reptilian.yml
+++ b/Resources/Prototypes/Species/reptilian.yml
@@ -38,6 +38,10 @@
   id: MobReptilianSprites
   sprites:
     Head: MobReptilianHead
+    #Omu Start - Giving reptilians and moth hair
+    Hair: MobHumanoidAnyMarking
+    FacialHair: MobHumanoidAnyMarking
+    #Omu End - Giving reptilians and moth hair
     Face: MobHumanoidAnyMarking
     Snout: MobHumanoidAnyMarking
     Underwear: MobHumanoidAnyMarking
@@ -60,13 +64,13 @@
 
 - type: markingPoints
   id: MobReptilianMarkingLimits
-  onlyWhitelisted: true
+  # onlyWhitelisted: true // Omu - Giving reptilians and moth hair
   points:
     Hair:
-      points: 0
+      points: 1 #Omu - Giving reptilians and moth hair
       required: false
     FacialHair:
-      points: 0
+      points: 1 #Omu - Giving reptilians and moth hair
       required: false
     Tail:
       points: 1


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
- added hair to Moth Person customization.
- added hair and facial hair to Reptilian customization.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Because someone suggested it on Discord and thought it would be neat.
## Technical details
<!-- Summary of code changes for easier review. -->
Added a hair slot and a marking sprite info to moth.yml at "Resources\Prototypes\Species\moth.yml"
Added a hair and facial hair slot and a marking sprite info to reptilian.yml at "Resources\Prototypes\Species\reptilian.yml"
Added hair being hidden when hats are equipped for Moths at "Resources\Prototypes\Entities\Mobs\Species\moth.yml"
Added hair being hidden when hats are equipped for Reptilians at "Resources\Prototypes\Entities\Mobs\Species\reptilian.yml"
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1766" height="866" alt="Screenshot 2026-06-29 105805" src="https://github.com/user-attachments/assets/453d3f43-83ed-4373-99e2-cfd531c2648c" />
<img width="1814" height="874" alt="Screenshot 2026-06-29 105950" src="https://github.com/user-attachments/assets/0804f1fc-f775-4be9-a7b1-047b85a821b0" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Added the ability for Moths to have hair.
-  add: Added the ability for Reptilians to have hair and facial hair.