### PR TITLE
Some QoL for PTLs

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/smes.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/smes.yml
@@ -72,7 +72,7 @@
     - type: Battery
       startingCharge: 0
       maxCharge: 16000000 # Goobstation - SMES buff
-      pricePerJoule: .00095
+      pricePerJoule: .0003 # Omu, aSMES cargo nerf
     - type: ExaminableBattery
     - type: NodeContainer
       examinable: true

--- a/Resources/Prototypes/Entities/Structures/Power/smes.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/smes.yml
@@ -72,7 +72,7 @@
     - type: Battery
       startingCharge: 0
       maxCharge: 16000000 # Goobstation - SMES buff
-      pricePerJoule: .0003 # Omu, aSMES cargo nerf
+      pricePerJoule: .00095
     - type: ExaminableBattery
     - type: NodeContainer
       examinable: true

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/power_laser.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/power_laser.yml
@@ -17,8 +17,8 @@
     mode: SnapgridCenter
   components:
   - type: PTL
-    minEnergyPerShot: 5e5 # Omu
-    maxEnergyPerShot: 3e6 # Omu 3MJ (300kw/s), 404spesos 10/s
+    minEnergyPerShot: 25e4 # Omu
+    maxEnergyPerShot: 3.5e6 # Omu 3.5MJ (@300kw/s, 404spesos 10/s), this is throttled to 3e6 by charge rate intentionally.
     active: false
     baseBeamDamage:
       types:
@@ -44,7 +44,7 @@
   - type: RadiationSource
   - type: Appearance
   - type: PowerNetworkBattery
-    maxChargeRate: 500000 # Omu, 500kW
+    maxChargeRate: 300000 # Omu, 300kW
   - type: Battery
     startingCharge: 0
     maxCharge: 25000000 # Omu, 25MJ (50s of 500kW)

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/power_laser.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/power_laser.yml
@@ -8,7 +8,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-- type: entity
+- type: entity # Omu Note, Capable of making 592 spesos from 500kj every 10 seconds
   id: MachinePowerTransmissionLaser
   parent: [ BaseMachine ]
   name: power transmission laser
@@ -21,6 +21,7 @@
     baseBeamDamage:
       types:
         Heat: 5
+        Structural: 5 # Omu
   - type: PTLVisuals
   - type: Sprite
     sprite: _Goobstation/Structures/Machines/PTL/pt_laser.rsi
@@ -102,9 +103,11 @@
 
 - type: hitscan
   id: PTL
+  maxLength: 50 # Omu, Stop firing it inside OML
   damage:
     types:
       Heat: 30
+      Structural: 30 # Omu
   muzzleFlash:
     sprite: _Goobstation/Structures/Machines/PTL/pt_beam.rsi
     state: ptl_beam

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/power_laser.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/power_laser.yml
@@ -8,7 +8,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-- type: entity # Omu Note, Capable of making 592 spesos from 500kj every 10 seconds
+- type: entity # Omu Note, Capable of making 592 spesos from 500kj every 10 seconds, 6x less than selling a SMES of equal power.
   id: MachinePowerTransmissionLaser
   parent: [ BaseMachine ]
   name: power transmission laser
@@ -46,6 +46,7 @@
   - type: Battery
     startingCharge: 0
     maxCharge: 100000000 # 100MJ
+    pricePerJoule: 0 # Omu
   - type: ExaminableBattery
   - type: BatteryCharger
     voltage: High
@@ -100,6 +101,8 @@
     range: 5
     sound:
       path: /Audio/Ambience/Objects/engine_hum.ogg
+  - type: StaticPrice # Omu
+    price: 1500
 
 - type: hitscan
   id: PTL

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/power_laser.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/power_laser.yml
@@ -17,8 +17,6 @@
     mode: SnapgridCenter
   components:
   - type: PTL
-    minShootPower: 25e4 # Omu
-    maxEnergyPerShot: 3.5e6 # Omu 3.5MJ (@300kw/s, 404spesos 10/s), this is throttled to 3e6 by charge rate intentionally.
     active: false
     baseBeamDamage:
       types:
@@ -44,10 +42,10 @@
   - type: RadiationSource
   - type: Appearance
   - type: PowerNetworkBattery
-    maxChargeRate: 300000 # Omu, 300kW
+    maxChargeRate: 5000000 # 5MJ
   - type: Battery
     startingCharge: 0
-    maxCharge: 25000000 # Omu, 25MJ (50s of 500kW)
+    maxCharge: 100000000 # 100MJ
     pricePerJoule: 0 # Omu
   - type: ExaminableBattery
   - type: BatteryCharger

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/power_laser.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/power_laser.yml
@@ -84,12 +84,12 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-          bounds: "-1.5,-1.5,1.5,1.5"
-        density: 50
+          bounds: "-1.2,-1.2,1.2,1.2" # Omu
+        density: 250 # Omu
         mask:
         - LargeMobMask
         layer:
-        - WallLayer
+        - MachineLayer # Omu
   - type: StationAiWhitelist
   # ui todo
   #- type: ActivatableUI

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/power_laser.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/power_laser.yml
@@ -8,7 +8,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-- type: entity # Omu Note, Capable of making 592 spesos from 500kj every 10 seconds, 6x less than selling a SMES of equal power.
+- type: entity
   id: MachinePowerTransmissionLaser
   parent: [ BaseMachine ]
   name: power transmission laser
@@ -17,6 +17,8 @@
     mode: SnapgridCenter
   components:
   - type: PTL
+    minEnergyPerShot: 5e5 # Omu
+    maxEnergyPerShot: 3e6 # Omu 3MJ (300kw/s), 404spesos 10/s
     active: false
     baseBeamDamage:
       types:
@@ -42,10 +44,10 @@
   - type: RadiationSource
   - type: Appearance
   - type: PowerNetworkBattery
-    maxChargeRate: 5000000 # 5MJ
+    maxChargeRate: 500000 # Omu, 500kW
   - type: Battery
     startingCharge: 0
-    maxCharge: 100000000 # 100MJ
+    maxCharge: 25000000 # Omu, 25MJ (50s of 500kW)
     pricePerJoule: 0 # Omu
   - type: ExaminableBattery
   - type: BatteryCharger

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/power_laser.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/power_laser.yml
@@ -108,7 +108,7 @@
 
 - type: hitscan
   id: PTL
-  maxLength: 50 # Omu, Stop firing it inside OML
+  maxLength: 50 # Omu
   damage:
     types:
       Heat: 30

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/power_laser.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/power_laser.yml
@@ -17,7 +17,7 @@
     mode: SnapgridCenter
   components:
   - type: PTL
-    minEnergyPerShot: 25e4 # Omu
+    minShootPower: 25e4 # Omu
     maxEnergyPerShot: 3.5e6 # Omu 3.5MJ (@300kw/s, 404spesos 10/s), this is throttled to 3e6 by charge rate intentionally.
     active: false
     baseBeamDamage:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
removes the 'sale price' of the PTL being adjusted for its stored power to prevent people getting confused by price analysing it when they're meant to be multitooling it to withdraw money, it now always is analzyed as 1500$.

makes PTLs 5x heavier, decreases their hitbox by .3 metres in all directions, moves it to the machine layer instead of wall layer (less annoying to interact with if things get partially placed inside such is the case with watertanks/watercoolers if you're familiar)
increases the range of the laser fired and adds structural damage to prevent them being fired indoors. (see media for hitbox)

## Why / Balance
The changes to the laser projectile should prevent any indoor use, though i can see reason to skip on the added range if theres worries of a slightly longer laser projectile constituting towards bad server performance, though consider worst case is 10 PTLs firing their full length its 500 tiles of raycasting spread out over 10 seconds.

## Technical details
yaml slop

## Media
<img width="295" height="592" alt="image" src="https://github.com/user-attachments/assets/6df32521-6c2b-478d-8337-883ee00860c9" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: PTLs are slightly smaller than they were before and weigh a more sensible amount for their size with their fired laser being more destructive.
- tweak: PTLs no longer gain price as their battery fills up and instead have a static price.
