### PR TITLE
Give Desoxyephedrine from Ambrosia to Glasstle

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -1854,7 +1854,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 24
+        maxVol: 14 #Omu, moved 10 desoxyephedrine from ambrosia to glasstle
         reagents:
         - ReagentId: Bicaridine
           Quantity: 5
@@ -1862,8 +1862,6 @@
           Quantity: 5
         - ReagentId: Nutriment
           Quantity: 2
-        - ReagentId: Desoxyephedrine
-          Quantity: 10
         - ReagentId: Vitamin
           Quantity: 2
   - type: Sprite
@@ -1899,7 +1897,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 20
+        maxVol: 10 #Omu, moved 10 desoxyephedrine from ambrosia to glasstle
         reagents:
         - ReagentId: Omnizine
           Quantity: 3
@@ -1907,8 +1905,6 @@
           Quantity: 5
         - ReagentId: Nutriment
           Quantity: 2
-        - ReagentId: Desoxyephedrine
-          Quantity: 10
   - type: Sprite
     sprite: Objects/Specific/Hydroponics/ambrosia_deus.rsi
   - type: Item
@@ -1978,10 +1974,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 25 #Omu, moved 10 desoxyephedrine from ambrosia to glasstle
         reagents:
         - ReagentId: Razorium
           Quantity: 15
+        - ReagentId: Desoxyephedrine
+          Quantity: 10
   - type: Sprite
     sprite: Objects/Specific/Hydroponics/glasstle.rsi
   - type: Produce


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
this is a splitting of https://github.com/ProjectOmu/OmuStation/pull/1191 for PR etiquette and so further talks about desoxyephedrine can continue

desoxyephedrine is now found in glasstle instead of in ambrosia vulgaris/deus
the maximum volumes of both plants are adjusted for this
(see wizden https://github.com/space-wizards/space-station-14/pull/40638 and https://github.com/space-wizards/space-station-14/pull/40639)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
desoxy/omni is a very potent and meta-defining mix for botany, and it comes free with making omnizine for medical. moving desoxyephedrine to glasstle makes acquiring it require significantly more effort than that it simply was around because you were making omnizine anyway

from what i know, there's a general frustration with "oh look it's desoxy/omni again what a shocker" when it comes to botanist traitors, so making desoxyephedrine more risky/involved to procure should help reduce the frequency at which desoxy/omni gets output and encourage craftier strategies for traitor botanists

## Technical details
<!-- Summary of code changes for easier review. -->
YAML changes to `Resources\Prototypes\Entities\Objects\Consumable\Food\produce.yml` to separate the desoxy from ambrosia

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1066" height="846" alt="Screenshot 2026-07-08 141550" src="https://github.com/user-attachments/assets/6982ad9f-f325-4118-9e7f-27c55874953b" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Duuckie
- tweak: Ambrosia Vulgaris and Ambrosia Deus no longer contain Desoxyephedrine; Glasstle now contains Desoxyephedrine.

