### PR TITLE
Add to AAC "Command" and "Blob"

### DIFF
--- a/Resources/Locale/en-US/_Omu/phrases/AAC.ftl
+++ b/Resources/Locale/en-US/_Omu/phrases/AAC.ftl
@@ -130,6 +130,11 @@ omu-phrase-job-visitor = Visitor
 
 omu-phrase-job-commandmaid = Command Maid
 omu-phrase-job-administrativeassistant = Administrative Assistant
+omu-phrase-job-command = Command
+
 omu-phrase-job-nanotrasenrepresentative = Nanotrasen Representative
 omu-phrase-job-nanotrasencareertrainer = Nanotrasen Career Trainer
 omu-phrase-job-blueshieldofficer = Blueshield Officer
+
+omu-phrase-hacked-tider = Tider
+omu-phrase-hacked-blob = Blob

--- a/Resources/Locale/en-US/_Omu/phrases/AAC.ftl
+++ b/Resources/Locale/en-US/_Omu/phrases/AAC.ftl
@@ -136,5 +136,4 @@ omu-phrase-job-nanotrasenrepresentative = Nanotrasen Representative
 omu-phrase-job-nanotrasencareertrainer = Nanotrasen Career Trainer
 omu-phrase-job-blueshieldofficer = Blueshield Officer
 
-omu-phrase-hacked-tider = Tider
 omu-phrase-hacked-blob = Blob

--- a/Resources/Prototypes/_Impstation/QuickPhrases/phrases_groups.yml
+++ b/Resources/Prototypes/_Impstation/QuickPhrases/phrases_groups.yml
@@ -550,6 +550,7 @@
     # non-departmental command; includes captain
     - CommandMaidPhraseOmu
     - AdministrativeAssistantPhraseOmu
+    - CommandPhraseOmu
     # centcomm
     - NanotrasenRepresentativePhraseOmu
     - NanotrasenCareerTrainerPhraseOmu
@@ -1117,6 +1118,7 @@
     # non-departmental command; includes captain
     - CommandMaidPhraseOmu
     - AdministrativeAssistantPhraseOmu
+    - CommandPhraseOmu
     # centcomm
     - NanotrasenRepresentativePhraseOmu
     - NanotrasenCareerTrainerPhraseOmu
@@ -1151,3 +1153,5 @@
     - UnionPhraseImp
     - KillerPhraseImp
     - TiltPhraseImp
+    - TiderPhraseOmu # Omu
+    - BlobPhraseOmu # Omu

--- a/Resources/Prototypes/_Impstation/QuickPhrases/phrases_groups.yml
+++ b/Resources/Prototypes/_Impstation/QuickPhrases/phrases_groups.yml
@@ -1153,5 +1153,4 @@
     - UnionPhraseImp
     - KillerPhraseImp
     - TiltPhraseImp
-    - TiderPhraseOmu # Omu
     - BlobPhraseOmu # Omu

--- a/Resources/Prototypes/_Omu/QuickPhrases/hacked.yml
+++ b/Resources/Prototypes/_Omu/QuickPhrases/hacked.yml
@@ -2,11 +2,6 @@
 # very bad not good no-no words
 
 - type: quickPhrase
-  id: TiderPhraseOmu
-  parent: BaseHackedImp
-  text: omu-phrase-hacked-tider
-
-- type: quickPhrase
   id: BlobPhraseOmu
   parent: BaseHackedImp
   text: omu-phrase-hacked-blob

--- a/Resources/Prototypes/_Omu/QuickPhrases/hacked.yml
+++ b/Resources/Prototypes/_Omu/QuickPhrases/hacked.yml
@@ -1,0 +1,12 @@
+
+# very bad not good no-no words
+
+- type: quickPhrase
+  id: TiderPhraseOmu
+  parent: BaseHackedImp
+  text: omu-phrase-hacked-tider
+
+- type: quickPhrase
+  id: BlobPhraseOmu
+  parent: BaseHackedImp
+  text: omu-phrase-hacked-blob

--- a/Resources/Prototypes/_Omu/QuickPhrases/jobs.yml
+++ b/Resources/Prototypes/_Omu/QuickPhrases/jobs.yml
@@ -136,6 +136,11 @@
   parent: BaseJobsOmuNonDepartmentalCommand
   text: omu-phrase-job-administrativeassistant
 
+- type: quickPhrase
+  id: CommandPhraseOmu
+  parent: BaseJobsOmuNonDepartmentalCommand
+  text: omu-phrase-job-command
+
   # centcomm
 
 - type: quickPhrase


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
requested addition of command, ~~tider~~ (removed by maint request) and blob to the (jailbroken) AAC
blob is in the hacked section
(builds off of work done in https://github.com/ProjectOmu/OmuStation/pull/1235)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
addition of command is because there is no group noun for command yet (unlike "officer" which i added as a group noun for sec)
blob is for fun

## Technical details
<!-- Summary of code changes for easier review. -->
added a `hacked.yml` to the `_Omu` namespace to add the hacked word
additions to omu's `jobs.yml` for command and `AAC.ftl` for the two words
omu changes to imp's `phrases_groups.yml` to add them into the AAC

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1038" height="279" alt="image" src="https://github.com/user-attachments/assets/c2f8194d-b519-48da-a2e9-efe082650b9e" />
<img width="853" height="328" alt="image" src="https://github.com/user-attachments/assets/d60ca524-9412-4822-9cec-48900aa58508" />
<img width="691" height="253" alt="image" src="https://github.com/user-attachments/assets/ba538863-7775-46bc-8dcb-fc2804b7426b" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl: Duuckie
- add: AAC tablets can now say "Command," and jailbroken tablets can say "Blob."
