### PR TITLE
more abductor glands a few changes to the abductor shuttles (don't merge yet)

### DIFF
--- a/Resources/Maps/_Omu/Shuttles/ShuttleEvent/abductor_shuttle.yml
+++ b/Resources/Maps/_Omu/Shuttles/ShuttleEvent/abductor_shuttle.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 266.0.0
   forkId: ""
   forkVersion: ""
-  time: 05/18/2026 16:25:03
-  entityCount: 262
+  time: 07/01/2026 02:15:05
+  entityCount: 261
 maps:
 - 1
 grids:
@@ -702,7 +702,7 @@ entities:
     - type: Transform
       pos: -3.7265432,1.5118785
       parent: 2
-- proto: ComputerIFF
+- proto: ComputerIFFSyndicate
   entities:
   - uid: 94
     components:
@@ -726,7 +726,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-- proto: DubiousOrganSpawner
+- proto: DubiousGlandSpawnerOmu
   entities:
   - uid: 96
     components:
@@ -1113,28 +1113,6 @@ entities:
     - type: Transform
       pos: 1.5,2.5
       parent: 2
-- proto: ReinforcedUraniumWindow
-  entities:
-  - uid: 75
-    components:
-    - type: Transform
-      pos: 1.5,-4.5
-      parent: 2
-  - uid: 243
-    components:
-    - type: Transform
-      pos: 3.5,5.5
-      parent: 2
-  - uid: 245
-    components:
-    - type: Transform
-      pos: 5.5,3.5
-      parent: 2
-  - uid: 254
-    components:
-    - type: Transform
-      pos: 5.5,-0.5
-      parent: 2
 - proto: PlushieAbductor
   entities:
   - uid: 145
@@ -1199,6 +1177,28 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,1.5
+      parent: 2
+- proto: ReinforcedUraniumWindow
+  entities:
+  - uid: 75
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 2
+  - uid: 243
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 2
+  - uid: 245
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 2
+  - uid: 254
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
       parent: 2
 - proto: SecurityCyberneticEyes
   entities:
@@ -1366,6 +1366,14 @@ entities:
     components:
     - type: Transform
       pos: -0.5,6.5
+      parent: 2
+- proto: TurboItemRecharger
+  entities:
+  - uid: 258
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,0.5
       parent: 2
 - proto: WallAbductor
   entities:

--- a/Resources/Maps/_Omu/Shuttles/ShuttleEvent/abductor_shuttle.yml
+++ b/Resources/Maps/_Omu/Shuttles/ShuttleEvent/abductor_shuttle.yml
@@ -702,7 +702,7 @@ entities:
     - type: Transform
       pos: -3.7265432,1.5118785
       parent: 2
-- proto: ComputerIFFSyndicate
+- proto: ComputerIFF
   entities:
   - uid: 94
     components:

--- a/Resources/Maps/_Omu/Shuttles/ShuttleEvent/duo_abductor_shuttle.yml
+++ b/Resources/Maps/_Omu/Shuttles/ShuttleEvent/duo_abductor_shuttle.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 266.0.0
   forkId: ""
   forkVersion: ""
-  time: 05/18/2026 16:25:03
+  time: 07/01/2026 02:17:15
   entityCount: 262
 maps:
 - 1
@@ -702,7 +702,7 @@ entities:
     - type: Transform
       pos: -3.7265432,1.5118785
       parent: 2
-- proto: ComputerIFF
+- proto: ComputerIFFSyndicate
   entities:
   - uid: 94
     components:
@@ -726,7 +726,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-- proto: DubiousOrganSpawner
+- proto: DubiousGlandSpawnerOmu
   entities:
   - uid: 96
     components:
@@ -744,6 +744,11 @@ entities:
       pos: -2.5,0.5
       parent: 2
   - uid: 99
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 2
+  - uid: 101
     components:
     - type: Transform
       pos: -2.5,0.5
@@ -769,11 +774,6 @@ entities:
       pos: -2.5,0.5
       parent: 2
   - uid: 142
-    components:
-    - type: Transform
-      pos: -2.5,0.5
-      parent: 2
-  - uid: 146
     components:
     - type: Transform
       pos: -2.5,0.5
@@ -1113,28 +1113,6 @@ entities:
     - type: Transform
       pos: 1.5,2.5
       parent: 2
-- proto: ReinforcedUraniumWindow
-  entities:
-  - uid: 75
-    components:
-    - type: Transform
-      pos: 1.5,-4.5
-      parent: 2
-  - uid: 243
-    components:
-    - type: Transform
-      pos: 3.5,5.5
-      parent: 2
-  - uid: 245
-    components:
-    - type: Transform
-      pos: 5.5,3.5
-      parent: 2
-  - uid: 254
-    components:
-    - type: Transform
-      pos: 5.5,-0.5
-      parent: 2
 - proto: PlushieAbductor
   entities:
   - uid: 145
@@ -1199,6 +1177,28 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,1.5
+      parent: 2
+- proto: ReinforcedUraniumWindow
+  entities:
+  - uid: 75
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 2
+  - uid: 243
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 2
+  - uid: 245
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 2
+  - uid: 254
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
       parent: 2
 - proto: SecurityCyberneticEyes
   entities:
@@ -1373,6 +1373,14 @@ entities:
     components:
     - type: Transform
       pos: -0.5,6.5
+      parent: 2
+- proto: TurboItemRecharger
+  entities:
+  - uid: 146
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,0.5
       parent: 2
 - proto: WallAbductor
   entities:

--- a/Resources/Maps/_Omu/Shuttles/ShuttleEvent/duo_abductor_shuttle.yml
+++ b/Resources/Maps/_Omu/Shuttles/ShuttleEvent/duo_abductor_shuttle.yml
@@ -702,7 +702,7 @@ entities:
     - type: Transform
       pos: -3.7265432,1.5118785
       parent: 2
-- proto: ComputerIFFSyndicate
+- proto: ComputerIFF
   entities:
   - uid: 94
     components:

--- a/Resources/Prototypes/_Omu/Body/Organs/dubious.yml
+++ b/Resources/Prototypes/_Omu/Body/Organs/dubious.yml
@@ -31,6 +31,7 @@
     - type: IntrinsicRadioTransmitter #so they can state laws in common.
       channels:
       - Common
+      - Science
 
 - type: entity
   id: OrganDubiousAllHearing #gives all radios, languages, and most hiveminds
@@ -43,7 +44,16 @@
     - type: IntrinsicRadioReceiver
     - type: IntrinsicRadioTransmitter
     - type: ActiveRadio
-      receiveAllChannels: true
+      channels:
+      - Common
+      - Command
+      - CentCom
+      - Engineering
+      - Medical
+      - Science
+      - Security
+      - Service
+      - Supply
       globalReceive: true
     - type: CollectiveMind
       defaultChannel: Abductormind
@@ -59,8 +69,6 @@
       - Blobmind
       - MansusLink
       - Binglemind
-      - Shadowmind
-      - Xenomorphivemind
       hearAll: true
       seeAllNames: true
     - type: TowerOfBabel

--- a/Resources/Prototypes/_Omu/Body/Organs/dubious.yml
+++ b/Resources/Prototypes/_Omu/Body/Organs/dubious.yml
@@ -238,3 +238,51 @@
   - type: Organ
     onAdd:
     - type: Clumsy
+
+- type: entity
+  id: OrganDubiousPowerGen # I can already sense CE and QM foaming at the mouth with this one
+  parent: OrganDubiousBase
+  components:
+  - type: Sprite
+    state: egg
+  - type: Organ
+    onAdd:
+    - type: NodeContainer
+      examinable: true
+      nodes:
+        output:
+          !type:CableDeviceNode
+          nodeGroupID:
+          - HVPower
+    - type: PowerMonitoringDevice
+      group: Generator
+      loadNode: output
+      state: static
+    - type: PowerSupplier #engineering would like to know your location
+      supplyRate: 200000 # remember. this is a person, a person who odds are don't want to spend the next 40 minutes anchored to the ground
+      supplyRampRate: 500
+      supplyRampTolerance: 500
+    - type: Anchorable
+    - type: Insulated
+
+- type: entity
+  id: OrganDubiousSlippery # Honkbot incarnate (everyone is going to hate you)
+  parent: OrganDubiousBase
+  components:
+  - type: Sprite
+    state: egg
+  - type: Organ
+    onAdd:
+    - type: Slippery
+      staminaDamage: 10 #default is 25
+      slipData:
+        knockdownTime: 1.0
+        launchForwardsMultiplier: 10.0
+    - type: StepTrigger
+      intersectRatio: 0.2
+      triggerGroups:
+        types:
+        - SlipEntity
+  - type: OrganInsertOnUse
+    slotId: heart
+    partType: Chest

--- a/Resources/Prototypes/_Omu/Body/Organs/dubious.yml
+++ b/Resources/Prototypes/_Omu/Body/Organs/dubious.yml
@@ -1,0 +1,204 @@
+
+- type: entity
+  id: OrganDubiousLawbound #makes them lawbound like cyborgs and station AI
+  parent: OrganDubiousBase
+  components:
+  - type: Sprite
+    state: mindshock
+  - type: Organ
+    onAdd:
+    - type: UserInterface
+      interfaces:
+        enum.SiliconLawsUiKey.Key:
+          type: SiliconLawBoundUserInterface
+    - type: ShowJobIcons
+    - type: SiliconLawBound
+    - type: SiliconLawProvider
+      laws: Crewsimov
+    - type: SlavedBorg
+      law: ObeyAI
+    - type: IonStormTarget
+    - type: CollectiveMind #if they are going to be enslaved to the AI they should have binary
+      defaultChannel: Binary
+      channels:
+      - Binary
+    - type: ActionGrant
+      actions:
+      - ActionViewLaws
+    - type: IntrinsicRadioTransmitter
+      channels:
+      - Common
+  - type: OrganInsertOnUse
+    slotId: heart
+    partType: Chest
+
+- type: entity
+  id: OrganDubiousAllHearingGood #gives all radios, languages, and most hiveminds
+  parent: OrganDubiousBase
+  components:
+  - type: Sprite
+    state: mindshock
+  - type: Organ
+    onAdd:
+    - type: IntrinsicRadioReceiver
+    - type: IntrinsicRadioTransmitter
+    - type: ActiveRadio
+      receiveAllChannels: true
+      globalReceive: true
+    - type: CollectiveMind
+      defaultChannel: Abductormind
+      channels:
+      - Abductormind # if you went though all the hassle of them probing you should at least share some "choice" words with them
+      - Binary
+      - Tidemind
+      - Empathy
+      - Dronemind
+      - Mousemind
+      - Dragonmind #antag hiveminds
+      - Lingmind
+      - Blobmind
+      - MansusLink
+      - Binglemind
+      - Shadowmind
+      - Xenomorphivemind
+      hearAll: true
+      seeAllNames: true
+    - type: TowerOfBabel
+    - type: LanguageSpeaker
+  - type: OrganInsertOnUse
+    slotId: heart
+    partType: Chest
+
+- type: entity
+  id: OrganDubiousTelepathic #mutes but gives them demonic wisper. idealy I would had made the wisper it's own generic system but that would require C# so it's a future TODO
+  parent: OrganDubiousBase
+  components:
+  - type: Sprite
+    state: mindshock
+  - type: Organ
+    onAdd:
+    - type: LanguageKnowledge
+      speaks:
+      - TauCetiBasic
+      understands:
+      - TauCetiBasic
+      - Canilunzt
+      - Bubblish
+      - Nekomimetic
+      - Draconic
+      - SolCommon
+      - RootSpeak
+      - Moffic
+      - ValyrianStandard
+      - Chittin
+      - SiikMaas
+      - RobotTalk
+      - Marish
+      - Elyran
+      - Freespeak
+      - Tradeband
+      - Schechi
+      - NewKinPidgin
+      - NovuNederic
+      - Sign
+      - Xeeplian #gleep glorp skill issue
+    - type: CollectiveMind
+      defaultChannel: Empathy # at least they can speak to the Mar crew
+      channels:
+      - Empathy
+    - type: Muted
+    - type: LanguageSpeaker
+    - type: TranslatorImplantBlocker #so they can't just grab a sign translater implant and circumvent the mute
+    - type: DemonicWhisper
+  - type: OrganActions
+    actions:
+    - DemonicWhisperAction
+  - type: OrganInsertOnUse
+    slotId: heart
+    partType: Chest
+
+- type: entity
+  id: OrganDubiousGun # Space Station 14: Become gun
+  parent: OrganDubiousBase
+  components:
+  - type: Sprite
+    state: species
+  - type: Organ
+    onAdd:
+    - type: Item
+      size: Huge
+      shape:
+      - 2,0,4,0
+    - type: AmmoCounter
+    - type: Gun
+      fireRate: 2
+      selectedMode: SemiAuto
+      availableModes:
+      - SemiAuto
+    - type: BallisticAmmoProvider
+      whitelist:
+        tags:
+        - Cartridge # pretty much any ammo works
+        - Grenade
+        - BulletFoam # FoamForce compatible!
+      capacity: 5
+      soundInsert:
+        path: /Audio/Weapons/Guns/MagIn/shotgun_insert.ogg
+      soundRack:
+        path: /Audio/_Mono/Weapons/Guns/Cock/shotgun_cock.ogg
+        params:
+          volume: -3
+      autoCycle: false
+    - type: RestrictGunshotsByUserTag # No Onis. you can't shoot 12 Gauge out of the Avali.
+      doesntContain:
+      - Oni
+      messages:
+      - oni-cannot-shoot-guns-1
+      - oni-cannot-shoot-guns-2
+      - oni-cannot-shoot-guns-3
+    - type: AltFireMelee
+      attackType: Heavy
+    - type: MeleeWeapon
+      damage:
+        types:
+          Blunt: 12
+      angle: 0
+      wideAnimationRotation: 180
+      soundHit:
+        collection: MetalThud
+    - type: GunSpreadModifier
+      spread: 0.5
+    - type: GunRequiresWield
+    - type: Wieldable
+      unwieldOnUse: false
+  - type: OrganInsertOnUse
+    slotId: heart
+    partType: Chest
+
+#- type: entity
+#  id: OrganDubiousTelekinetic # great idea. need to figure out a way to incress interaction range while respecting walls and windows
+#  parent: OrganDubiousBase
+#  components:
+#  - type: Sprite
+#    state: mindshock
+#  - type: Organ
+#    onAdd:
+#    - type: Tag
+#      tags:
+#      - BypassInteractionRangeChecks
+#  - type: OrganInsertOnUse
+#    slotId: heart
+#    partType: Chest
+
+- type: entity
+  id: OrganDubiousAllHearingBad # might remove this one. Could get pretty bad for people who get overstimulated in this game
+  parent: OrganDubiousBase
+  components:
+  - type: Sprite
+    state: mindshock
+  - type: Organ
+    onAdd:
+    - type: GhostHearing
+  - type: OrganInsertOnUse
+    slotId: heart
+    partType: Chest

--- a/Resources/Prototypes/_Omu/Body/Organs/dubious.yml
+++ b/Resources/Prototypes/_Omu/Body/Organs/dubious.yml
@@ -283,6 +283,3 @@
       triggerGroups:
         types:
         - SlipEntity
-  - type: OrganInsertOnUse
-    slotId: heart
-    partType: Chest

--- a/Resources/Prototypes/_Omu/Body/Organs/dubious.yml
+++ b/Resources/Prototypes/_Omu/Body/Organs/dubious.yml
@@ -11,7 +11,7 @@
       interfaces:
         enum.SiliconLawsUiKey.Key:
           type: SiliconLawBoundUserInterface
-    - type: ShowJobIcons
+    - type: ShowJobIcons # so they can see who's crew
     - type: SiliconLawBound
     - type: SiliconLawProvider
       laws: Crewsimov
@@ -25,7 +25,7 @@
     - type: ActionGrant
       actions:
       - ActionViewLaws
-    - type: IntrinsicRadioTransmitter
+    - type: IntrinsicRadioTransmitter #so they can state laws on common to the AI.
       channels:
       - Common
   - type: OrganInsertOnUse
@@ -33,7 +33,7 @@
     partType: Chest
 
 - type: entity
-  id: OrganDubiousAllHearingGood #gives all radios, languages, and most hiveminds
+  id: OrganDubiousAllHearing #gives all radios, languages, and most hiveminds
   parent: OrganDubiousBase
   components:
   - type: Sprite
@@ -175,30 +175,82 @@
     slotId: heart
     partType: Chest
 
-#- type: entity
-#  id: OrganDubiousTelekinetic # great idea. need to figure out a way to incress interaction range while respecting walls and windows
-#  parent: OrganDubiousBase
-#  components:
-#  - type: Sprite
-#    state: mindshock
-#  - type: Organ
-#    onAdd:
-#    - type: Tag
-#      tags:
-#      - BypassInteractionRangeChecks
-#  - type: OrganInsertOnUse
-#    slotId: heart
-#    partType: Chest
-
 - type: entity
-  id: OrganDubiousAllHearingBad # might remove this one. Could get pretty bad for people who get overstimulated in this game
+  id: OrganDubiousTheVoices # might remove this one later. Could get pretty bad for people who get overstimulated in this game
   parent: OrganDubiousBase
   components:
   - type: Sprite
     state: mindshock
   - type: Organ
     onAdd:
-    - type: GhostHearing
+    - type: GhostHearing # Gets to hear all normal local, wispers, and emotes from everywhere and anywhere. No this doesn't let you hear dead chat
+  - type: OrganInsertOnUse
+    slotId: heart
+    partType: Chest
+
+- type: entity
+  id: OrganDubiousAllSeeing # sees ghosts, AI eye, abductor eye, normal HUD icons
+  parent: OrganDubiousBase
+  components:
+  - type: Sprite
+    state: mindshock
+  - type: Organ
+    onAdd:
+    - type: Eye #Warning. if this gland is not installed by a abductor. the victium will need to reconnect to fix there camera
+      visMask:
+        - Ghost
+        - Normal
+        - Abductor
+    - type: ShowElectrocutionHUD
+    - type: ShowHealthBars
+    - type: ShowHealthIcons
+    - type: ShowDiseaseIcons
+    - type: ShowJobIcons
+    - type: ShowMindShieldIcons
+    - type: ShowCriminalRecordIcons
+    - type: ShowContrabandDetails
+  - type: OrganInsertOnUse
+    slotId: heart
+    partType: Chest
+
+- type: entity
+  id: OrganDubiousFriendship # NPCs won't attack them
+  parent: OrganDubiousBase
+  components:
+  - type: Sprite
+    state: egg
+  - type: Organ
+    onAdd:
+    - type: NpcFactionMember
+      factions:
+      - AllFriendly
+  - type: OrganInsertOnUse
+    slotId: heart
+    partType: Chest
+
+- type: entity
+  id: OrganDubiousDroneVision # gives drone vision (everyone else appears as black silhouettes) and lets them see job icons to help them a little
+  parent: OrganDubiousBase
+  components:
+  - type: Sprite
+    state: egg
+  - type: Organ
+    onAdd:
+    - type: DroneVision
+    - type: ShowJobIcons
+  - type: OrganInsertOnUse
+    slotId: heart
+    partType: Chest
+
+- type: entity
+  id: OrganDubiousClumsy # makes them clumsy
+  parent: OrganDubiousBase
+  components:
+  - type: Sprite
+    state: egg
+  - type: Organ
+    onAdd:
+    - type: Clumsy
   - type: OrganInsertOnUse
     slotId: heart
     partType: Chest

--- a/Resources/Prototypes/_Omu/Body/Organs/dubious.yml
+++ b/Resources/Prototypes/_Omu/Body/Organs/dubious.yml
@@ -1,6 +1,7 @@
 
+# these are made with the idea that they can be removed with cloning. If glands can no longer be removed by cloning or cloning because less accessible, these will need to be removed/changed.
 - type: entity
-  id: OrganDubiousLawbound #makes them lawbound like cyborgs and station AI
+  id: OrganDubiousLawbound #makes them lawbound like cyborgs and station AI. Right now there's no way to tell if someone has this or not unless they tell you. if people abuse that I'll add a HUD icon to AI and cyborgs
   parent: OrganDubiousBase
   components:
   - type: Sprite
@@ -18,6 +19,8 @@
     - type: SlavedBorg
       law: ObeyAI
     - type: IonStormTarget
+    - type: StationAiVision
+      range: 3
     - type: CollectiveMind #if they are going to be enslaved to the AI they should have binary
       defaultChannel: Binary
       channels:
@@ -25,12 +28,9 @@
     - type: ActionGrant
       actions:
       - ActionViewLaws
-    - type: IntrinsicRadioTransmitter #so they can state laws on common to the AI.
+    - type: IntrinsicRadioTransmitter #so they can state laws in common.
       channels:
       - Common
-  - type: OrganInsertOnUse
-    slotId: heart
-    partType: Chest
 
 - type: entity
   id: OrganDubiousAllHearing #gives all radios, languages, and most hiveminds
@@ -65,9 +65,6 @@
       seeAllNames: true
     - type: TowerOfBabel
     - type: LanguageSpeaker
-  - type: OrganInsertOnUse
-    slotId: heart
-    partType: Chest
 
 - type: entity
   id: OrganDubiousTelepathic #mutes but gives them demonic wisper. idealy I would had made the wisper it's own generic system but that would require C# so it's a future TODO
@@ -113,9 +110,6 @@
   - type: OrganActions
     actions:
     - DemonicWhisperAction
-  - type: OrganInsertOnUse
-    slotId: heart
-    partType: Chest
 
 - type: entity
   id: OrganDubiousGun # Space Station 14: Become gun
@@ -171,9 +165,6 @@
     - type: GunRequiresWield
     - type: Wieldable
       unwieldOnUse: false
-  - type: OrganInsertOnUse
-    slotId: heart
-    partType: Chest
 
 - type: entity
   id: OrganDubiousTheVoices # might remove this one later. Could get pretty bad for people who get overstimulated in this game
@@ -184,9 +175,6 @@
   - type: Organ
     onAdd:
     - type: GhostHearing # Gets to hear all normal local, wispers, and emotes from everywhere and anywhere. No this doesn't let you hear dead chat
-  - type: OrganInsertOnUse
-    slotId: heart
-    partType: Chest
 
 - type: entity
   id: OrganDubiousAllSeeing # sees ghosts, AI eye, abductor eye, normal HUD icons
@@ -209,9 +197,6 @@
     - type: ShowMindShieldIcons
     - type: ShowCriminalRecordIcons
     - type: ShowContrabandDetails
-  - type: OrganInsertOnUse
-    slotId: heart
-    partType: Chest
 
 - type: entity
   id: OrganDubiousFriendship # NPCs won't attack them
@@ -224,12 +209,9 @@
     - type: NpcFactionMember
       factions:
       - AllFriendly
-  - type: OrganInsertOnUse
-    slotId: heart
-    partType: Chest
 
 - type: entity
-  id: OrganDubiousDroneVision # gives drone vision (everyone else appears as black silhouettes) and lets them see job icons to help them a little
+  id: OrganDubiousDroneVision # gives drone vision (everyone else appears as black silhouettes) and lets them see job icons to help that a little
   parent: OrganDubiousBase
   components:
   - type: Sprite
@@ -238,9 +220,6 @@
     onAdd:
     - type: DroneVision
     - type: ShowJobIcons
-  - type: OrganInsertOnUse
-    slotId: heart
-    partType: Chest
 
 - type: entity
   id: OrganDubiousClumsy # makes them clumsy
@@ -251,6 +230,3 @@
   - type: Organ
     onAdd:
     - type: Clumsy
-  - type: OrganInsertOnUse
-    slotId: heart
-    partType: Chest

--- a/Resources/Prototypes/_Omu/Entities/Markers/Spawners/Random/dubious.yml
+++ b/Resources/Prototypes/_Omu/Entities/Markers/Spawners/Random/dubious.yml
@@ -1,0 +1,40 @@
+
+
+- type: entity
+  name: Random Dubious Gland Spawner
+  id: DubiousGlandSpawner
+  parent: MarkerBase
+  components:
+    - type: Sprite
+      layers:
+        - state: red
+        - sprite: _Shitmed/Mobs/Species/Misc/Dubious/organs.rsi
+          state: gland
+    - type: RandomSpawner
+      rarePrototypes: # glands that are only beneficial to the abductee
+      - OrganDubiousHealth
+      - OrganDubiousAA
+      - OrganDubiousInvisible
+      - OrganDubiousGoliath
+      - OrganDubiousSpaceAdaptation
+      - OrganDubiousSteptriggerImmune
+      - OrganDubiousVentcrawler
+      - OrganDubiousRepairable
+      - OrganDubiousAllHearingGood
+      - OrganDubiousGun
+      rareChance: 0.5
+      prototypes: # Glands that are detrimental to the abductee that may also have some benefit
+      - OrganDubiousShock
+      - OrganDubiousScrambleDna
+      - OrganDubiousScrambleLocation
+      - OrganDubiousSpiderEggs
+      - OrganDubiousSlimeEggs
+      - OrganDubiousEMP
+      - OrganDubiousGravityWell
+      - OrganDubiousFlash
+      - OrganDubiousSmoke
+      - OrganDubiousGas
+      - OrganDubiousLawbound
+      - OrganDubiousTelepathic
+      - OrganDubiousAllHearingBad
+      offset: 0.2

--- a/Resources/Prototypes/_Omu/Entities/Markers/Spawners/Random/dubious.yml
+++ b/Resources/Prototypes/_Omu/Entities/Markers/Spawners/Random/dubious.yml
@@ -1,7 +1,7 @@
 
 
 - type: entity
-  name: Random Dubious Gland Spawner
+  name: Random Dubious Gland Spawner (Omu)
   id: DubiousGlandSpawner
   parent: MarkerBase
   components:
@@ -9,9 +9,9 @@
       layers:
         - state: red
         - sprite: _Shitmed/Mobs/Species/Misc/Dubious/organs.rsi
-          state: gland
+          state: mindshock
     - type: RandomSpawner
-      rarePrototypes: # glands that are only beneficial to the abductee
+      rarePrototypes: # Glands that are only beneficial to the abductee
       - OrganDubiousHealth
       - OrganDubiousAA
       - OrganDubiousInvisible
@@ -24,15 +24,16 @@
       - OrganDubiousGun
       - OrganDubiousAllSeeing
       - OrganDubiousFriendship
-      rareChance: 0.5
+      rareChance: 0.5 # Helps ensure there's a even distribution of good and bad glands no matter how many are added or removed.
       prototypes: # Glands that are detrimental to the abductee that may also have some benefit
+      #- OrganDubiousScrambleDna
+      #- OrganDubiousScrambleLocation
+      #- OrganDubiousArtifact #lag issues
+      #- OrganDubiousGravityWell
       - OrganDubiousShock
-      - OrganDubiousScrambleDna
-      - OrganDubiousScrambleLocation
       - OrganDubiousSpiderEggs
       - OrganDubiousSlimeEggs
       - OrganDubiousEMP
-      - OrganDubiousGravityWell
       - OrganDubiousFlash
       - OrganDubiousSmoke
       - OrganDubiousGas

--- a/Resources/Prototypes/_Omu/Entities/Markers/Spawners/Random/dubious.yml
+++ b/Resources/Prototypes/_Omu/Entities/Markers/Spawners/Random/dubious.yml
@@ -24,6 +24,7 @@
       - OrganDubiousGun
       - OrganDubiousAllSeeing
       - OrganDubiousFriendship
+      - OrganDubiousPowerGen
       rareChance: 0.5 # Helps ensure there's a even distribution of good and bad glands no matter how many are added or removed.
       prototypes: # Glands that are detrimental to the abductee that may also have some benefit
       #- OrganDubiousScrambleDna
@@ -42,4 +43,5 @@
       - OrganDubiousTheVoices
       - OrganDubiousDroneVision
       - OrganDubiousClumsy
+      - OrganDubiousSlippery # Everyone is going to hate you. so I'm putting it in the bad section
       offset: 0.2

--- a/Resources/Prototypes/_Omu/Entities/Markers/Spawners/Random/dubious.yml
+++ b/Resources/Prototypes/_Omu/Entities/Markers/Spawners/Random/dubious.yml
@@ -2,7 +2,7 @@
 
 - type: entity
   name: Random Dubious Gland Spawner (Omu)
-  id: DubiousGlandSpawner
+  id: DubiousGlandSpawnerOmu
   parent: MarkerBase
   components:
     - type: Sprite

--- a/Resources/Prototypes/_Omu/Entities/Markers/Spawners/Random/dubious.yml
+++ b/Resources/Prototypes/_Omu/Entities/Markers/Spawners/Random/dubious.yml
@@ -20,8 +20,10 @@
       - OrganDubiousSteptriggerImmune
       - OrganDubiousVentcrawler
       - OrganDubiousRepairable
-      - OrganDubiousAllHearingGood
+      - OrganDubiousAllHearing
       - OrganDubiousGun
+      - OrganDubiousAllSeeing
+      - OrganDubiousFriendship
       rareChance: 0.5
       prototypes: # Glands that are detrimental to the abductee that may also have some benefit
       - OrganDubiousShock
@@ -36,5 +38,7 @@
       - OrganDubiousGas
       - OrganDubiousLawbound
       - OrganDubiousTelepathic
-      - OrganDubiousAllHearingBad
+      - OrganDubiousTheVoices
+      - OrganDubiousDroneVision
+      - OrganDubiousClumsy
       offset: 0.2

--- a/Resources/Prototypes/_Omu/ai_factions.yml
+++ b/Resources/Prototypes/_Omu/ai_factions.yml
@@ -1,0 +1,22 @@
+- type: npcFaction
+  id: AllFriendly # mainly for the abductor gland. figure admin CCOs may also want to use this
+  friendly:
+  - NanoTrasen
+  - Dragon
+  - Mouse
+  - Passive
+  - PetsNT
+  - SimpleHostile
+  - SimpleNeutral
+  - Syndicate
+  - Xeno
+  - Zombie
+  - Revolutionary
+  - Changeling
+  - Heretic
+  - Blob
+  - Shadowling
+  - Wizard
+  - PirateFaction
+  - Wraith
+  - Lavafauna


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
- add more glands
- add a new randomized spawner for glands
- add a recharger to the abductor shuttle

Right now the following organs are functional but I would like input on any I should remove/change any.
- OrganDubiousLawbound (gives them crewimov and AI law 0, sees job icons, and can use Binary)
- OrganDubiousAllHearing (gives crew radios, languages, and most hiveminds)
- OrganDubiousTelepathic (mutes (can't use sign), understands most crew languages, and gives the demon whisper action, and blocks use of translator implants)
- OrganDubiousGun (your now also a gun that fits 5 rounds and needs to be manually cycled)
- OrganDubiousTheVoices (global hearing of local and whispers)
- OrganDubiousAllSeeing (can see ghosts, abductor eye, AI eye, and most normal HUD icons)
- OrganDubiousDroneVision (everyone shows as a black silhouette, can see job icons)
- OrganDubiousClumsy (gives clumsy)
- OrganDubiousPowerGen (makes you a powerful HV power source. requires anchoring)
- OrganDubiousSlippery (Honkbot incarnate, everyone is going to hate you) 
- OrganDubiousFriendship (NPCs won't attack you. kinda redundant when considering OrganDubiousInvisible exists)
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Abductors haven't meaningfully gotten new content in while so I'm tossing them a bone with some new glands and adding the stuff that was left out of the old shuttle to the new one.

As for the new gland spawner. Right now the current gland spawner uses a weighted table that heavily favors a select 6 all good glands. This means out of the only handful of people that get abducted, most if not all will have one of these 6 boring glands. Abductors aren't about that, there about causing chaos via cursing/blessing crewmembers of random often genuinely absurd effects.
The new gland spawner has a 50% chance to spawn one of the purely positive glands from a pool of 13 otherwise it'll spawn of the negative/neutral gland from a pool of 13
## Technical details
<!-- Summary of code changes for easier review. -->
Added two new yml files under _omu for the new glands and a spawner.
Also very small changes to the lone and duo abductor shuttles to feature a turbo charger
## Media
lone shuttle
<img width="689" height="631" alt="image" src="https://github.com/user-attachments/assets/45d4e413-7675-476f-88d1-e274d1a60bae" />
duo shuttle
<img width="689" height="631" alt="image" src="https://github.com/user-attachments/assets/8e63886a-fc3d-4e39-92f3-b1b518275076" />
If you're not sure what drone Vision does here's a example image. note the gland also gives showjobicons
<img width="1030" height="491" alt="image" src="https://github.com/user-attachments/assets/eb2985e5-bc9c-41d2-b257-35f434d3e09d" />

<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Abductors gotten 11 new glands and there shuttles now come with a turbo charger again.
