### PR TITLE
[FIX] Prevent players abusing a bug to get infinite chems from echem

### DIFF
--- a/Content.Goobstation.Server/Chemistry/EntitySystems/EnergyReagentDispenserSystem.cs
+++ b/Content.Goobstation.Server/Chemistry/EntitySystems/EnergyReagentDispenserSystem.cs
@@ -238,7 +238,7 @@ namespace Content.Goobstation.Server.Chemistry.EntitySystems
         {
             return comp.Reagents.TryGetValue(reagentId, out var cost)
                 ? cost * amount
-                : float.MaxValue;
+                : 0;//float.MaxValue; // Omu, was float.MaxValue
         }
         private void OnMapInit(Entity<EnergyReagentDispenserComponent> entity, ref MapInitEvent args) =>
             _itemSlotsSystem.AddItemSlot(entity.Owner, SharedEnergyReagentDispenser.OutputSlotName, entity.Comp.EnergyBeakerSlot);


### PR DESCRIPTION
Fixes #1040 
## About the PR
Change the default for if a chem isn't in the list of reagents from infinite, to 0. (when refunding chems if its not in the list don't give any energy)

## Why / Balance
It allowed people to make chems far faster than they should have been able to, it's a bug.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed unlisted chems from granting max energy to chem dispensers. 
