### PR TITLE
fix ship guns

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
@@ -31,6 +31,8 @@
     powerChargeRate: 200
     powerUsePassive: 2000
     powerUseActive: 0
+  - type: ApcPowerReceiverBattery # Omu
+    batteryRechargeRate: 200
   - type: Actions
   - type: ProjectileBatteryAmmoProvider
     proto: ShipRubiconProjectile
@@ -96,6 +98,8 @@
     powerChargeRate: 100
     powerUsePassive: 500
     powerUseActive: 0
+  - type: ApcPowerReceiverBattery # Omu
+    batteryRechargeRate: 100
   - type: Actions
   - type: ProjectileBatteryAmmoProvider
     proto: ShipMediumPlasmaProjectile
@@ -164,6 +168,8 @@
     powerChargeRate: 2000
     powerUsePassive: 20000
     powerUseActive: 0
+  - type: ApcPowerReceiverBattery # Omu
+    batteryRechargeRate: 2000
   - type: Actions
   - type: ProjectileBatteryAmmoProvider
     proto: ShipDymereProjectile

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/launcher.yml
@@ -31,9 +31,8 @@
       path: /Audio/_Mono/Weapons/Guns/Gunshots/slammer.ogg
     soundEmpty:
       path: /Audio/Weapons/Guns/Empty/lmg_empty.ogg
-  - type: BatterySelfRecharger
-    autoRecharge: true
-    autoRechargeRate: 550
+  - type: ApcPowerReceiverBattery # Omu
+    batteryRechargeRate: 550
   - type: SpaceArtillery
     powerChargeRate: 100
     powerUsePassive: 100
@@ -83,9 +82,8 @@
       path: /Audio/_Mono/Weapons/Guns/Gunshots/mortar.ogg
     soundEmpty:
       path: /Audio/Weapons/Guns/Empty/lmg_empty.ogg
-  - type: BatterySelfRecharger
-    autoRecharge: true
-    autoRechargeRate: 220
+  - type: ApcPowerReceiverBattery # Omu
+    batteryRechargeRate: 220
   - type: SpaceArtillery
     powerChargeRate: 220
     powerUsePassive: 750
@@ -136,9 +134,8 @@
       path: /Audio/_Mono/Weapons/Guns/Gunshots/120mm_mortar.ogg
     soundEmpty:
       path: /Audio/Weapons/Guns/Empty/lmg_empty.ogg
-  - type: BatterySelfRecharger
-    autoRecharge: true
-    autoRechargeRate: 125
+  - type: ApcPowerReceiverBattery # Omu
+    batteryRechargeRate: 125
   - type: SpaceArtillery
     powerChargeRate: 125
     powerUsePassive: 600
@@ -184,9 +181,8 @@
       path: /Audio/Weapons/Guns/Gunshots/ship_duster.ogg
     soundEmpty:
       path: /Audio/Weapons/Guns/Empty/lmg_empty.ogg
-  - type: BatterySelfRecharger
-    autoRecharge: true
-    autoRechargeRate: 214
+  - type: ApcPowerReceiverBattery # Omu
+    batteryRechargeRate: 214
   - type: SpaceArtillery
     powerChargeRate: 214
     powerUsePassive: 3500
@@ -249,9 +245,8 @@
       path: /Audio/_Mono/Weapons/Guns/Gunshots/cannon.ogg
     soundEmpty:
       path: /Audio/Weapons/Guns/Empty/lmg_empty.ogg
-  - type: BatterySelfRecharger
-    autoRecharge: true
-    autoRechargeRate: 12000
+  - type: ApcPowerReceiverBattery # Omu
+    batteryRechargeRate: 12000
   - type: SpaceArtillery
     powerChargeRate: 12000
     powerUsePassive: 1500
@@ -314,9 +309,8 @@
       path: /Audio/_Mono/Weapons/Guns/Gunshots/cannon.ogg
     soundEmpty:
       path: /Audio/Weapons/Guns/Empty/lmg_empty.ogg
-  - type: BatterySelfRecharger
-    autoRecharge: true
-    autoRechargeRate: 12000
+  - type: ApcPowerReceiverBattery # Omu
+    batteryRechargeRate: 12000
   - type: SpaceArtillery
     powerChargeRate: 12000
     powerUsePassive: 1500
@@ -362,9 +356,8 @@
       path: /Audio/_Mono/Weapons/Guns/Gunshots/leviathan_fire.ogg
     soundEmpty:
       path: /Audio/Weapons/Guns/EmptyAlarm/smg_empty_alarm.ogg
-  - type: BatterySelfRecharger
-    autoRecharge: true
-    autoRechargeRate: 350
+  - type: ApcPowerReceiverBattery # Omu
+    batteryRechargeRate: 350
   - type: SpaceArtillery
     powerChargeRate: 350
     powerUsePassive: 1000
@@ -450,10 +443,8 @@
       path: /Audio/_Mono/Weapons/Guns/Gunshots/cannon.ogg
     soundEmpty:
       path: /Audio/Weapons/Guns/Empty/lmg_empty.ogg
-  - type: BatterySelfRecharger
-    autoRecharge: true
-    autoRechargeRate: 12000
-    autoRechargePause: true
+  - type: ApcPowerReceiverBattery # Omu
+    batteryRechargeRate: 12000
   - type: SpaceArtillery
     powerChargeRate: 800
     powerUsePassive: 1500
@@ -511,10 +502,8 @@
       path: /Audio/_Mono/Weapons/Guns/Gunshots/cannon.ogg
     soundEmpty:
       path: /Audio/Weapons/Guns/Empty/lmg_empty.ogg
-  - type: BatterySelfRecharger
-    autoRecharge: true
-    autoRechargeRate: 12000
-    autoRechargePause: true
+  - type: ApcPowerReceiverBattery # Omu
+    batteryRechargeRate: 1200
   - type: SpaceArtillery
     powerChargeRate: 700
     powerUsePassive: 1500

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/launcher.yml
@@ -27,9 +27,8 @@
       path: /Audio/Weapons/Guns/Gunshots/rocket_launcher.ogg
     soundEmpty:
       path: /Audio/Weapons/Guns/EmptyAlarm/smg_empty_alarm.ogg
-  - type: BatterySelfRecharger
-    autoRecharge: true
-    autoRechargeRate: 200
+  - type: ApcPowerReceiverBattery # Omu
+    batteryRechargeRate: 200
   - type: SpaceArtillery
     powerChargeRate: 200
     powerUsePassive: 750
@@ -78,9 +77,8 @@
   - type: SpaceArtillery
     powerChargeRate: 250
     powerUsePassive: 200
-  - type: BatterySelfRecharger
-    autoRecharge: true
-    autoRechargeRate: 60
+  - type: ApcPowerReceiverBattery # Omu
+    batteryRechargeRate: 250
   - type: Actions
   - type: ProjectileBatteryAmmoProvider
     proto: ShipMissileASM501
@@ -122,9 +120,8 @@
       path: /Audio/Weapons/Guns/Gunshots/rocket_launcher.ogg
     soundEmpty:
       path: /Audio/Weapons/Guns/EmptyAlarm/smg_empty_alarm.ogg
-  - type: BatterySelfRecharger
-    autoRecharge: true
-    autoRechargeRate: 60
+  - type: ApcPowerReceiverBattery # Omu
+    batteryRechargeRate: 350
   - type: Actions
   - type: ProjectileBatteryAmmoProvider
     proto: ShipMissileASM302
@@ -187,9 +184,8 @@
       path: /Audio/Weapons/Guns/Gunshots/rocket_launcher.ogg
     soundEmpty:
       path: /Audio/Weapons/Guns/EmptyAlarm/smg_empty_alarm.ogg
-  - type: BatterySelfRecharger
-    autoRecharge: true
-    autoRechargeRate: 500
+  - type: ApcPowerReceiverBattery # Omu
+    batteryRechargeRate: 500
   - type: SpaceArtillery
     powerChargeRate: 500
     powerUsePassive: 2500

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/base_launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/base_launcher.yml
@@ -11,6 +11,8 @@
     priority: 1
   - type: ApcPowerReceiver
     powerLoad: 250
+  - type: ApcPowerReceiverBattery # Omu
+    batteryRechargeRate: 250
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: StructuralMetallic


### PR DESCRIPTION
## About the PR
Fixes the recharge on ship guns.

## Why / Balance
It annoyed me. And its a bugfix.

## Technical details
Remove BatterySelfRecharger, replace with ApcPowerReceiverBattery, now shuttle guns receive power from the LV network.

## Media
N/a, go fire a 20mm and see that it fires constantly if you want to test.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed monolith shuttleguns to no longer fail to recharge.