### PR TITLE
Unmute Blinking For Mute People

### DIFF
--- a/Content.Server/Speech/Muting/MutingSystem.cs
+++ b/Content.Server/Speech/Muting/MutingSystem.cs
@@ -38,7 +38,7 @@ namespace Content.Server.Speech.Muting
                 return;
 
             //still leaves the text so it looks like they are pantomiming a laugh
-            if (args.Emote.Category.HasFlag(EmoteCategory.Vocal))
+            if (args.Emote.Category.HasFlag(EmoteCategory.Vocal) && !args.Emote.OverrideMute) // Omu, adds manual overriding of mute
                 args.Handled = true;
         }
 

--- a/Content.Shared/Chat/Prototypes/EmotePrototype.cs
+++ b/Content.Shared/Chat/Prototypes/EmotePrototype.cs
@@ -43,6 +43,14 @@ public sealed partial class EmotePrototype : IPrototype
     [DataField]
     public bool Available = true;
 
+    // Omu edit, added for handling blinking
+    /// <summary>
+    ///     Allows for overriding of mute trait for vocal/general emotes
+    ///     This check is handled in <see cref="Content.Server.Speech.Muting.MutingSystem"/>
+    /// </summary>
+    [DataField]
+    public bool OverrideMute = false;
+
     /// <summary>
     ///     Different emote categories may be handled by different systems.
     ///     Also may be used for filtering.

--- a/Resources/Prototypes/_Impstation/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/_Impstation/Voice/speech_emotes.yml
@@ -75,6 +75,7 @@
 - type: emote
   id: Blink
   name: chat-emote-name-blink
+  overrideMute: true # Omu
   category: General
   icon: _Omu/Interface/Emotes/blink.png #imp
   chatMessages: ["chat-emote-msg-blink"]


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
blinking now makes a sound if you're muted
added the option to unmute other vocal/general sounds with a new datafield

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
done as a bounty

it makes no sense why blinking should be muted, as it's a body sound
i went with the whole datafield solution for futureproofing if we add in other sounds that shouldn't be muted

## Technical details
<!-- Summary of code changes for easier review. -->
added data field `OverrideMute` to `Content.Shared/Chat/Prototypes/EmotePrototype.cs`
changed the check in `Content.Server/Speech/Muting/MutingSystem.cs` for muting sounds to additionally check that mute shouldn't be overridden

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/9ebf7668-7235-4f61-b4c0-4c0c1ee48804



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Duuckie
- add: Mimes and other mute characters can make noise by blinking.

