### PR TITLE
Fix Aghost picking up Pseudoitems (Birds in a bag)

### DIFF
--- a/Content.Server/Nyanotrasen/Item/PseudoItem/PseudoItemSystem.cs
+++ b/Content.Server/Nyanotrasen/Item/PseudoItem/PseudoItemSystem.cs
@@ -13,6 +13,8 @@ using Content.Server.Popups;
 using Content.Server.Storage.EntitySystems;
 using Content.Shared.Bed.Sleep;
 using Content.Shared._DV.Carrying;
+using Content.Shared._Omu.Carrying;
+using Content.Shared.Ghost;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Item;
@@ -67,10 +69,11 @@ public sealed class PseudoItemSystem : SharedPseudoItemSystem
         args.Verbs.Add(verb);
     }
 
-    protected override void OnGettingPickedUpAttempt(EntityUid uid, PseudoItemComponent component, GettingPickedUpAttemptEvent args)
+    protected override void OnGettingPickedUpAttempt(EntityUid uid, PseudoItemComponent component,
+        GettingCarriedEvent args) // Omu
     {
         // Try to pick the entity up instead first
-        if (args.User != args.Item && _carrying.TryCarry(args.User, uid))
+        if (args.Carrier != args.Carried && !_carrying.TryCarry(args.Carried, uid)) // omu
         {
             args.Cancel();
             return;

--- a/Content.Shared/Nyanotrasen/Item/PseudoItem/SharedPseudoItemSystem.cs
+++ b/Content.Shared/Nyanotrasen/Item/PseudoItem/SharedPseudoItemSystem.cs
@@ -33,6 +33,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Shared._Omu.Carrying;
 using Content.Shared.Actions;
 using Content.Shared.DoAfter;
 using Content.Shared.Hands;
@@ -68,7 +69,7 @@ public abstract partial class SharedPseudoItemSystem : EntitySystem
         base.Initialize();
         SubscribeLocalEvent<PseudoItemComponent, GetVerbsEvent<InnateVerb>>(AddInsertVerb);
         SubscribeLocalEvent<PseudoItemComponent, EntGotRemovedFromContainerMessage>(OnEntRemoved);
-        SubscribeLocalEvent<PseudoItemComponent, GettingPickedUpAttemptEvent>(OnGettingPickedUpAttempt);
+        SubscribeLocalEvent<PseudoItemComponent, GettingCarriedEvent>(OnGettingPickedUpAttempt); // Omu
         SubscribeLocalEvent<PseudoItemComponent, DropAttemptEvent>(OnDropAttempt);
         SubscribeLocalEvent<PseudoItemComponent, ContainerGettingInsertedAttemptEvent>(OnInsertAttempt);
         SubscribeLocalEvent<PseudoItemComponent, InteractionAttemptEvent>(OnInteractAttempt);
@@ -148,9 +149,9 @@ public abstract partial class SharedPseudoItemSystem : EntitySystem
     }
 
     protected virtual void OnGettingPickedUpAttempt(EntityUid uid, PseudoItemComponent component,
-        GettingPickedUpAttemptEvent args)
+        GettingCarriedEvent args) // Omu
     {
-        if (args.User == args.Item)
+        if (args.Carrier == args.Carried) // Omu
             return;
 
         Transform(uid).AttachToGridOrMap();

--- a/Content.Shared/_DV/Carrying/CarryingSystem.cs
+++ b/Content.Shared/_DV/Carrying/CarryingSystem.cs
@@ -39,7 +39,8 @@ using System.Numerics;
 using Content.Shared._EinsteinEngines.Contests;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Mind.Components;
-using Content.Shared._EinsteinEngines.Carrying; // EE
+using Content.Shared._EinsteinEngines.Carrying;
+using Content.Shared._Omu.Carrying; // EE
 
 namespace Content.Shared._DV.Carrying;
 
@@ -319,6 +320,20 @@ public sealed class CarryingSystem : EntitySystem
 
         if (GetPickupDuration(carrier, toCarry).TotalSeconds > 9f)
             return false;
+
+        // Omu start,
+        // carry checks because hey treating people as items and using item pickup events is bad.
+
+        var carryAttempt = new CarryAttemptEvent(carrier, toCarry);
+        RaiseLocalEvent(toCarry, carryAttempt);
+
+        if (carryAttempt.Cancelled)
+            return false;
+
+        var itemEv = new GettingCarriedEvent(carrier, toCarry);
+        RaiseLocalEvent(toCarry, itemEv);
+
+        // Omu end
 
         Carry(carrier, toCarry);
         return true;

--- a/Content.Shared/_Omu/Carrying/CarryingEvent.cs
+++ b/Content.Shared/_Omu/Carrying/CarryingEvent.cs
@@ -1,0 +1,21 @@
+namespace Content.Shared._Omu.Carrying;
+
+public class CarryAttemptEvent : CancellableEntityEventArgs
+{
+    public readonly EntityUid Carrier;
+    public readonly EntityUid Carried;
+
+    public CarryAttemptEvent(EntityUid carrier, EntityUid carried)
+    {
+        Carrier = carrier;
+        Carried = carried;
+    }
+}
+
+/// <summary>
+///     Raised directed at entity being picked up when someone tries to carry it
+/// </summary>
+public sealed class GettingCarriedEvent : CarryAttemptEvent
+{
+    public GettingCarriedEvent(EntityUid carrier, EntityUid carried) : base(carrier, carried) { }
+}


### PR DESCRIPTION
## About the PR
Raises a separate event for items / carryables so we dont raise item events on pseudoitems and pick them up when we get verbs.

## Why / Balance


## Technical details
Technically you get prediction fuckups. Try and `LeftClick` a pseudoitem entity inside a bag and youll see what i mean. but this is clientside only and better than the current version which will pick up any pseudoitems when you get verbs.

## Media

https://github.com/user-attachments/assets/f624cff7-00a1-4467-ab41-7e4826e96e18


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**

:cl:
- fix: Admins will no longer be compulsively compelled to accidentally pick up crewmembers that are inside a bag
