### PR TITLE
Fix Photophobia-Shader crash on ARM devices

### DIFF
--- a/Resources/Textures/_Omu/Shaders/photophobia.swsl
+++ b/Resources/Textures/_Omu/Shaders/photophobia.swsl
@@ -12,9 +12,9 @@ void fragment() {
     // Those arbitrary -0.5, 0.5, and 0.10 values are my attempt at dealing with the fact that humans percieve different colours differently.
     // There's probably a better way to do that. But I don't know much of vector math, and I've never done math with matrices in my life. So you get this.
     // Plus, I think there's a beauty in only blowing out one colour channel instead of all three. It looks good.
-    color.r = pow(color.r, pow(2, 2*(0.5-clamp((lightcolor.r - 0.05)*effectStrength, 0.5, 1))));
-    color.g = pow(color.g, pow(2, 2*(0.5-clamp((lightcolor.g + 0.05)*effectStrength, 0.5, 1))));
-    color.b = pow(color.b, pow(2, 2*(0.5-clamp((lightcolor.b + 0.10)*effectStrength, 0.5, 1))));
+    color.r = pow(color.r, pow(2.0, 2.0*(0.5-clamp((lightcolor.r - 0.05)*effectStrength, 0.5, 1.0))));
+    color.g = pow(color.g, pow(2.0, 2.0*(0.5-clamp((lightcolor.g + 0.05)*effectStrength, 0.5, 1.0))));
+    color.b = pow(color.b, pow(2.0, 2.0*(0.5-clamp((lightcolor.b + 0.10)*effectStrength, 0.5, 1.0))));
 
     COLOR = color;
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Fixes the Photophobia shader (`Resources/Textures/_Omu/Shaders/photophobia.swsl`) crashing the client on startup under the engine's GLES/ANGLE compatibility-mode renderer. Changes the `2`/`1` int literals inside float expressions to `2.0`/`1.0` — 3 lines, nothing else.

## Why / Balance
int literals mixed with float operands (`pow(2, ...)`, `clamp(v, 0.5, 1)`) compile fine on desktop OpenGL but are a hard error under GLSL ES, which is what the engine's ANGLE/compat-mode renderer uses (auto-forced on Qualcomm/Snapdragon ARM devices due to their broken native OpenGL driver). Since shader prototypes are compiled eagerly on client startup, this crashed the client for every player on such hardware before they could even reach the main menu — regardless of whether they had the Photophobia trait.

## Technical details
Only `Resources/Textures/_Omu/Shaders/photophobia.swsl` is touched (3 lines, int literal → float literal). No YAML or C# changes needed — `Resources/Prototypes/_Omu/Shaders/shaders.yml` is the only reference to this shader and stays as-is.

Test plan:
- `dotnet run --project Content.Omu.Client -- --cvar display.compat=true`

## Media
Not applicable — pure type-compatibility fix in a shader source file, no visual or gameplay change; the fix is intuitively obvious from reading the diff.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None.

**Changelog**
:cl:
- fix: Fixed the client crashing on startup for players on GLES/compatibility-mode renderers (e.g. Qualcomm/Snapdragon ARM devices) due to a shader compile error in the Photophobia effect.