### PR TITLE
Improve Funkystation Content Warning

### DIFF
--- a/Content.Client/_Funkystation/ContentWarning/ContentWarningPopup.xaml
+++ b/Content.Client/_Funkystation/ContentWarning/ContentWarningPopup.xaml
@@ -1,8 +1,8 @@
 <controls:FancyWindow xmlns="https://spacestation14.io"
                       xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                       Title="{Loc 'content-warning-title'}"
-                      MinSize="520 900"
-                      MaxSize="520 900">
+                      MinSize="560 940"
+                      MaxSize="560 940"><!--Omu, slightly enlarged by 40u for wording changes-->
     <BoxContainer Orientation="Vertical" Margin="20">
         <Label Name="TitleLabel"
                StyleClasses="LabelBig"

--- a/Resources/Locale/en-US/_Funkystation/content_warning.ftl
+++ b/Resources/Locale/en-US/_Funkystation/content_warning.ftl
@@ -5,21 +5,22 @@ content-warning-reject = This is not the place for me.
 content-warning-message =
     Space Station 14 is a game about surviving a disaster with incompetent and cruel people on a space station.
 
-    Your character is not a stand in for yourself. At Omu Station, we believe this is the in-correct way to play the game. With that in-mind, we also believe in fully sharing what we think may be potentially triggering scenarios.
+    Your character is not a stand-in for yourself. At Omu Station, we believe this is the incorrect way to play the game. With that in mind, we also believe in fully sharing what we think may be potentially triggering scenarios.
 
-    Do not play Omu Station if you are sensitive to:
+    Do not play on Omu Station if you are sensitive to the following:
 
-    - You losing control of your character
+    - Losing control of your character
     - Violent crime
+    - Being a victim of violent crime
     - Interrogations
-    - Being a victim to violent crime
     - Your own character dying
     - Witnessing others dying
     - Brainwashing
     - Body horror
-    - You playing someone elses character, or parts of your characters appearance changing
-    - Being framed for a crime that you did not do
+    - Playing someone else's character
+    - Parts of your character's appearance changing
+    - Being framed for a crime that you didn't commit
 
-    Do not make a stand in for yourself. If you are not confident in your ability to distinguish what is part of the game and what isn't, do not play here.
+    Do not make a stand-in for yourself. If you are not confident in your ability to distinguish what is part of the game and what isn't, do not play here.
 
-    A critical part of playing a character who is employed on station is that you are a [bold]MODERATELY FUNCTIONAL ADULT[/bold] and would not act like a child, a mental patient, or an animal/pet. Failure to act like an employable adult will be punished heavily. This is doubly true for command. If you cannot take your job seriously, you will be banned from command.
+    A critical part of playing a character who is employed on-station is that you are a [bold]MODERATELY FUNCTIONAL ADULT[/bold] and would not act like a child, a mental patient, or an animal/pet. Failure to act like an employable adult will be punished heavily. This is doubly true for command: if you cannot take your job seriously, you will be banned from command.


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
i made loads of minor text changes in the content warning for a better reading experience
i also increased the overall popup size slightly to accomodate for my changes and to fix the decline button's clipping off the bottom of the popup

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
it's just more pleasant to read (and feisty forgot to commit half of these changes i made the first time around; see comments of https://github.com/ProjectOmu/OmuStation/pull/1158)

## Technical details
<!-- Summary of code changes for easier review. -->
changes to `Content.Client/_Funkystation/ContentWarning/ContentWarningPopup.xaml` for sizing
changes to `Resources/Locale/en-US/_Funkystation/content_warning.ftl` for text
i did not see it fit to add omu comments to the content warning since the content warning must necessarily be changed per server (and i also don't know how to make comments in FTL files)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

the first one is my screen's resolution. the second and third are my resizing the window to try to screw up the warning
i do note that the warning can clip off the bottom of the screen at extreme resolutions, but it's draggable so it's a'ight

<img width="1917" height="997" alt="image" src="https://github.com/user-attachments/assets/dbb1fa25-b515-4f62-9eae-67fc102e2975" />
<img width="895" height="705" alt="image" src="https://github.com/user-attachments/assets/979ef525-4bc6-48f7-8fbb-6ca3e1b2321b" />
<img width="768" height="548" alt="image" src="https://github.com/user-attachments/assets/aabc5044-e967-4769-83f4-070ba692f0e0" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Duuckie
- fix: The content warning's reject button no longer clips off the bottom of the popup at certain aspect ratios. The text received minor changes for a better reading experience.

