### PR TITLE
Secure PTech Restock Crates

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/vending.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/vending.yml
@@ -152,7 +152,7 @@
 
 - type: entity
   id: CrateVendingMachineRestockPTechFilled
-  parent: CrateCommandSecure
+  parent: CrateCommandSecure # Omu, changed from plastic to command secure
   name: PTech restock crate
   description: Contains a restock box for the PTech bureaucracy dispenser.
   components:

--- a/Resources/Prototypes/Catalog/Fills/Crates/vending.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/vending.yml
@@ -152,7 +152,7 @@
 
 - type: entity
   id: CrateVendingMachineRestockPTechFilled
-  parent: CratePlastic
+  parent: CrateCommandSecure
   name: PTech restock crate
   description: Contains a restock box for the PTech bureaucracy dispenser.
   components:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
changed PTech Restock Box crates to be secure command instead of normal plastic crates

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
the PTech restock contains all non-command PDAs with appropriate modules and accesses of every department
if you crack open the restock (purchaseable from Cargo for 1,200 spesos), you effectively have station-wide non-command access and every available module (including the wanted list)
this probably isn't intended to be easy

## Technical details
<!-- Summary of code changes for easier review. -->
one-line change in `Resources/Prototypes/Catalog/Fills/Crates/vending.yml` to change the parent of the restock box

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="569" height="323" alt="Screenshot 2026-07-11 140817" src="https://github.com/user-attachments/assets/8d7862c5-a561-4f56-94b6-9277e01a6eb1" />
<img width="1077" height="736" alt="image" src="https://github.com/user-attachments/assets/c5d77457-819c-4dea-9d06-aaa36ded34db" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Duuckie
- tweak: The PTech restock crate is now a secure Command crate.


