### PR TITLE
Security Training Manual In HoS' Locker

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -555,6 +555,7 @@
     - id: ComputerSecurityCommsFlatpack #Omu adds departmental comms board
     - id: Multitool # Omu
     - id: HoSPetKennel #Omu
+    - id: BookCorporateSecretsSecurity # Omu
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable

--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Misc/books.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Misc/books.yml
@@ -15,3 +15,18 @@
   - type: GuideHelp
     guides:
     - CommandTrainingManual
+
+
+- type: entity # omu
+  id: BookCorporateSecretsSecurity
+  parent: [BaseGuidebook, BaseSecurityContraband] # Manual directly states command arent allowed to read it security is, so it makes sense to me.
+  name: security training manual
+  description: There's a big red stamp that says "CONFIDENTIAL" on it. Probably should keep this locked up.
+  components:
+  - type: Sprite
+    sprite: _Funkystation/Objects/Misc/books.rsi
+    layers:
+    - state: corporate-secrets
+  - type: GuideHelp
+    guides:
+    - SecurityTrainingManual


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->

Adds the security training manual in the Head of Security's Locker, since it wasnt a thing for some reason...

the item itself is sec contraband (command arent allowed to read it, but sec is) and has the same sprite as the CMT

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

so I can hand this item to cadets and/or officers that were transferred to sec midshift (So they dont have crew metashield)

## Technical details
<!-- Summary of code changes for easier review. -->

I added the prototype here: Resources\Prototypes/_Funkystation\Entities\Objects\Misc\books.yml
added one line of yaml to add it to HoS' locker here: Resources\Prototypes\Catalog\Fills\Lockers\heads.yml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

I was gonna take a screenshot, but the game refused to load textures correctly and I gave up

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

This is a very simple change, it only adds a new item and adds that item to HoS' locker. its all YAML

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: 4Hangar
- add: Added the Security Training Manual as an item, it can be found in HoS' locker.

