### PR TITLE
Nerfing/Removing Omnizine/Desoxyephedrine Mix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -1854,7 +1854,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 24
+        maxVol: 14
         reagents:
         - ReagentId: Bicaridine
           Quantity: 5
@@ -1862,8 +1862,6 @@
           Quantity: 5
         - ReagentId: Nutriment
           Quantity: 2
-        - ReagentId: Desoxyephedrine
-          Quantity: 10
         - ReagentId: Vitamin
           Quantity: 2
   - type: Sprite
@@ -1899,7 +1897,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 20
+        maxVol: 10
         reagents:
         - ReagentId: Omnizine
           Quantity: 3
@@ -1907,8 +1905,6 @@
           Quantity: 5
         - ReagentId: Nutriment
           Quantity: 2
-        - ReagentId: Desoxyephedrine
-          Quantity: 10
   - type: Sprite
     sprite: Objects/Specific/Hydroponics/ambrosia_deus.rsi
   - type: Item
@@ -1978,10 +1974,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 25
         reagents:
         - ReagentId: Razorium
           Quantity: 15
+        - ReagentId: Desoxyephedrine
+          Quantity: 10
   - type: Sprite
     sprite: Objects/Specific/Hydroponics/glasstle.rsi
   - type: Produce

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -1854,7 +1854,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 14
+        maxVol: 14 #Omu, removed desoxyephedrine from ambrosia
         reagents:
         - ReagentId: Bicaridine
           Quantity: 5
@@ -1897,7 +1897,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 10
+        maxVol: 10 #Omu, removed desoxyephedrine from ambrosia
         reagents:
         - ReagentId: Omnizine
           Quantity: 3
@@ -1974,7 +1974,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 25
+        maxVol: 25 #Omu, moved 10 desoxyephedrine from ambrosia to glasstle
         reagents:
         - ReagentId: Razorium
           Quantity: 15

--- a/Resources/Prototypes/_Omu/Recipes/Reactions/single_reagent.yml
+++ b/Resources/Prototypes/_Omu/Recipes/Reactions/single_reagent.yml
@@ -13,3 +13,14 @@
     gas: WaterVapor
   products:
     Syrup: 1
+
+- type: reaction
+  id: AntiOmniDesoxy #added particularly to remove the oppressive omni/desoxy mix from use
+  impact: Medium 
+  reactants:
+    Omnizine:
+      amount: 1
+    Desoxyephedrine:
+      amount: 1
+  products:
+    Diphenylmethylamine: 2


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
omni/desoxy now combines 1:1 to make diphenylmethylamine, a strong anti-narcolepsy med
to accomodate for this, desoxyephedrine from ambrosia vulgaris/deus has been separated out and given to glasstle (see wizden https://github.com/space-wizards/space-station-14/pull/40638 and https://github.com/space-wizards/space-station-14/pull/40639)

if this is too harsh, then this is also negotiable to simply separating desoxyephedrine out from ambrosia vulgaris/deus to glasstle (or further discussion about general nerfs to desoxyephedrine, as it is quite strong)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
desoxy/omni is an incredibly oppressive meta mix, as desoxyephedrine comes free with your omnizine. it's also not particularly difficult for chemistry to whip up a batch of meth in a few minutes (like most other T3s) compared to how strong meth is at the moment (it gives a greater speeed boost than aranesp or hyperzine at 1.35x compared to 1.3x)

when both are combined, the omnizine drastically outpaces the minor poisoning from meth, and omni still outpaces meth's poison and asphyxiation damage when overdosing. meth or omnizine alone are strong but (reasonably) handleable, but when both are combined, one becomes impossible to stun and rather difficult to kill

in making this change, i did not want to penalize ephedrine, aranesp, or hyperzine combined with omnizine, as ephedrine is quite weak, aranesp is time-consuming and restricted essentially to late-game chemistry, and hyperzine is costly or involved to obtain. meth is simply not very difficult to obtain compared to its effects

choosing diphenylmethylamine as the desoxy/omni derivative was because it's a cool, niche desoxyephedrine derivative that is never, ever made, as it requires a massive amount of cooperation between botany, chemistry, and some coffee dispenser. it has very little combat utility as well (for most characters), so i thought it suitable to prevent omni/desoxy mixing and to have a more accessible recipe for the few times it may be wanted

## Technical details
<!-- Summary of code changes for easier review. -->
YAML changes to `Resources\Prototypes\Entities\Objects\Consumable\Food\produce.yml` to separate the desoxy from ambrosia
YAML changes to `Resources\Prototypes\_Omu\Recipes\Reactions\single_reagent.yml` to cause desoxy/omni to mix into diphenylmethylamine

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="672" height="366" alt="image" src="https://github.com/user-attachments/assets/71ba6846-fdc2-46f1-8d66-9261ae7e61a7" />
<img width="1231" height="1006" alt="image" src="https://github.com/user-attachments/assets/619dc62c-1537-465a-8caf-a0b61cbf3d85" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Duuckie
- tweak: Ambrosia Vulgaris and Ambrosia Deus no longer contain Desoxyephedrine; Glasstle now contains Desoxyephedrine.
- tweak: Desoxyephedrine and Omnizine now mix together to make Diphenylmethylamine, an anti-narcolepsy medication.

