### PR TITLE
Expand and Fix AAC Vocabulary

### DIFF
--- a/Resources/Locale/en-US/_Impstation/phrases/AAC.ftl
+++ b/Resources/Locale/en-US/_Impstation/phrases/AAC.ftl
@@ -207,7 +207,8 @@ imp-phrase-ad-trapped = Trapped
 imp-phrase-ad-big = Big
 imp-phrase-ad-small = Small
 imp-phrase-ad-broken = Broken
-imp-phrase-ad-innocent = Inocent
+# Omu, correct Inocent to Innocent
+imp-phrase-ad-innocent = Innocent
 imp-phrase-ad-guilty = Guilty
 imp-phrase-ad-lethal = Lethal
 imp-phrase-ad-spaced = Spaced
@@ -266,13 +267,14 @@ imp-phrase-nouns-dwarf = Dwarf
 imp-phrase-nouns-vox = Vox
 imp-phrase-nouns-raptor = Allulalo
 imp-phrase-nouns-thaven = Thaven
-imp-phrase-nouns-apid = Apid
-imp-phrase-nouns-deca = Decapoid
+# Omu, below commented-out species are not present; Gray can stay for abductors/tourists
+# imp-phrase-nouns-apid = Apid
+# imp-phrase-nouns-deca = Decapoid
 imp-phrase-nouns-gray = Gray
-imp-phrase-nouns-snail = Gastropoid
-imp-phrase-nouns-shrimp = Anomalocarid
-imp-phrase-nouns-kodi = Kodepiia
-imp-phrase-nouns-ungu = Ungu
+# imp-phrase-nouns-snail = Gastropoid
+# imp-phrase-nouns-shrimp = Anomalocarid
+# imp-phrase-nouns-kodi = Kodepiia
+# imp-phrase-nouns-ungu = Ungu
 imp-phrase-nouns-xeno = Xeno
 imp-phrase-nouns-bird = Bird
 imp-phrase-nouns-cat = Cat
@@ -296,7 +298,8 @@ imp-phrase-nouns-lathe = Lathe
 imp-phrase-nouns-computer = Computer
 imp-phrase-nouns-tool = Tool
 imp-phrase-nouns-fruit = Fruit
-imp-phrase-nouns-veg = Vegtable
+# Omu, correct Vegtable to Vegetable
+imp-phrase-nouns-veg = Vegetable
 imp-phrase-nouns-meat = Meat
 imp-phrase-nouns-access = Access
 imp-phrase-nouns-id = ID
@@ -340,16 +343,19 @@ imp-phrase-nouns-seed = Seed
 imp-phrase-nouns-oven = Oven
 imp-phrase-nouns-art = Art
 imp-phrase-nouns-music = Music
-imp-phrase-nouns-defib = Defibulator
+# Omu, correct Defibulator to Defibrillator
+imp-phrase-nouns-defib = Defibrillator
 imp-phrase-nouns-stasis = Stasis Bed
 imp-phrase-nouns-mail = Mail
 imp-phrase-nouns-exped = Expedition
 imp-phrase-nouns-crime = Crime
 imp-phrase-nouns-cuffs = Handcuffs
-imp-phrase-nouns-warrent = Warrent
+# Omu, correct Warrent to Warrant
+imp-phrase-nouns-warrent = Warrant
 imp-phrase-nouns-brute = Brute
 imp-phrase-nouns-burn = Burn
-imp-phrase-nouns-toxic = Toxic
+# Omu, change from Toxic to Toxin; Toxic is readded in Adjectives
+imp-phrase-nouns-toxic = Toxin
 imp-phrase-nouns-rads = Radiation
 imp-phrase-nouns-poison = Poison
 imp-phrase-nouns-contra = Contraband
@@ -399,7 +405,8 @@ imp-phrase-nouns-welding = Welding Tool
 imp-phrase-nouns-o2 = Oxygen
 imp-phrase-nouns-n2 = Nitrogen
 
-imp-phrase-job-atmos = Atmospherics
+# Omu, replaces Atmospherics with Atmospheric Technician; Atmospherics moved to location
+imp-phrase-job-atmos = Atmospheric Technician
 imp-phrase-job-engie = Engineer
 imp-phrase-job-ce = Chief Engineer
 
@@ -425,7 +432,8 @@ imp-phrase-job-chemist = Chemist
 imp-phrase-job-cmo = Chief Medical Officer
 imp-phrase-job-paramed = Paramedic
 
-imp-phrase-job-qm = Quarter Master
+# Omu, correct Quarter Master to Quartermaster
+imp-phrase-job-qm = Quartermaster
 imp-phrase-job-courier = Courier
 imp-phrase-job-ct = Cargo Technician
 imp-phrase-job-salv = Salvage Specialist
@@ -435,7 +443,8 @@ imp-phrase-job-warden = Warden
 imp-phrase-job-secof = Security Officer
 imp-phrase-job-det = Detective
 
-imp-phrase-job-hop = Head Of Personel
+# Omu, correct Personel to Personnel
+imp-phrase-job-hop = Head Of Personnel
 imp-phrase-job-cap = Captain
 
 imp-phrase-danger-viral = Viral Threat
@@ -460,7 +469,8 @@ imp-phrase-hacked-target = Target
 imp-phrase-hacked-syndie = Syndicate
 imp-phrase-hacked-sacrifice = Sacrifice
 imp-phrase-hacked-sick = Paid Sick Leave
-imp-phrase-hacked-rights = Workers Rights
+# Omu, change from Workers to Worker for correctness
+imp-phrase-hacked-rights = Worker Rights
 imp-phrase-hacked-benifits = Benefits
 imp-phrase-hacked-deathsquad = Death Squad
 imp-phrase-hacked-straight = Straight

--- a/Resources/Locale/en-US/_Omu/phrases/AAC.ftl
+++ b/Resources/Locale/en-US/_Omu/phrases/AAC.ftl
@@ -1,0 +1,116 @@
+omu-phrase-but = But
+omu-phrase-with = With
+omu-phrase-other = Other
+
+omu-phrase-verb-be = Be
+
+omu-phrase-locations-to = To
+omu-phrase-locations-behind = Behind
+omu-phrase-locations-of = Of
+omu-phrase-locations-front = Front
+omu-phrase-locations-under = Under
+omu-phrase-locations-over = Over
+omu-phrase-locations-through = Through
+omu-phrase-locations-between = Between
+omu-phrase-locations-around = Around
+
+omu-phrase-locations-atmos = Atmospherics
+
+omu-phrase-determiners-a = A
+omu-phrase-determiners-the = The
+
+omu-phrase-determiners-most = Most
+omu-phrase-determiners-least = Least
+
+omu-phrase-ad-bluespace = Bluespace
+omu-phrase-ad-experimental = Experimental
+omu-phrase-ad-advanced = Advanced
+omu-phrase-ad-toxic = Toxic
+omu-phrase-ad-blind = Blind
+omu-phrase-ad-deaf = Deaf
+omu-phrase-ad-another = Another
+
+omu-phrase-ad-pink = Pink
+
+omu-phrase-nouns-battery = Battery
+omu-phrase-nouns-drink = Drink
+
+omu-phrase-nouns-airloss = Airloss
+omu-phrase-nouns-genetic = Genetic
+omu-phrase-nouns-heat = Heat
+omu-phrase-nouns-shock = Shock
+omu-phrase-nouns-cold = Cold
+omu-phrase-nouns-caustic = Caustic
+omu-phrase-nouns-asphyx = Asphyxiation
+omu-phrase-nouns-bloodloss = Bloodloss
+omu-phrase-nouns-blunt = Blunt
+omu-phrase-nouns-slash = Slash
+omu-phrase-nouns-piercing = Piercing
+omu-phrase-nouns-cellular = Cellular
+
+omu-phrase-nouns-avali = Avali
+omu-phrase-nouns-chitinid = Chitinid
+omu-phrase-nouns-felinid = Felinid
+omu-phrase-nouns-feroxi = Feroxi
+omu-phrase-nouns-harpy = Harpy
+omu-phrase-nouns-ipc = IPC
+omu-phrase-nouns-oni = Oni
+omu-phrase-nouns-plasmaman = Plasmaman
+omu-phrase-nouns-resomi = Resomi
+omu-phrase-nouns-rodentia = Rodentia
+omu-phrase-nouns-shadowkin = Shadowkin
+omu-phrase-nouns-shrimp = Shrimp
+omu-phrase-nouns-tajaran = Tajaran
+omu-phrase-nouns-vulpkanin = Vulpkanin
+omu-phrase-nouns-xelthia = Xelthia
+omu-phrase-nouns-yowie = Yowie
+
+omu-phrase-nouns-never = Never
+omu-phrase-nouns-then = Then
+omu-phrase-nouns-ago = Ago
+
+omu-phrase-nouns-coworker = Coworker
+
+omu-phrase-nouns-artifactfragment = Artifact Fragment
+omu-phrase-nouns-crystal = Crystal
+
+omu-phrase-nouns-wirecutter = Wirecutter
+omu-phrase-nouns-trayscanner = T-ray Scanner
+omu-phrase-nouns-gasanalyzer = Gas Analyzer
+omu-phrase-nouns-jawsoflife = Jaws Of Life
+omu-phrase-nouns-powerdrill = Power Drill
+omu-phrase-nouns-holofan = Holofan
+
+omu-phrase-job-stationengineer = Station Engineer
+omu-phrase-job-technicalassistant = Technical Assistant
+
+omu-phrase-job-researchassistant = Research Assistant
+omu-phrase-job-roboticist = Roboticist
+
+omu-phrase-job-serviceworker = Service Worker
+omu-phrase-job-chaplain = Chaplain
+omu-phrase-job-librarian = Librarian
+omu-phrase-job-musician = Musician
+omu-phrase-job-radiohost = Radio Host
+
+omu-phrase-job-medicaldoctor = Medical Doctor
+omu-phrase-job-psychologist = Psychologist
+omu-phrase-job-virologist = Virologist
+omu-phrase-job-medicalintern = Medical Intern
+
+omu-phrase-job-shaftminer = Shaft Miner
+
+omu-phrase-job-securitycadet = Security Cadet
+omu-phrase-job-corpsman = Corpsman
+omu-phrase-job-prisoner = Prisoner
+omu-phrase-job-sergeant = Sergeant
+omu-phrase-job-officer = Officer
+
+omu-phrase-job-assistant = Assistant
+omu-phrase-job-visitor = Visitor
+
+omu-phrase-job-commandmaid = Command Maid
+omu-phrase-job-administrativeassistant = Administrative Assistant
+omu-phrase-job-nanotrasenrepresentative = Nanotrasen Representative
+omu-phrase-job-nanotrasencareertrainer = Nanotrasen Career Trainer
+omu-phrase-job-blueshieldofficer = Blueshield Officer

--- a/Resources/Locale/en-US/_Omu/phrases/AAC.ftl
+++ b/Resources/Locale/en-US/_Omu/phrases/AAC.ftl
@@ -81,6 +81,23 @@ omu-phrase-nouns-jawsoflife = Jaws Of Life
 omu-phrase-nouns-powerdrill = Power Drill
 omu-phrase-nouns-holofan = Holofan
 
+omu-phrase-nouns-head = Head
+omu-phrase-nouns-chest = Chest
+omu-phrase-nouns-arm = Arm
+omu-phrase-nouns-hand = Hand
+# I was given the go-ahead to include this. May it be used moderately appropriately — Duuckie
+omu-phrase-nouns-groin = Groin
+omu-phrase-nouns-leg = Leg
+omu-phrase-nouns-foot = Foot
+
+omu-phrase-nouns-heart = Heart
+omu-phrase-nouns-lungs = Lungs
+omu-phrase-nouns-stomach = Stomach
+omu-phrase-nouns-liver = Liver
+omu-phrase-nouns-kidneys = Kidneys
+omu-phrase-nouns-brain = Brain
+omu-phrase-nouns-eyes = Eyes
+
 omu-phrase-job-stationengineer = Station Engineer
 omu-phrase-job-technicalassistant = Technical Assistant
 

--- a/Resources/Locale/en-US/_Omu/phrases/AAC.ftl
+++ b/Resources/Locale/en-US/_Omu/phrases/AAC.ftl
@@ -3,6 +3,8 @@ omu-phrase-with = With
 omu-phrase-other = Other
 
 omu-phrase-verb-be = Be
+omu-phrase-verb-see = See
+omu-phrase-verb-cut = Cut
 
 omu-phrase-locations-to = To
 omu-phrase-locations-behind = Behind

--- a/Resources/Prototypes/_Impstation/QuickPhrases/danger.yml
+++ b/Resources/Prototypes/_Impstation/QuickPhrases/danger.yml
@@ -16,7 +16,7 @@
   text: imp-phrase-danger-lifeform
 
 - type: quickPhrase
-  id: BokenEqPhraseImp
+  id: BrokenEqPhraseImp # Omu, fix typo
   parent: BaseDangerImp
   text: imp-phrase-danger-brokeneq
 

--- a/Resources/Prototypes/_Impstation/QuickPhrases/jobs.yml
+++ b/Resources/Prototypes/_Impstation/QuickPhrases/jobs.yml
@@ -39,6 +39,20 @@
   group: Security
   abstract: true
 
+# Omu, adds Civilian and Non-departmental command
+# Outside of Omu namespace due to Passenger, Lawyer and Captain
+- type: quickPhrase
+  id: BaseJobsOmuCivilian
+  parent: BaseJobsImp
+  group: Civilian
+  abstract: true
+
+- type: quickPhrase
+  id: BaseJobsOmuNonDepartmentalCommand
+  parent: BaseJobsImp
+  group: Non-departmental command
+  abstract: true
+
 # engie
 
 - type: quickPhrase
@@ -95,10 +109,11 @@
   parent: BaseJobsImpService
   text: imp-phrase-job-mime
 
-- type: quickPhrase
-  id: HDPhraseImp
-  parent: BaseJobsImpService
-  text: imp-phrase-job-hd
+# Omu, we don't have this job
+# - type: quickPhrase
+#   id: HDPhraseImp
+#   parent: BaseJobsImpService
+#   text: imp-phrase-job-hd
 
 - type: quickPhrase
   id: BotanistPhraseImp
@@ -172,38 +187,39 @@
   text: imp-phrase-job-det
 
 # other
+# Omu, all "other" jobs are moved to appropriate categories
 
 - type: quickPhrase
   id: HOPPhraseImp
-  parent: BaseJobsImp
+  parent: BaseJobsImpService # Omu
   text: imp-phrase-job-hop
 
 - type: quickPhrase
   id: CapPhraseImp
-  parent: BaseJobsImp
+  parent: BaseJobsOmuNonDepartmentalCommand # Omu
   text: imp-phrase-job-cap
 
 - type: quickPhrase
   id: PassengerPhraseImp
-  parent: BaseJobsImp
+  parent: BaseJobsOmuCivilian # Omu
   text: imp-phrase-job-passenger
 
 - type: quickPhrase
   id: ReporterPhraseImp
-  parent: BaseJobsImp
+  parent: BaseJobsImpService # Omu
   text: imp-phrase-job-reporter
 
 - type: quickPhrase
   id: LawyerPhraseImp
-  parent: BaseJobsImp
+  parent: BaseJobsOmuCivilian # Omu; not sec, not service
   text: imp-phrase-job-lawyer
 
 - type: quickPhrase
   id: ZookeeperPhraseImp
-  parent: BaseJobsImp
+  parent: BaseJobsImpService # Omu
   text: imp-phrase-job-zookeeper
 
 - type: quickPhrase
   id: BoxerPhraseImp
-  parent: BaseJobsImp
+  parent: BaseJobsImpService # Omu (somehow they get service comms)
   text: imp-phrase-job-boxer

--- a/Resources/Prototypes/_Impstation/QuickPhrases/locations.yml
+++ b/Resources/Prototypes/_Impstation/QuickPhrases/locations.yml
@@ -3,10 +3,22 @@
   tab: Locations
   abstract: true
 
+- type: quickPhrase # Omu, categorize unlabeled location words
+  id: BaseLocationsRelative
+  parent: BaseLocations
+  group: Directions (Relative)
+  abstract: true
+
+- type: quickPhrase # Omu, categorize unlabeled location words
+  id: BaseLocationsPrepositional
+  parent: BaseLocations
+  group: Prepositions
+  abstract: true
+
 - type: quickPhrase
   id: BaseLocationsCardinal
   parent: BaseLocations
-  group: Cardinal directions
+  group: Directions (Cardinal) # Omu, keeps the relative and cardinal directions close in the menu
   abstract: true
 
 - type: quickPhrase
@@ -19,32 +31,32 @@
 
 - type: quickPhrase
   id: UpPhraseImp
-  parent: BaseLocations
+  parent: BaseLocationsRelative # Omu, categorize unlabeled words
   text: imp-phrase-locations-up
 
 - type: quickPhrase
   id: DownPhraseImp
-  parent: BaseLocations
+  parent: BaseLocationsRelative # Omu, categorize unlabeled words
   text: imp-phrase-locations-down
 
 - type: quickPhrase
   id: LeftPhraseImp
-  parent: BaseLocations
+  parent: BaseLocationsRelative # Omu, categorize unlabeled words
   text: imp-phrase-locations-left
 
 - type: quickPhrase
   id: RightPhraseImp
-  parent: BaseLocations
+  parent: BaseLocationsRelative # Omu, categorize unlabeled words
   text: imp-phrase-locations-right
 
 - type: quickPhrase
   id: InsidePhraseImp
-  parent: BaseLocations
+  parent: BaseLocationsPrepositional # Omu, categorize unlabeled words
   text: imp-phrase-locations-inside
 
 - type: quickPhrase
   id: OutsidePhraseImp
-  parent: BaseLocations
+  parent: BaseLocationsPrepositional # Omu, categorize unlabeled words
   text: imp-phrase-locations-outside
 
 # cardinal

--- a/Resources/Prototypes/_Impstation/QuickPhrases/nouns.yml
+++ b/Resources/Prototypes/_Impstation/QuickPhrases/nouns.yml
@@ -10,9 +10,15 @@
   abstract: true
 
 - type: quickPhrase
-  id: BaseNounsHurt
+  id: BaseNounsDamageGeneral
   parent: BaseNouns
-  group: Damage types
+  group: Damage types (General) # Omu, divide Damage types into General and Specific
+  abstract: true
+
+- type: quickPhrase
+  id: BaseNounsDamageSpecific
+  parent: BaseNouns
+  group: Damage types (Specific) # Omu, divide Damage types into General and Specific
   abstract: true
 
 - type: quickPhrase
@@ -435,27 +441,27 @@
 
 - type: quickPhrase
   id: BrutePhraseImp
-  parent: BaseNounsHurt
+  parent: BaseNounsDamageGeneral # Omu, divide into General and Specific damage types
   text: imp-phrase-nouns-brute
 
 - type: quickPhrase
   id: BurnPhraseImp
-  parent: BaseNounsHurt
+  parent: BaseNounsDamageGeneral # Omu, divide into General and Specific damage types
   text: imp-phrase-nouns-burn
 
 - type: quickPhrase
   id: ToxicPhraseImp
-  parent: BaseNounsHurt
+  parent: BaseNounsDamageGeneral # Omu, divide into General and Specific damage 
   text: imp-phrase-nouns-toxic
 
 - type: quickPhrase
   id: RadsPhraseImp
-  parent: BaseNounsHurt
+  parent: BaseNounsDamageSpecific # Omu, divide into General and Specific damage types
   text: imp-phrase-nouns-rads
 
 - type: quickPhrase
   id: PoisonPhraseImp
-  parent: BaseNounsHurt
+  parent: BaseNounsDamageSpecific # Omu, divide into General and Specific damage types
   text: imp-phrase-nouns-poison
 
 # species
@@ -510,40 +516,46 @@
   parent: BaseNounsSpecies
   text: imp-phrase-nouns-thaven
 
-- type: quickPhrase
-  id: ApidPhraseImp
-  parent: BaseNounsSpecies
-  text: imp-phrase-nouns-apid
+# Omu, not present
+# - type: quickPhrase
+#   id: ApidPhraseImp
+#   parent: BaseNounsSpecies
+#   text: imp-phrase-nouns-apid
 
-- type: quickPhrase
-  id: DecaPhraseImp
-  parent: BaseNounsSpecies
-  text: imp-phrase-nouns-deca
+# Omu, not present
+# - type: quickPhrase
+#   id: DecaPhraseImp
+#   parent: BaseNounsSpecies
+#   text: imp-phrase-nouns-deca
 
 - type: quickPhrase
   id: GrayPhraseImp
   parent: BaseNounsSpecies
   text: imp-phrase-nouns-gray
+  
+# Omu, not present
+# - type: quickPhrase
+#   id: SnailPhraseImp
+#   parent: BaseNounsSpecies
+#   text: imp-phrase-nouns-snail
 
-- type: quickPhrase
-  id: SnailPhraseImp
-  parent: BaseNounsSpecies
-  text: imp-phrase-nouns-snail
+# Omu, not present
+# - type: quickPhrase
+#   id: ShrimpPhraseImp
+#   parent: BaseNounsSpecies
+#   text: imp-phrase-nouns-shrimp
 
-- type: quickPhrase
-  id: ShrimpPhraseImp
-  parent: BaseNounsSpecies
-  text: imp-phrase-nouns-shrimp
+# Omu, not present
+# - type: quickPhrase
+#   id: KodiPhraseImp
+#   parent: BaseNounsSpecies
+#   text: imp-phrase-nouns-kodi
 
-- type: quickPhrase
-  id: KodiPhraseImp
-  parent: BaseNounsSpecies
-  text: imp-phrase-nouns-kodi
-
-- type: quickPhrase
-  id: UnguPhraseImp
-  parent: BaseNounsSpecies
-  text: imp-phrase-nouns-ungu
+# Omu, not present
+# - type: quickPhrase
+#   id: UnguPhraseImp
+#   parent: BaseNounsSpecies
+#   text: imp-phrase-nouns-ungu
 
 - type: quickPhrase
   id: XenoPhraseImp

--- a/Resources/Prototypes/_Impstation/QuickPhrases/phrases_groups.yml
+++ b/Resources/Prototypes/_Impstation/QuickPhrases/phrases_groups.yml
@@ -411,7 +411,23 @@
     - GasAnalyzerPhraseOmu
     - JawsOfLifePhraseOmu
     - PowerDrillPhraseOmu
-    - HolofanPhraseOmu # Omu end
+    - HolofanPhraseOmu
+  # Omu, body parts (external)
+    - HeadPhraseOmu
+    - ChestPhraseOmu
+    - ArmPhraseOmu
+    - HandPhraseOmu
+    - GroinPhraseOmu
+    - LegPhraseOmu
+    - FootPhraseOmu
+  # Omu, body parts (internal)
+    - HeartPhraseOmu
+    - LungsPhraseOmu
+    - StomachPhraseOmu
+    - LiverPhraseOmu
+    - KidneysPhraseOmu
+    - BrainPhraseOmu
+    - EyesPhraseOmu # Omu end
   # locations
     - UpPhraseImp
     - DownPhraseImp
@@ -960,7 +976,23 @@
     - GasAnalyzerPhraseOmu
     - JawsOfLifePhraseOmu
     - PowerDrillPhraseOmu
-    - HolofanPhraseOmu # Omu end
+    - HolofanPhraseOmu
+  # Omu, body parts (external)
+    - HeadPhraseOmu
+    - ChestPhraseOmu
+    - ArmPhraseOmu
+    - HandPhraseOmu
+    - GroinPhraseOmu
+    - LegPhraseOmu
+    - FootPhraseOmu
+  # Omu, body parts (internal)
+    - HeartPhraseOmu
+    - LungsPhraseOmu
+    - StomachPhraseOmu
+    - LiverPhraseOmu
+    - KidneysPhraseOmu
+    - BrainPhraseOmu
+    - EyesPhraseOmu # Omu end
   # locations
     - UpPhraseImp
     - DownPhraseImp

--- a/Resources/Prototypes/_Impstation/QuickPhrases/phrases_groups.yml
+++ b/Resources/Prototypes/_Impstation/QuickPhrases/phrases_groups.yml
@@ -191,7 +191,9 @@
     - ClearPhraseImp
     - InjectPhraseImp
     - ArrestPhraseImp
-    - BePhraseOmu # Omu
+    - BePhraseOmu # Omu start
+    - SeePhraseOmu
+    - CutPhraseOmu # Omu end
   # determiners
     - MyPhraseImp
     - MinePhraseImp
@@ -756,7 +758,9 @@
     - ClearPhraseImp
     - InjectPhraseImp
     - ArrestPhraseImp
-    - BePhraseOmu # Omu
+    - BePhraseOmu # Omu start
+    - SeePhraseOmu
+    - CutPhraseOmu # Omu end
   # determiners
     - MyPhraseImp
     - MinePhraseImp

--- a/Resources/Prototypes/_Impstation/QuickPhrases/phrases_groups.yml
+++ b/Resources/Prototypes/_Impstation/QuickPhrases/phrases_groups.yml
@@ -21,6 +21,9 @@
     - ThanksPhraseImp
     - SorryPhraseImp
     - HelpPhraseImp
+    - ButPhraseOmu # Omu start
+    - WithPhraseOmu
+    - OtherPhraseOmu # Omu end
   # common group
     - HowAreYouPhraseImp
     - IAmPhraseImp
@@ -110,6 +113,13 @@
     - HandsomePhraseImp
     - KindPhraseImp
     - CruelPhraseImp
+    - BluespacePhraseOmu # Omu start
+    - ExperimentalPhraseOmu
+    - AdvancedPhraseOmu
+    - ToxicPhraseOmu
+    - BlindPhraseOmu
+    - DeafPhraseOmu
+    - AnotherPhraseOmu # Omu end
   # colours
     - RedPhraseImp
     - OrangePhraseImp
@@ -121,6 +131,7 @@
     - RainbowPhraseImp
     - BlackPhraseImp
     - WhitePhraseImp
+    - PinkPhraseOmu # Omu
   # feelings
     - LikePhraseImp
     - HatePhraseImp
@@ -155,7 +166,7 @@
     - EatPhraseImp
     - DrinkPhraseImp
     - WantPhraseImp
-    - WantPhraseImp
+    # - WantPhraseImp # Omu, duplicated phrase
     - TalkPhraseImp
     - WritePhraseImp
     - BreakPhraseImp
@@ -180,16 +191,21 @@
     - ClearPhraseImp
     - InjectPhraseImp
     - ArrestPhraseImp
+    - BePhraseOmu # Omu
   # determiners
     - MyPhraseImp
     - MinePhraseImp
     - OursPhraseImp
     - YoursPhraseImp
+    - APhraseOmu # Omu
+    - ThePhraseOmu # Omu
   # amounts
     - AllPhraseImp
     - NothingPhraseImp
     - MorePhraseImp
     - LessPhraseImp
+    - MostPhraseOmu # Omu
+    - LeastPhraseOmu # Omu
   # numbers
     - 1PhraseImp
     - 2PhraseImp
@@ -212,7 +228,7 @@
     - PDAPhraseImp
     - BountyPhraseImp
     - FoodPhraseImp
-    - DrinkPhraseImp
+    # - DrinkPhraseImp # Omu, conflicts with Drink (verb); verb will stay
     - WeaponPhraseImp
     - GunPhraseImp
     - KnifePhraseImp
@@ -285,12 +301,25 @@
     - BombPhraseImp
     - O2PhraseImp
     - N2PhraseImp
+    - BatteryPhraseOmu # Omu
   # damage
     - BrutePhraseImp
     - BurnPhraseImp
     - ToxicPhraseImp
     - RadsPhraseImp
     - PoisonPhraseImp
+    - AirlossPhraseOmu # Omu start
+    - GeneticPhraseOmu
+    - HeatPhraseOmu
+    - ShockPhraseOmu
+    - ColdPhraseOmu
+    - CausticPhraseOmu
+    - AsphyxPhraseOmu
+    - BloodlossPhraseOmu
+    - BluntPhraseOmu
+    - SlashPhraseOmu
+    - PiercingPhraseOmu
+    - CellularPhraseOmu # Omu end
   # species
     - DionaPhraseImp
     - SlimePhraseImp
@@ -302,13 +331,14 @@
     - VoxPhraseImp
     - RaptorPhraseImp
     - ThavenPhraseImp
-    - ApidPhraseImp
-    - DecaPhraseImp
+    # Omu, comment out species that we don't have
+    # - ApidPhraseImp
+    # - DecaPhraseImp
     - GrayPhraseImp
-    - SnailPhraseImp
-    - ShrimpPhraseImp
-    - KodiPhraseImp
-    - UnguPhraseImp
+    # - SnailPhraseImp
+    # - ShrimpPhraseImp
+    # - KodiPhraseImp
+    # - UnguPhraseImp
     - XenoPhraseImp
     - BirdPhraseImp
     - CatPhraseImp
@@ -317,6 +347,22 @@
     - BugPhraseImp
     - PestPhraseImp
     - PetPhraseImp
+    - AvaliPhraseOmu # Omu start
+    - ChitinidPhraseOmu
+    - FelinidPhraseOmu
+    - FeroxiPhraseOmu
+    - HarpyPhraseOmu
+    - IPCPhraseOmu
+    - OniPhraseOmu
+    - PlasmamanPhraseOmu
+    - ResomiPhraseOmu
+    - RodentiaPhraseOmu
+    - ShadowkinPhraseOmu
+    - ShrimpPhraseOmu
+    - TajaranPhraseOmu
+    - VulpkaninPhraseOmu
+    - XelthiaPhraseOmu
+    - YowiePhraseOmu # Omu end
   # time
     - SecondPhraseImp
     - HourPhraseImp
@@ -326,6 +372,9 @@
     - LaterPhraseImp
     - SoonPhraseImp
     - NextPhraseImp
+    - NeverPhraseOmu # Omu start
+    - ThenPhraseOmu
+    - AgoPhraseOmu # Omu end
   # relationships
     - FriendPhraseImp
     - PartnerPhraseImp
@@ -335,6 +384,7 @@
     - SiblingPhraseImp
     - StrangerPhraseImp
     - BossPhraseImp
+    - CoworkerPhraseOmu # Omu
   # mats
     - SteelPhraseImp
     - PlasteelPhraseImp
@@ -348,12 +398,20 @@
     - QuartzPhraseImp
     - WoodPhraseImp
     - CardPhraseImp
+    - ArtifactFragmentPhraseOmu # Omu
+    - CrystalPhraseOmu # Omu
   # tools
     - WrenchPhraseImp
     - CrowbarPhraseImp
     - MultitoolPhraseImp
     - ScrewdriverPhraseImp
     - WeldingPhraseImp
+    - WirecutterPhraseOmu # Omu start
+    - TRayScannerPhraseOmu
+    - GasAnalyzerPhraseOmu
+    - JawsOfLifePhraseOmu
+    - PowerDrillPhraseOmu
+    - HolofanPhraseOmu # Omu end
   # locations
     - UpPhraseImp
     - DownPhraseImp
@@ -361,6 +419,15 @@
     - RightPhraseImp
     - InsidePhraseImp
     - OutsidePhraseImp
+    - FrontPhraseOmu # Omu start
+    - BehindPhraseOmu
+    - ToPhraseOmu
+    - OfPhraseOmu
+    - UnderPhraseOmu
+    - OverPhraseOmu
+    - ThroughPhraseOmu
+    - BetweenPhraseOmu
+    - AroundPhraseOmu # Omu end
   # cardinal
     - NorthPhraseImp
     - SouthPhraseImp
@@ -399,6 +466,8 @@
     - StagePhraseImp
     - ChemPhraseImp
     - ArmouryPhraseImp
+    - BridgePhraseImp # Omu; this goes unused originally
+    - AtmosPhraseOmu # Omu
   # jobs
     - AtmosPhraseImp
     - EngiePhraseImp
@@ -410,7 +479,7 @@
     - JaniPhraseImp
     - ClownPhraseImp
     - MimePhraseImp
-    - HDPhraseImp
+    # - HDPhraseImp # Omu, we don't have this job
     - BotanistPhraseImp
     - MedicPhraseImp
     - ChemistPhraseImp
@@ -431,10 +500,47 @@
     - LawyerPhraseImp
     - ZookeeperPhraseImp
     - BoxerPhraseImp
+    # Omu start
+    # engi
+    - StationEngineerPhraseOmu
+    - TechnicalAssistantPhraseOmu
+    # sci
+    - ResearchAssistantPhraseOmu
+    - RoboticistPhraseOmu
+    # service
+    - ServiceWorkerPhraseOmu
+    - ChaplainPhraseOmu
+    - LibrarianPhraseOmu
+    - MusicianPhraseOmu
+    - RadioHostPhraseOmu
+    # med
+    - MedicalDoctorPhraseOmu
+    - PsychologistPhraseOmu
+    - VirologistPhraseOmu
+    - MedicalInternPhraseOmu
+    # cargo
+    - ShaftMinerPhraseOmu
+    # sec
+    - SecurityCadetPhraseOmu
+    - CorpsmanPhraseOmu
+    - PrisonerPhraseOmu
+    - SergeantPhraseOmu
+    - OfficerPhraseOmu
+    # civilian
+    - AssistantPhraseOmu
+    - VisitorPhraseOmu
+    # non-departmental command; includes captain
+    - CommandMaidPhraseOmu
+    - AdministrativeAssistantPhraseOmu
+    # centcomm
+    - NanotrasenRepresentativePhraseOmu
+    - NanotrasenCareerTrainerPhraseOmu
+    - BlueshieldOfficerPhraseOmu
+    # Omu end
   # danger
     - ViralPhraseImp
     - LifeformPhraseImp
-    - BrokenPhraseImp
+    - BrokenEqPhraseImp # Omu, corrected to BrokenEqPhrase
     - ChemSpillPhraseImp
     - ShockPhraseImp
     - PowerOutPhraseImp
@@ -444,6 +550,7 @@
 - type: quickPhraseGroup
   id: HackedPhrasesImp # THERE HAS TO BE A BETTER WAY
   prototypes:
+  # Common
     - IPhraseImp
     - YouPhraseImp
     - MePhraseImp
@@ -463,6 +570,9 @@
     - ThanksPhraseImp
     - SorryPhraseImp
     - HelpPhraseImp
+    - ButPhraseOmu # Omu start
+    - WithPhraseOmu
+    - OtherPhraseOmu # Omu end
   # common group
     - HowAreYouPhraseImp
     - IAmPhraseImp
@@ -552,6 +662,13 @@
     - HandsomePhraseImp
     - KindPhraseImp
     - CruelPhraseImp
+    - BluespacePhraseOmu # Omu start
+    - ExperimentalPhraseOmu
+    - AdvancedPhraseOmu
+    - ToxicPhraseOmu
+    - BlindPhraseOmu
+    - DeafPhraseOmu
+    - AnotherPhraseOmu # Omu end
   # colours
     - RedPhraseImp
     - OrangePhraseImp
@@ -563,6 +680,7 @@
     - RainbowPhraseImp
     - BlackPhraseImp
     - WhitePhraseImp
+    - PinkPhraseOmu # Omu
   # feelings
     - LikePhraseImp
     - HatePhraseImp
@@ -597,7 +715,7 @@
     - EatPhraseImp
     - DrinkPhraseImp
     - WantPhraseImp
-    - WantPhraseImp
+    # - WantPhraseImp # Omu, duplicated phrase
     - TalkPhraseImp
     - WritePhraseImp
     - BreakPhraseImp
@@ -622,16 +740,21 @@
     - ClearPhraseImp
     - InjectPhraseImp
     - ArrestPhraseImp
+    - BePhraseOmu # Omu
   # determiners
     - MyPhraseImp
     - MinePhraseImp
     - OursPhraseImp
     - YoursPhraseImp
+    - APhraseOmu # Omu
+    - ThePhraseOmu # Omu
   # amounts
     - AllPhraseImp
     - NothingPhraseImp
     - MorePhraseImp
     - LessPhraseImp
+    - MostPhraseOmu # Omu
+    - LeastPhraseOmu # Omu
   # numbers
     - 1PhraseImp
     - 2PhraseImp
@@ -654,7 +777,7 @@
     - PDAPhraseImp
     - BountyPhraseImp
     - FoodPhraseImp
-    - DrinkPhraseImp
+    # - DrinkPhraseImp # Omu, conflicts with Drink (verb); verb will stay
     - WeaponPhraseImp
     - GunPhraseImp
     - KnifePhraseImp
@@ -727,12 +850,25 @@
     - BombPhraseImp
     - O2PhraseImp
     - N2PhraseImp
+    - BatteryPhraseOmu # Omu
   # damage
     - BrutePhraseImp
     - BurnPhraseImp
     - ToxicPhraseImp
     - RadsPhraseImp
     - PoisonPhraseImp
+    - AirlossPhraseOmu # Omu start
+    - GeneticPhraseOmu
+    - HeatPhraseOmu
+    - ShockPhraseOmu
+    - ColdPhraseOmu
+    - CausticPhraseOmu
+    - AsphyxPhraseOmu
+    - BloodlossPhraseOmu
+    - BluntPhraseOmu
+    - SlashPhraseOmu
+    - PiercingPhraseOmu
+    - CellularPhraseOmu # Omu end
   # species
     - DionaPhraseImp
     - SlimePhraseImp
@@ -744,13 +880,14 @@
     - VoxPhraseImp
     - RaptorPhraseImp
     - ThavenPhraseImp
-    - ApidPhraseImp
-    - DecaPhraseImp
+    # Omu, comment out species that we don't have
+    # - ApidPhraseImp
+    # - DecaPhraseImp
     - GrayPhraseImp
-    - SnailPhraseImp
-    - ShrimpPhraseImp
-    - KodiPhraseImp
-    - UnguPhraseImp
+    # - SnailPhraseImp
+    # - ShrimpPhraseImp
+    # - KodiPhraseImp
+    # - UnguPhraseImp
     - XenoPhraseImp
     - BirdPhraseImp
     - CatPhraseImp
@@ -759,6 +896,22 @@
     - BugPhraseImp
     - PestPhraseImp
     - PetPhraseImp
+    - AvaliPhraseOmu # Omu start
+    - ChitinidPhraseOmu
+    - FelinidPhraseOmu
+    - FeroxiPhraseOmu
+    - HarpyPhraseOmu
+    - IPCPhraseOmu
+    - OniPhraseOmu
+    - PlasmamanPhraseOmu
+    - ResomiPhraseOmu
+    - RodentiaPhraseOmu
+    - ShadowkinPhraseOmu
+    - ShrimpPhraseOmu
+    - TajaranPhraseOmu
+    - VulpkaninPhraseOmu
+    - XelthiaPhraseOmu
+    - YowiePhraseOmu # Omu end
   # time
     - SecondPhraseImp
     - HourPhraseImp
@@ -768,6 +921,9 @@
     - LaterPhraseImp
     - SoonPhraseImp
     - NextPhraseImp
+    - NeverPhraseOmu # Omu start
+    - ThenPhraseOmu
+    - AgoPhraseOmu # Omu end
   # relationships
     - FriendPhraseImp
     - PartnerPhraseImp
@@ -777,6 +933,7 @@
     - SiblingPhraseImp
     - StrangerPhraseImp
     - BossPhraseImp
+    - CoworkerPhraseOmu # Omu
   # mats
     - SteelPhraseImp
     - PlasteelPhraseImp
@@ -790,12 +947,20 @@
     - QuartzPhraseImp
     - WoodPhraseImp
     - CardPhraseImp
+    - ArtifactFragmentPhraseOmu # Omu
+    - CrystalPhraseOmu # Omu
   # tools
     - WrenchPhraseImp
     - CrowbarPhraseImp
     - MultitoolPhraseImp
     - ScrewdriverPhraseImp
     - WeldingPhraseImp
+    - WirecutterPhraseOmu # Omu start
+    - TRayScannerPhraseOmu
+    - GasAnalyzerPhraseOmu
+    - JawsOfLifePhraseOmu
+    - PowerDrillPhraseOmu
+    - HolofanPhraseOmu # Omu end
   # locations
     - UpPhraseImp
     - DownPhraseImp
@@ -803,6 +968,15 @@
     - RightPhraseImp
     - InsidePhraseImp
     - OutsidePhraseImp
+    - FrontPhraseOmu # Omu start
+    - BehindPhraseOmu
+    - ToPhraseOmu
+    - OfPhraseOmu
+    - UnderPhraseOmu
+    - OverPhraseOmu
+    - ThroughPhraseOmu
+    - BetweenPhraseOmu
+    - AroundPhraseOmu # Omu end
   # cardinal
     - NorthPhraseImp
     - SouthPhraseImp
@@ -841,6 +1015,8 @@
     - StagePhraseImp
     - ChemPhraseImp
     - ArmouryPhraseImp
+    - BridgePhraseImp # Omu; this goes unused originally
+    - AtmosPhraseOmu # Omu
   # jobs
     - AtmosPhraseImp
     - EngiePhraseImp
@@ -852,7 +1028,7 @@
     - JaniPhraseImp
     - ClownPhraseImp
     - MimePhraseImp
-    - HDPhraseImp
+    # - HDPhraseImp # Omu, we don't have this job
     - BotanistPhraseImp
     - MedicPhraseImp
     - ChemistPhraseImp
@@ -873,10 +1049,47 @@
     - LawyerPhraseImp
     - ZookeeperPhraseImp
     - BoxerPhraseImp
+    # Omu start
+    # engi
+    - StationEngineerPhraseOmu
+    - TechnicalAssistantPhraseOmu
+    # sci
+    - ResearchAssistantPhraseOmu
+    - RoboticistPhraseOmu
+    # service
+    - ServiceWorkerPhraseOmu
+    - ChaplainPhraseOmu
+    - LibrarianPhraseOmu
+    - MusicianPhraseOmu
+    - RadioHostPhraseOmu
+    # med
+    - MedicalDoctorPhraseOmu
+    - PsychologistPhraseOmu
+    - VirologistPhraseOmu
+    - MedicalInternPhraseOmu
+    # cargo
+    - ShaftMinerPhraseOmu
+    # sec
+    - SecurityCadetPhraseOmu
+    - CorpsmanPhraseOmu
+    - PrisonerPhraseOmu
+    - SergeantPhraseOmu
+    - OfficerPhraseOmu
+    # civilian
+    - AssistantPhraseOmu
+    - VisitorPhraseOmu
+    # non-departmental command; includes captain
+    - CommandMaidPhraseOmu
+    - AdministrativeAssistantPhraseOmu
+    # centcomm
+    - NanotrasenRepresentativePhraseOmu
+    - NanotrasenCareerTrainerPhraseOmu
+    - BlueshieldOfficerPhraseOmu
+    # Omu end
   # danger
     - ViralPhraseImp
     - LifeformPhraseImp
-    - BrokenPhraseImp
+    - BrokenEqPhraseImp # Omu, corrected to BrokenEqPhrase
     - ChemSpillPhraseImp
     - ShockPhraseImp
     - PowerOutPhraseImp

--- a/Resources/Prototypes/_Omu/QuickPhrases/adjectives.yml
+++ b/Resources/Prototypes/_Omu/QuickPhrases/adjectives.yml
@@ -1,0 +1,51 @@
+
+# basic
+
+- type: quickPhrase
+  id: BluespacePhraseOmu
+  parent: BaseAdjectives
+  text: omu-phrase-ad-bluespace
+
+- type: quickPhrase
+  id: ExperimentalPhraseOmu
+  parent: BaseAdjectives
+  text: omu-phrase-ad-experimental
+
+- type: quickPhrase
+  id: AdvancedPhraseOmu
+  parent: BaseAdjectives
+  text: omu-phrase-ad-advanced
+
+- type: quickPhrase
+  id: ToxicPhraseOmu
+  parent: BaseAdjectives
+  text: omu-phrase-ad-toxic
+
+- type: quickPhrase
+  id: BlindPhraseOmu
+  parent: BaseAdjectives
+  text: omu-phrase-ad-blind
+
+- type: quickPhrase
+  id: DeafPhraseOmu
+  parent: BaseAdjectives
+  text: omu-phrase-ad-deaf
+
+- type: quickPhrase
+  id: AnotherPhraseOmu
+  parent: BaseAdjectives
+  text: omu-phrase-ad-another
+
+# health status
+
+
+
+# colours
+
+- type: quickPhrase
+  id: PinkPhraseOmu
+  parent: BaseAdjectivesColours
+  text: omu-phrase-ad-pink
+
+# feelings
+

--- a/Resources/Prototypes/_Omu/QuickPhrases/common.yml
+++ b/Resources/Prototypes/_Omu/QuickPhrases/common.yml
@@ -1,0 +1,25 @@
+
+ # common sle
+
+- type: quickPhrase
+  id: ButPhraseOmu
+  parent: BaseCommonPhraseImp
+  text: omu-phrase-but
+
+- type: quickPhrase
+  id: WithPhraseOmu
+  parent: BaseCommonPhraseImp
+  text: omu-phrase-with
+
+- type: quickPhrase
+  id: OtherPhraseOmu
+  parent: BaseCommonPhraseImp
+  text: omu-phrase-other
+
+  # common group
+
+  # pronouns
+
+  # identity
+
+  # question words

--- a/Resources/Prototypes/_Omu/QuickPhrases/determiners.yml
+++ b/Resources/Prototypes/_Omu/QuickPhrases/determiners.yml
@@ -1,0 +1,26 @@
+
+  # basic
+
+- type: quickPhrase
+  id: APhraseOmu
+  parent: BaseDeterminers
+  text: omu-phrase-determiners-a
+
+- type: quickPhrase
+  id: ThePhraseOmu
+  parent: BaseDeterminers
+  text: omu-phrase-determiners-the
+
+  # amounts
+
+- type: quickPhrase
+  id: MostPhraseOmu
+  parent: BaseDeterminersAmounts
+  text: omu-phrase-determiners-most
+
+- type: quickPhrase
+  id: LeastPhraseOmu
+  parent: BaseDeterminersAmounts
+  text: omu-phrase-determiners-least
+
+  # numbers

--- a/Resources/Prototypes/_Omu/QuickPhrases/jobs.yml
+++ b/Resources/Prototypes/_Omu/QuickPhrases/jobs.yml
@@ -1,0 +1,157 @@
+
+- type: quickPhrase
+  id: BaseJobsOmuCentralCommand
+  parent: BaseJobsImp
+  group: Central Command
+  abstract: true
+
+# engie
+
+- type: quickPhrase
+  id: StationEngineerPhraseOmu
+  parent: BaseJobsImpEngie
+  text: omu-phrase-job-stationengineer
+
+- type: quickPhrase
+  id: TechnicalAssistantPhraseOmu
+  parent: BaseJobsImpEngie
+  text: omu-phrase-job-technicalassistant
+
+# sci
+
+- type: quickPhrase
+  id: ResearchAssistantPhraseOmu
+  parent: BaseJobsImpSci
+  text: omu-phrase-job-researchassistant
+
+- type: quickPhrase
+  id: RoboticistPhraseOmu
+  parent: BaseJobsImpSci
+  text: omu-phrase-job-roboticist
+
+# service
+
+- type: quickPhrase
+  id: ServiceWorkerPhraseOmu
+  parent: BaseJobsImpService
+  text: omu-phrase-job-serviceworker
+
+- type: quickPhrase
+  id: ChaplainPhraseOmu
+  parent: BaseJobsImpService
+  text: omu-phrase-job-chaplain
+
+- type: quickPhrase
+  id: LibrarianPhraseOmu
+  parent: BaseJobsImpService
+  text: omu-phrase-job-librarian
+
+- type: quickPhrase
+  id: MusicianPhraseOmu
+  parent: BaseJobsImpService
+  text: omu-phrase-job-musician
+
+- type: quickPhrase
+  id: RadioHostPhraseOmu
+  parent: BaseJobsImpService
+  text: omu-phrase-job-radiohost
+
+# med
+
+- type: quickPhrase
+  id: MedicalDoctorPhraseOmu
+  parent: BaseJobsImpMed
+  text: omu-phrase-job-medicaldoctor
+
+- type: quickPhrase
+  id: PsychologistPhraseOmu
+  parent: BaseJobsImpMed
+  text: omu-phrase-job-psychologist
+
+- type: quickPhrase
+  id: VirologistPhraseOmu
+  parent: BaseJobsImpMed
+  text: omu-phrase-job-virologist
+
+- type: quickPhrase
+  id: MedicalInternPhraseOmu
+  parent: BaseJobsImpMed
+  text: omu-phrase-job-medicalintern
+
+# cargo
+
+- type: quickPhrase
+  id: ShaftMinerPhraseOmu
+  parent: BaseJobsImpCargo
+  text: omu-phrase-job-shaftminer
+
+# sec
+
+- type: quickPhrase
+  id: SecurityCadetPhraseOmu
+  parent: BaseJobsImpSec
+  text: omu-phrase-job-securitycadet
+
+- type: quickPhrase
+  id: CorpsmanPhraseOmu
+  parent: BaseJobsImpSec
+  text: omu-phrase-job-corpsman
+
+- type: quickPhrase
+  id: PrisonerPhraseOmu
+  parent: BaseJobsImpSec
+  text: omu-phrase-job-prisoner
+
+- type: quickPhrase
+  id: SergeantPhraseOmu
+  parent: BaseJobsImpSec
+  text: omu-phrase-job-sergeant
+
+- type: quickPhrase
+  id: OfficerPhraseOmu
+  parent: BaseJobsImpSec
+  text: omu-phrase-job-officer
+
+  # civilian
+
+- type: quickPhrase
+  id: AssistantPhraseOmu
+  parent: BaseJobsOmuCivilian
+  text: omu-phrase-job-assistant
+
+- type: quickPhrase
+  id: VisitorPhraseOmu
+  parent: BaseJobsOmuCivilian
+  text: omu-phrase-job-visitor
+
+  # non-departmental command
+
+- type: quickPhrase
+  id: CommandMaidPhraseOmu
+  parent: BaseJobsOmuNonDepartmentalCommand
+  text: omu-phrase-job-commandmaid
+
+- type: quickPhrase
+  id: AdministrativeAssistantPhraseOmu
+  parent: BaseJobsOmuNonDepartmentalCommand
+  text: omu-phrase-job-administrativeassistant
+
+  # centcomm
+
+- type: quickPhrase
+  id: NanotrasenRepresentativePhraseOmu
+  parent: BaseJobsOmuCentralCommand
+  text: omu-phrase-job-nanotrasenrepresentative
+
+- type: quickPhrase
+  id: NanotrasenCareerTrainerPhraseOmu
+  parent: BaseJobsOmuCentralCommand
+  text: omu-phrase-job-nanotrasencareertrainer
+
+- type: quickPhrase
+  id: BlueshieldOfficerPhraseOmu
+  parent: BaseJobsOmuCentralCommand
+  text: omu-phrase-job-blueshieldofficer
+
+
+

--- a/Resources/Prototypes/_Omu/QuickPhrases/locations.yml
+++ b/Resources/Prototypes/_Omu/QuickPhrases/locations.yml
@@ -1,0 +1,58 @@
+
+# locations from something
+
+- type: quickPhrase
+  id: FrontPhraseOmu
+  parent: BaseLocationsPrepositional
+  text: omu-phrase-locations-front
+
+- type: quickPhrase
+  id: BehindPhraseOmu
+  parent: BaseLocationsPrepositional
+  text: omu-phrase-locations-behind
+
+- type: quickPhrase
+  id: ToPhraseOmu
+  parent: BaseLocationsPrepositional
+  text: omu-phrase-locations-to
+  
+- type: quickPhrase
+  id: OfPhraseOmu
+  parent: BaseLocationsPrepositional
+  text: omu-phrase-locations-of
+
+- type: quickPhrase
+  id: UnderPhraseOmu
+  parent: BaseLocationsPrepositional
+  text: omu-phrase-locations-under
+
+- type: quickPhrase
+  id: OverPhraseOmu
+  parent: BaseLocationsPrepositional
+  text: omu-phrase-locations-over
+
+- type: quickPhrase
+  id: ThroughPhraseOmu
+  parent: BaseLocationsPrepositional
+  text: omu-phrase-locations-through
+
+- type: quickPhrase
+  id: BetweenPhraseOmu
+  parent: BaseLocationsPrepositional
+  text: omu-phrase-locations-between
+
+- type: quickPhrase
+  id: AroundPhraseOmu
+  parent: BaseLocationsPrepositional
+  text: omu-phrase-locations-around
+
+# cardinal
+
+
+
+# station
+
+- type: quickPhrase
+  id: AtmosPhraseOmu
+  parent: BaseLocationsSpace
+  text: omu-phrase-locations-atmos

--- a/Resources/Prototypes/_Omu/QuickPhrases/nouns.yml
+++ b/Resources/Prototypes/_Omu/QuickPhrases/nouns.yml
@@ -1,0 +1,220 @@
+
+# basic
+
+- type: quickPhrase
+  id: BatteryPhraseOmu
+  parent: BaseNouns
+  text: omu-phrase-nouns-battery
+
+# damage types
+
+- type: quickPhrase
+  id: AirlossPhraseOmu
+  parent: BaseNounsDamageGeneral
+  text: omu-phrase-nouns-airloss
+
+- type: quickPhrase
+  id: GeneticPhraseOmu
+  parent: BaseNounsDamageGeneral
+  text: omu-phrase-nouns-genetic
+
+- type: quickPhrase
+  id: HeatPhraseOmu
+  parent: BaseNounsDamageSpecific
+  text: omu-phrase-nouns-heat
+
+- type: quickPhrase
+  id: ShockPhraseOmu
+  parent: BaseNounsDamageSpecific
+  text: omu-phrase-nouns-shock
+
+- type: quickPhrase
+  id: ColdPhraseOmu
+  parent: BaseNounsDamageSpecific
+  text: omu-phrase-nouns-cold
+
+- type: quickPhrase
+  id: CausticPhraseOmu
+  parent: BaseNounsDamageSpecific
+  text: omu-phrase-nouns-caustic
+
+- type: quickPhrase
+  id: AsphyxPhraseOmu
+  parent: BaseNounsDamageSpecific
+  text: omu-phrase-nouns-asphyx
+
+- type: quickPhrase
+  id: BloodlossPhraseOmu
+  parent: BaseNounsDamageSpecific
+  text: omu-phrase-nouns-bloodloss
+
+- type: quickPhrase
+  id: BluntPhraseOmu
+  parent: BaseNounsDamageSpecific
+  text: omu-phrase-nouns-blunt
+
+- type: quickPhrase
+  id: SlashPhraseOmu
+  parent: BaseNounsDamageSpecific
+  text: omu-phrase-nouns-slash
+
+- type: quickPhrase
+  id: PiercingPhraseOmu
+  parent: BaseNounsDamageSpecific
+  text: omu-phrase-nouns-piercing
+
+- type: quickPhrase
+  id: CellularPhraseOmu
+  parent: BaseNounsDamageSpecific
+  text: omu-phrase-nouns-cellular
+
+# species
+
+- type: quickPhrase
+  id: AvaliPhraseOmu
+  parent: BaseNounsSpecies
+  text: omu-phrase-nouns-avali
+
+- type: quickPhrase
+  id: ChitinidPhraseOmu
+  parent: BaseNounsSpecies
+  text: omu-phrase-nouns-chitinid
+
+- type: quickPhrase
+  id: FelinidPhraseOmu
+  parent: BaseNounsSpecies
+  text: omu-phrase-nouns-felinid
+
+- type: quickPhrase
+  id: FeroxiPhraseOmu
+  parent: BaseNounsSpecies
+  text: omu-phrase-nouns-feroxi
+
+- type: quickPhrase
+  id: HarpyPhraseOmu
+  parent: BaseNounsSpecies
+  text: omu-phrase-nouns-harpy
+
+- type: quickPhrase
+  id: IPCPhraseOmu
+  parent: BaseNounsSpecies
+  text: omu-phrase-nouns-ipc
+
+- type: quickPhrase
+  id: OniPhraseOmu
+  parent: BaseNounsSpecies
+  text: omu-phrase-nouns-oni
+
+- type: quickPhrase
+  id: PlasmamanPhraseOmu
+  parent: BaseNounsSpecies
+  text: omu-phrase-nouns-plasmaman
+
+- type: quickPhrase
+  id: ResomiPhraseOmu
+  parent: BaseNounsSpecies
+  text: omu-phrase-nouns-resomi
+
+- type: quickPhrase
+  id: RodentiaPhraseOmu
+  parent: BaseNounsSpecies
+  text: omu-phrase-nouns-rodentia
+
+- type: quickPhrase
+  id: ShadowkinPhraseOmu
+  parent: BaseNounsSpecies
+  text: omu-phrase-nouns-shadowkin
+
+- type: quickPhrase
+  id: ShrimpPhraseOmu
+  parent: BaseNounsSpecies
+  text: omu-phrase-nouns-shrimp
+
+- type: quickPhrase
+  id: TajaranPhraseOmu
+  parent: BaseNounsSpecies
+  text: omu-phrase-nouns-tajaran
+
+- type: quickPhrase
+  id: VulpkaninPhraseOmu
+  parent: BaseNounsSpecies
+  text: omu-phrase-nouns-vulpkanin
+
+- type: quickPhrase
+  id: XelthiaPhraseOmu
+  parent: BaseNounsSpecies
+  text: omu-phrase-nouns-xelthia
+
+- type: quickPhrase
+  id: YowiePhraseOmu
+  parent: BaseNounsSpecies
+  text: omu-phrase-nouns-yowie
+
+# time
+
+- type: quickPhrase
+  id: NeverPhraseOmu
+  parent: BaseNounsTime
+  text: omu-phrase-nouns-never
+
+- type: quickPhrase
+  id: ThenPhraseOmu
+  parent: BaseNounsTime
+  text: omu-phrase-nouns-then
+
+- type: quickPhrase
+  id: AgoPhraseOmu
+  parent: BaseNounsTime
+  text: omu-phrase-nouns-ago
+
+# relationships
+
+- type: quickPhrase
+  id: CoworkerPhraseOmu
+  parent: BaseNounsRelationships
+  text: omu-phrase-nouns-coworker
+
+# materials
+
+- type: quickPhrase
+  id: ArtifactFragmentPhraseOmu
+  parent: BaseNounsMats
+  text: omu-phrase-nouns-artifactfragment
+
+- type: quickPhrase
+  id: CrystalPhraseOmu
+  parent: BaseNounsMats
+  text: omu-phrase-nouns-crystal
+  
+# tools
+
+- type: quickPhrase
+  id: WirecutterPhraseOmu
+  parent: BaseNounsTools
+  text: omu-phrase-nouns-wirecutter
+  
+- type: quickPhrase
+  id: TRayScannerPhraseOmu
+  parent: BaseNounsTools
+  text: omu-phrase-nouns-trayscanner
+  
+- type: quickPhrase
+  id: GasAnalyzerPhraseOmu
+  parent: BaseNounsTools
+  text: omu-phrase-nouns-gasanalyzer
+  
+- type: quickPhrase
+  id: JawsOfLifePhraseOmu
+  parent: BaseNounsTools
+  text: omu-phrase-nouns-jawsoflife
+  
+- type: quickPhrase
+  id: PowerDrillPhraseOmu
+  parent: BaseNounsTools
+  text: omu-phrase-nouns-powerdrill
+  
+- type: quickPhrase
+  id: HolofanPhraseOmu
+  parent: BaseNounsTools
+  text: omu-phrase-nouns-holofan
+

--- a/Resources/Prototypes/_Omu/QuickPhrases/nouns.yml
+++ b/Resources/Prototypes/_Omu/QuickPhrases/nouns.yml
@@ -1,3 +1,14 @@
+- type: quickPhrase
+  id: BaseNounsBodyPartsExternal
+  parent: BaseNouns
+  group: Body parts (External) # named like this to keep grouped together in headers
+  abstract: true
+
+- type: quickPhrase
+  id: BaseNounsBodyPartsInternal
+  parent: BaseNouns
+  group: Body parts (Internal) # named like this to keep grouped together in headers
+  abstract: true
 
 # basic
 
@@ -218,3 +229,76 @@
   parent: BaseNounsTools
   text: omu-phrase-nouns-holofan
 
+# body parts (external) (omu)
+
+- type: quickPhrase
+  id: HeadPhraseOmu
+  parent: BaseNounsBodyPartsExternal
+  text: omu-phrase-nouns-head
+
+- type: quickPhrase
+  id: ChestPhraseOmu
+  parent: BaseNounsBodyPartsExternal
+  text: omu-phrase-nouns-chest
+
+- type: quickPhrase
+  id: ArmPhraseOmu
+  parent: BaseNounsBodyPartsExternal
+  text: omu-phrase-nouns-arm
+
+- type: quickPhrase
+  id: HandPhraseOmu
+  parent: BaseNounsBodyPartsExternal
+  text: omu-phrase-nouns-hand
+
+- type: quickPhrase
+  id: GroinPhraseOmu
+  parent: BaseNounsBodyPartsExternal
+  text: omu-phrase-nouns-groin
+
+- type: quickPhrase
+  id: LegPhraseOmu
+  parent: BaseNounsBodyPartsExternal
+  text: omu-phrase-nouns-leg
+
+- type: quickPhrase
+  id: FootPhraseOmu
+  parent: BaseNounsBodyPartsExternal
+  text: omu-phrase-nouns-foot
+
+# body parts (internal) (omu)
+
+- type: quickPhrase
+  id: HeartPhraseOmu
+  parent: BaseNounsBodyPartsInternal
+  text: omu-phrase-nouns-heart
+
+- type: quickPhrase
+  id: LungsPhraseOmu
+  parent: BaseNounsBodyPartsInternal
+  text: omu-phrase-nouns-lungs
+
+- type: quickPhrase
+  id: StomachPhraseOmu
+  parent: BaseNounsBodyPartsInternal
+  text: omu-phrase-nouns-stomach
+
+- type: quickPhrase
+  id: LiverPhraseOmu
+  parent: BaseNounsBodyPartsInternal
+  text: omu-phrase-nouns-liver
+
+- type: quickPhrase
+  id: KidneysPhraseOmu
+  parent: BaseNounsBodyPartsInternal
+  text: omu-phrase-nouns-kidneys
+
+- type: quickPhrase
+  id: BrainPhraseOmu
+  parent: BaseNounsBodyPartsInternal
+  text: omu-phrase-nouns-brain
+
+- type: quickPhrase
+  id: EyesPhraseOmu
+  parent: BaseNounsBodyPartsInternal
+  text: omu-phrase-nouns-eyes

--- a/Resources/Prototypes/_Omu/QuickPhrases/verbs.yml
+++ b/Resources/Prototypes/_Omu/QuickPhrases/verbs.yml
@@ -6,3 +6,13 @@
   id: BePhraseOmu
   parent: BaseVerbs
   text: omu-phrase-verb-be
+
+- type: quickPhrase
+  id: SeePhraseOmu
+  parent: BaseVerbs
+  text: omu-phrase-verb-see
+
+- type: quickPhrase
+  id: CutPhraseOmu
+  parent: BaseVerbs
+  text: omu-phrase-verb-cut

--- a/Resources/Prototypes/_Omu/QuickPhrases/verbs.yml
+++ b/Resources/Prototypes/_Omu/QuickPhrases/verbs.yml
@@ -1,0 +1,8 @@
+
+
+# verbs
+
+- type: quickPhrase
+  id: BePhraseOmu
+  parent: BaseVerbs
+  text: omu-phrase-verb-be


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
the AAC now has a greatly expanded vocabulary of common/necessary words that were missing, including body parts, omu-specific jobs, and omu species

impstation-specific species and jobs were removed

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
the AAC has seen a lot of fun use as a meme tool, but there were noticeable gaping holes in its vocabulary and several very annoying minor errors. this aims to patch those up to give those mute players something nice to use

## Technical details
<!-- Summary of code changes for easier review. -->
added versions of `.ftl` files from the `_Impstation` namespace into the respective `_Omu` spaces
likewise with several `.yml` files within the AAC port
i changed many, many things within `_Impstation\Quickprhases\phrases_groups.yml` because from what i can tell, this is the master file for normal and jailbroken AACs, and i could not find a way to link additions via an `_Omu` version
other changes to imp's YAML files were for changing things relating to what already there; i tried to keep as much as i could within omu's versions

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://www.youtube.com/watch?v=Zcy19xMKjp4 for a full scroll-through of the changes i made

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Duuckie
- add: The AAC tablet (and jailbroken version) have an expanded and polished Omu-specific vocabulary.

