### PR TITLE
Moth wings moved to wing part

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/moth.yml
@@ -187,8 +187,8 @@
 # Wings
 - type: marking
   id: MothWingsDefault
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
@@ -196,8 +196,8 @@
 
 - type: marking
   id: MothWingsCharred
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
@@ -205,8 +205,8 @@
 
 - type: marking
   id: MothWingsDbushy
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
@@ -216,8 +216,8 @@
 
 - type: marking
   id: MothWingsDeathhead
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
@@ -227,8 +227,8 @@
 
 - type: marking
   id: MothWingsFan
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
@@ -236,8 +236,8 @@
 
 - type: marking
   id: MothWingsDfan
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
@@ -245,8 +245,8 @@
 
 - type: marking
   id: MothWingsFeathery
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
@@ -254,8 +254,8 @@
 
 - type: marking
   id: MothWingsFirewatch
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
@@ -265,8 +265,8 @@
 
 - type: marking
   id: MothWingsGothic
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
@@ -274,8 +274,8 @@
 
 - type: marking
   id: MothWingsJungle
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
@@ -283,8 +283,8 @@
 
 - type: marking
   id: MothWingsLadybug
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
@@ -292,8 +292,8 @@
 
 - type: marking
   id: MothWingsMaple
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
@@ -303,8 +303,8 @@
 
 - type: marking
   id: MothWingsMoffra
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
@@ -314,8 +314,8 @@
 
 - type: marking
   id: MothWingsOakworm
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
@@ -323,8 +323,8 @@
 
 - type: marking
   id: MothWingsPlasmafire
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
@@ -334,8 +334,8 @@
 
 - type: marking
   id: MothWingsPointy
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
@@ -343,8 +343,8 @@
 
 - type: marking
   id: MothWingsRoyal
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
@@ -354,8 +354,8 @@
 
 - type: marking
   id: MothWingsStellar
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
@@ -363,8 +363,8 @@
 
 - type: marking
   id: MothWingsStriped
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
@@ -372,8 +372,8 @@
 
 - type: marking
   id: MothWingsSwirly
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
@@ -381,8 +381,8 @@
 
 - type: marking
   id: MothWingsWhitefly
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
@@ -390,8 +390,8 @@
 
 - type: marking
   id: MothWingsWitchwing
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
@@ -399,8 +399,8 @@
 
 - type: marking
   id: MothWingsUnderwing
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -233,6 +233,7 @@
       - map: [ "outerClothing" ]
       - map: [ "beltalt" ] # Omu change.
       - map: [ "enum.HumanoidVisualLayers.Wings" ] #Omu - change Tail to Wings
+      - map: [ "enum.HumanoidVisualLayers.Tail" ]
       - map: [ "back" ]
       - map: [ "neck" ]
       - map: [ "enum.HumanoidVisualLayers.Face" ]

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -232,7 +232,7 @@
       - map: [ "id" ]
       - map: [ "outerClothing" ]
       - map: [ "beltalt" ] # Omu change.
-      - map: [ "enum.HumanoidVisualLayers.Tail" ] #in the utopian future we should probably have a wings enum inserted here so everyhting doesn't break
+      - map: [ "enum.HumanoidVisualLayers.Wings" ] #Omu - change Tail to Wings
       - map: [ "back" ]
       - map: [ "neck" ]
       - map: [ "enum.HumanoidVisualLayers.Face" ]

--- a/Resources/Prototypes/Species/moth.yml
+++ b/Resources/Prototypes/Species/moth.yml
@@ -53,7 +53,7 @@
     Groin: MobMothGroin
     HeadTop: MobHumanoidAnyMarking
     HeadSide: MobHumanoidAnyMarking
-    #Tail: MobHumanoidAnyMarking // Omu - moving moth wings to Wings body part
+    Tail: MobHumanoidAnyMarking # Omu - moving moth wings to Wings body part
     Eyes: MobMothEyes
     LArm: MobMothLArm
     RArm: MobMothRArm
@@ -88,9 +88,9 @@
       defaultMarkings: [ MothWingsDefault ]      
     #Omu End - Moving moth wings to Wings body part
     #Omu start - moving moth wings to Wings body part
-#    Tail:
-#      points: 1 
-#      required: false
+    Tail:
+      points: 1 
+      required: false
 #      defaultMarkings: [ MothWingsDefault ]  // Omu - Moving moth wings to Wings body part
     #Omu end - moving moth wings to Wings body part
     Snout:

--- a/Resources/Prototypes/Species/moth.yml
+++ b/Resources/Prototypes/Species/moth.yml
@@ -53,7 +53,7 @@
     Groin: MobMothGroin
     HeadTop: MobHumanoidAnyMarking
     HeadSide: MobHumanoidAnyMarking
-    Tail: MobHumanoidAnyMarking
+    #Tail: MobHumanoidAnyMarking // Omu - moving moth wings to Wings body part
     Eyes: MobMothEyes
     LArm: MobMothLArm
     RArm: MobMothRArm
@@ -63,6 +63,7 @@
     RLeg: MobMothRLeg
     LFoot: MobMothLFoot
     RFoot: MobMothRFoot
+    Wings: MobHumanoidAnyMarking #Omu - Moving moth wings to Wings body part
 
 - type: humanoidBaseSprite
   id: MobMothEyes
@@ -80,10 +81,18 @@
     FacialHair:
       points: 0
       required: false
-    Tail:
+    #Omu Start - Moving moth wings to Wings body part
+    Wings:
       points: 1
       required: true
-      defaultMarkings: [ MothWingsDefault ]
+      defaultMarkings: [ MothWingsDefault ]      
+    #Omu End - Moving moth wings to Wings body part
+    #Omu start - moving moth wings to Wings body part
+#    Tail:
+#      points: 1 
+#      required: false
+#      defaultMarkings: [ MothWingsDefault ]  // Omu - Moving moth wings to Wings body part
+    #Omu end - moving moth wings to Wings body part
     Snout:
       points: 1
       required: false

--- a/Resources/Prototypes/Species/moth.yml
+++ b/Resources/Prototypes/Species/moth.yml
@@ -53,7 +53,7 @@
     Groin: MobMothGroin
     HeadTop: MobHumanoidAnyMarking
     HeadSide: MobHumanoidAnyMarking
-    Tail: MobHumanoidAnyMarking # Omu - moving moth wings to Wings body part
+    Tail: MobHumanoidAnyMarking
     Eyes: MobMothEyes
     LArm: MobMothLArm
     RArm: MobMothRArm
@@ -87,12 +87,10 @@
       required: true
       defaultMarkings: [ MothWingsDefault ]      
     #Omu End - Moving moth wings to Wings body part
-    #Omu start - moving moth wings to Wings body part
     Tail:
       points: 1 
       required: false
 #      defaultMarkings: [ MothWingsDefault ]  // Omu - Moving moth wings to Wings body part
-    #Omu end - moving moth wings to Wings body part
     Snout:
       points: 1
       required: false

--- a/Resources/Prototypes/_Imp/Mobs/Customization/moth.yml
+++ b/Resources/Prototypes/_Imp/Mobs/Customization/moth.yml
@@ -571,8 +571,8 @@
 
 - type: marking
   id: LunaWings
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [ Moth ]
   sprites:
   - sprite: _Impstation/Mobs/Customization/Moth/tail.rsi
@@ -582,8 +582,8 @@
 
 - type: marking
   id: MothBee
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [ Moth ]
   sprites:
   - sprite: _Impstation/Mobs/Customization/Moth/tail.rsi
@@ -595,8 +595,8 @@
 
 - type: marking
   id: MothBeetleTail
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [ Moth ]
   sprites:
   - sprite: _Impstation/Mobs/Customization/Moth/tail.rsi
@@ -608,8 +608,8 @@
 
 - type: marking
   id: MothFirefly
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [ Moth ]
   sprites:
   - sprite: _Impstation/Mobs/Customization/Moth/tail.rsi
@@ -617,7 +617,7 @@
 
 - type: marking
   id: MothFireflyOverlay
-  bodyPart: Tail
+  bodyPart: Wings #Omu - Tail to Wings
   markingCategory: Overlay
   speciesRestriction: [ Moth ]
   sprites:
@@ -627,8 +627,8 @@
 
 - type: marking
   id: MothGlasswing
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [ Moth ]
   sprites:
   - sprite: _Impstation/Mobs/Customization/Moth/tail.rsi
@@ -640,8 +640,8 @@
 
 - type: marking
   id: MothRhinoBeetle
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [ Moth ]
   sprites:
   - sprite: _Impstation/Mobs/Customization/Moth/tail.rsi
@@ -653,8 +653,8 @@
 
 - type: marking
   id: MothSnoth
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [ Moth ]
   sprites:
   - sprite: _Impstation/Mobs/Customization/Moth/tail.rsi
@@ -664,8 +664,8 @@
 
 - type: marking
   id: MothTrueButterfly
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [ Moth ]
   sprites:
   - sprite: _Impstation/Mobs/Customization/Moth/tail.rsi
@@ -677,8 +677,8 @@
 
 - type: marking
   id: WingsBackstabbed
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [ Moth ]
   sprites:
   - sprite: _Impstation/Mobs/Customization/Moth/tail.rsi
@@ -686,8 +686,8 @@
 
 - type: marking
   id: WingsDragonfly
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [ Moth ]
   sprites:
   - sprite: _Impstation/Mobs/Customization/Moth/tail.rsi
@@ -699,8 +699,8 @@
 
 - type: marking
   id: WingsFly
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [ Moth ]
   sprites:
   - sprite: _Impstation/Mobs/Customization/Moth/tail.rsi
@@ -712,8 +712,8 @@
 
 - type: marking
   id: WingsLanternfly
-  bodyPart: Tail
-  markingCategory: Tail
+  bodyPart: Wings #Omu - Tail to Wings
+  markingCategory: Wings #Omu - Tail to Wings
   speciesRestriction: [ Moth ]
   sprites:
   - sprite: _Impstation/Mobs/Customization/Moth/tail.rsi


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
- moved moth wings to Wing marking category and body part
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Because it was under "Tail" and didn't make sense
## Technical details
<!-- Summary of code changes for easier review. -->
changed the bodypart and marking category from Tail to Wings on the wings in moth.yml:
"Resources/Prototypes/Entities/Mobs/Customization/Markings/moth.yml"
changed the bodypart and marking category from Tail to Wings on the wings in moth.yml: "Resources/Prototypes/_Imp/Mobs/Customization/moth.yml"
added "Wing" body part and slot to moth.yml: "Resources/Prototypes/Species/moth.yml"
changed tail to wings in the layering moth.yml: "Resources/Prototypes/Entities/Mobs/Species/moth.yml"
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1812" height="852" alt="image" src="https://github.com/user-attachments/assets/1285dc2a-6daf-4c08-b4b8-ced5ebf2d5d2" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Changed moth wings to be under Wings marking.