### PR TITLE
Buff Hercuri

### DIFF
--- a/Resources/Prototypes/_Goobstation/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Goobstation/Reagents/medicine.yml
@@ -1212,6 +1212,7 @@
   plantMetabolism:
     - !type:PlantAdjustHealth
       amount: -10
+  worksOnTheDead: true # Omu
   reactiveEffects:
     Extinguish:
       methods: [ Touch ]
@@ -1252,7 +1253,14 @@
       - !type:AdjustTemperature
         conditions:
         - !type:Temperature
-          min: 160.15 # entire syringe lands you at -20 degrees celcius, not incredibly dangerous
+          min: 73.15 # Omu, this is the minimum temperature of a standard freezer; it takes a lot of herc to cool someone alive anyways
+        amount: -10000
+      - !type:AdjustTemperature # Omu, doubled cooling on corpses
+        conditions:
+        - !type:Temperature
+          min: 73.15
+        - !type:MobStateCondition
+          mobstate: Dead
         amount: -10000
       - !type:AdjustSolutionThermalEnergyEffect
         delta: -150


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
- hercuri works on dead people
- hercuri cools to 73.15K (freezer temp)
- hercuri has doubled cooling potential on dead people (similar to how cryox has doubled effectiveness on dead)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
in its current form, hercuri is genuinely one of the least useful chems for its cost (plasma, which at times is limited, and ice, which is non-renewable for chemistry since it requires frezon; ice must be begged for from the bartender)
giving hercuri the ability to cool people down to opporozidone temperatures would greatly help for insulated people and pets (since i think you can't cryo hamlet). it would make hercuri genuinely worthwhile to consider for its massive cost

## Technical details
<!-- Summary of code changes for easier review. -->
changed `Resources/Prototypes/_Goobstation/Reagents/medicine.yml`

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="967" height="309" alt="image" src="https://github.com/user-attachments/assets/2838e582-6b2e-4aac-b27f-c42d2f82cb57" />
videos of this working are too large. please see https://discord.com/channels/1406768242843979816/1521220671097667716/1521239369556557885 in the omucord for the mp4s of herc doing its thing

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Duuckie
- tweak: Hercuri in the bloodstream now works on dead people, can cool down to 73.15K, and cools corpses twice as much as alive people.

