### PR TITLE
[Bounty] Formal shoes in loadouts

### DIFF
--- a/Resources/Locale/en-US/_Omu/loadouts/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_Omu/loadouts/loadout-groups.ftl
@@ -33,3 +33,6 @@ loadout-group-clown-belt = Clown belt
 # Musician
 loadout-group-musician-shoes = Musician Shoes
 loadout-group-musician-hat = Musician Hat
+
+# Other
+loadout-group-civilian_formal-shoes = Formal shoes

--- a/Resources/Locale/en-US/_Omu/loadouts/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_Omu/loadouts/loadout-groups.ftl
@@ -29,3 +29,6 @@ loadout-group-sergeant-belt = Sergeant belt
 
 # Clown
 loadout-group-clown-belt = Clown belt
+
+# Other
+loadout-group-civilian_formal-shoes = Formal shoes

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -979,6 +979,13 @@
   loadouts:
   - BrownShoes
   - CargoWinterBoots
+  - BlackShoes # Omu
+  - WorkBoots # Omu
+  - FishingBoots # Omu
+  - SalvageBoots # Omu
+  - CargoWinterBoots # Omu
+  - LaceupBoots # Omu
+  - LeatherShoes # Omu
 
 - type: loadoutGroup
   id: CargoTechnicianHead
@@ -1103,6 +1110,8 @@
   loadouts:
   - BrownShoes
   - EngineeringWinterBoots
+  - LaceupBoots # Omu
+  - LeatherShoes # Omu
 
 - type: loadoutGroup
   id: TechnicalAssistantJumpsuit
@@ -1273,6 +1282,8 @@
   loadouts:
   - BrownShoes
   - ScienceWinterBoots
+  - LaceupBoots # Omu
+  - LeatherShoes # Omu
 
 - type: loadoutGroup
   id: ScientistHead
@@ -1637,6 +1648,8 @@
   loadouts:
   - BrownShoes
   - MedicalWinterBoots
+  - LaceupBoots # Omu
+  - LeatherShoes # Omu
 
 - type: loadoutGroup
   id: MedicalDoctorHead

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -535,6 +535,8 @@
   loadouts:
   - BlackShoes
   - WinterBoots
+  - LaceupBoots # Omu
+  - LeatherShoes # Omu
 
 - type: loadoutGroup
   id: BartenderHead

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1709,6 +1709,8 @@
   - WhiteShoes
   - BrownShoes # Omu
   - BlueShoes # Omu
+  - LaceupBoots # Omu
+  - LeatherShoes # Omu
   - MedicalWinterBoots
 
 - type: loadoutGroup
@@ -1826,6 +1828,8 @@
   - BrownShoes # Omu
   - WhiteShoes
   - MedicalWinterBoots
+  - LaceupBoots # Omu
+  - LeatherShoes # Omu
 
 - type: loadoutGroup
   id: MedicalEyewear

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -975,6 +975,13 @@
   loadouts:
   - BrownShoes
   - CargoWinterBoots
+  - BlackShoes # Omu
+  - WorkBoots # Omu
+  - FishingBoots # Omu
+  - SalvageBoots # Omu
+  - CargoWinterBoots # Omu
+  - LaceupBoots # Omu
+  - LeatherShoes # Omu
 
 - type: loadoutGroup
   id: CargoTechnicianHead
@@ -1099,6 +1106,8 @@
   loadouts:
   - BrownShoes
   - EngineeringWinterBoots
+  - LaceupBoots # Omu
+  - LeatherShoes # Omu
 
 - type: loadoutGroup
   id: TechnicalAssistantJumpsuit
@@ -1269,6 +1278,8 @@
   loadouts:
   - BrownShoes
   - ScienceWinterBoots
+  - LaceupBoots # Omu
+  - LeatherShoes # Omu
 
 - type: loadoutGroup
   id: ScientistHead
@@ -1633,6 +1644,8 @@
   loadouts:
   - BrownShoes
   - MedicalWinterBoots
+  - LaceupBoots # Omu
+  - LeatherShoes # Omu
 
 - type: loadoutGroup
   id: MedicalDoctorHead

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1705,6 +1705,8 @@
   - WhiteShoes
   - BrownShoes # Omu
   - BlueShoes # Omu
+  - LaceupBoots # Omu
+  - LeatherShoes # Omu
   - MedicalWinterBoots
 
 - type: loadoutGroup
@@ -1822,6 +1824,8 @@
   - BrownShoes # Omu
   - WhiteShoes
   - MedicalWinterBoots
+  - LaceupBoots # Omu
+  - LeatherShoes # Omu
 
 - type: loadoutGroup
   id: MedicalEyewear

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1339,6 +1339,8 @@
   - WhiteShoes
   - BlackShoes
   - ScienceWinterBoots
+  - LaceupBoots # Omu
+  - LeatherShoes # Omu
 
 - type: loadoutGroup
   id: ScientistGloves

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1343,6 +1343,8 @@
   - WhiteShoes
   - BlackShoes
   - ScienceWinterBoots
+  - LaceupBoots # Omu
+  - LeatherShoes # Omu
 
 - type: loadoutGroup
   id: ScientistGloves

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -538,6 +538,8 @@
   loadouts:
   - BlackShoes
   - WinterBoots
+  - LaceupBoots # Omu
+  - LeatherShoes # Omu
 
 - type: loadoutGroup
   id: BartenderHead

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -125,6 +125,7 @@
   - CaptainMask # Goobstation - Lollypops!
   - CaptainBackpack
   - CaptainOuterClothing
+  - CivilianFormalShoes # Omu
   - CaptainPDA # Omu
   - Survival
   - Trinkets
@@ -145,6 +146,7 @@
   - HoPJumpsuit
   - HoPBackpack
   - HoPOuterClothing
+  - CivilianFormalShoes # Omu
   - HoPPDA # Omu
   - Glasses
   - Survival
@@ -410,7 +412,7 @@
   - QuartermasterJumpsuit
   - CargoTechnicianBackpack
   - QuartermasterOuterClothing
-  - CargoShoes # omu
+  - QuartermasterShoes # Omu
   - Glasses
   - Survival
   - Trinkets

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -252,6 +252,7 @@
   - GroupTankHarness
   - LibrarianJumpsuit
   - CommonBackpack
+  - CivilianFormalShoes # Omu
   - Glasses
   - Survival
   - Trinkets
@@ -269,6 +270,7 @@
   - LawyerNeck
   - LawyerJumpsuit
   - CommonBackpack
+  - CivilianFormalShoes # Omu
   - Glasses
   - Survival
   - Trinkets
@@ -289,6 +291,7 @@
   - ChaplainJumpsuit
   - CommonBackpack
   - ChaplainOuterClothing
+  - CivilianFormalShoes # Omu
   - Glasses
   - Survival
   - Trinkets
@@ -830,6 +833,7 @@
   - GroupTankHarness
   - ReporterJumpsuit
   - ReporterOuterClothing # Goobstation - Bodycams
+  - CivilianFormalShoes # Omu
   - CommonBackpack
   - Glasses
   - Survival
@@ -847,6 +851,7 @@
   - GroupTankHarness
   - PsychologistJumpsuit
   - MedicalBackpack
+  - CivilianFormalShoes # Omu
   - Glasses
   - Survival
   - Trinkets

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -252,6 +252,7 @@
   - GroupTankHarness
   - LibrarianJumpsuit
   - CommonBackpack
+  - CivilianFormalShoes # Omu
   - Glasses
   - Survival
   - Trinkets
@@ -269,6 +270,7 @@
   - LawyerNeck
   - LawyerJumpsuit
   - CommonBackpack
+  - CivilianFormalShoes # Omu
   - Glasses
   - Survival
   - Trinkets
@@ -289,6 +291,7 @@
   - ChaplainJumpsuit
   - CommonBackpack
   - ChaplainOuterClothing
+  - CivilianFormalShoes # Omu
   - Glasses
   - Survival
   - Trinkets
@@ -385,6 +388,7 @@
   - MusicianJumpsuit
   - CommonBackpack
   - MusicianOuterClothing
+  - CivilianFormalShoes # Omu
   - Glasses
   - Survival
   - Trinkets
@@ -828,6 +832,7 @@
   - GroupTankHarness
   - ReporterJumpsuit
   - ReporterOuterClothing # Goobstation - Bodycams
+  - CivilianFormalShoes # Omu
   - CommonBackpack
   - Glasses
   - Survival
@@ -845,6 +850,7 @@
   - GroupTankHarness
   - PsychologistJumpsuit
   - MedicalBackpack
+  - CivilianFormalShoes # Omu
   - Glasses
   - Survival
   - Trinkets

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -125,6 +125,7 @@
   - CaptainMask # Goobstation - Lollypops!
   - CaptainBackpack
   - CaptainOuterClothing
+  - CivilianFormalShoes # Omu
   - CaptainPDA # Omu
   - Survival
   - Trinkets
@@ -145,6 +146,7 @@
   - HoPJumpsuit
   - HoPBackpack
   - HoPOuterClothing
+  - CivilianFormalShoes # Omu
   - HoPPDA # Omu
   - Glasses
   - Survival
@@ -411,7 +413,7 @@
   - QuartermasterJumpsuit
   - CargoTechnicianBackpack
   - QuartermasterOuterClothing
-  - CargoShoes # omu
+  - QuartermasterShoes # Omu
   - Glasses
   - Survival
   - Trinkets

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
@@ -91,7 +91,7 @@
 - type: startingGear
   id: ChaplainGear
   equipment:
-    shoes: ClothingShoesColorBlack
+    #shoes: ClothingShoesColorBlack # Omu, Selectable formal shoes
     id: ChaplainPDA
     ears: ClothingHeadsetService
   storage:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
@@ -94,7 +94,7 @@
 - type: startingGear
   id: LawyerGear
   equipment:
-    shoes: ClothingShoesBootsLaceup
+    #shoes: ClothingShoesBootsLaceup # Omu, Selectable formal shoes
     id: LawyerPDA
     ears: ClothingHeadsetSecurity
   inhand:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
@@ -82,7 +82,7 @@
 - type: startingGear
   id: LibrarianGear
   equipment:
-    shoes: ClothingShoesBootsLaceup
+    #shoes: ClothingShoesBootsLaceup # Omu, Selectable formal shoes
     id: LibrarianPDA
     ears: ClothingHeadsetService
     pocket1: d20Dice

--- a/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
@@ -76,7 +76,7 @@
   id: MusicianGear
   equipment:
     eyes: ClothingEyesGlassesSunglasses
-    shoes: ClothingShoesBootsLaceup
+    #shoes: ClothingShoesBootsLaceup # Omu, Selectable formal shoes
     id: MusicianPDA
     ears: ClothingHeadsetService
   #storage:

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -190,7 +190,7 @@
 - type: startingGear
   id: CaptainGear
   equipment:
-    shoes: ClothingShoesBootsLaceup
+    #shoes: ClothingShoesBootsLaceup # Omu, Selectable formal shoes
     eyes: ClothingEyesGlassesCommand
     #gloves: ClothingHandsGlovesCaptain - Goobstation, moved to loadouts
     #id: CaptainPDA - Omu, moved to loadouts

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -210,7 +210,7 @@
 - type: startingGear
   id: HoPGear
   equipment:
-    shoes: ClothingShoesColorBrown
+    #shoes: ClothingShoesColorBrown # Omu, Selectable formal shoes
     #id: HoPPDA - Omu, moved to loadouts
     #gloves: ClothingHandsGlovesHop
     ears: ClothingHeadsetAltCommand

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/psychologist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/psychologist.yml
@@ -116,7 +116,7 @@
 - type: startingGear
   id: PsychologistGear
   equipment:
-    shoes: ClothingShoesLeather
+    #shoes: ClothingShoesLeather # Omu, Selectable formal shoes
     id: PsychologistPDA
     ears: ClothingHeadsetMedical
   storage:

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/reporter.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/reporter.yml
@@ -70,7 +70,7 @@
 - type: startingGear
   id: ReporterGear
   equipment:
-    shoes: ClothingShoesColorWhite
+    #shoes: ClothingShoesColorWhite # Omu, Selectable formal shoes
     id: ReporterPDA
     ears: ClothingHeadsetService
   storage: # DeltaV: Give reporters tape recording equipment

--- a/Resources/Prototypes/_DV/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_DV/Loadouts/role_loadouts.yml
@@ -4,7 +4,7 @@
   groups:
   - AdminAssistantJumpsuit
   - AdminAssistantOuter
-  - AdminAssistantShoes
+  - CivilianFormalShoes # Omu
   - AdminAssistantEar
   - AdminAssistantHead
   - AdminAssistantGloves

--- a/Resources/Prototypes/_Goobstation/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Goobstation/Loadouts/loadout_groups.yml
@@ -1275,6 +1275,8 @@
   - WhiteShoes
   - BlackShoes
   - ScienceWinterBoots
+  - LaceupBoots # Omu
+  - LeatherShoes # Omu
 
 - type: loadoutGroup
   id: RoboticistGloves

--- a/Resources/Prototypes/_Omu/Loadouts/Jobs/Civilian/musician.yml
+++ b/Resources/Prototypes/_Omu/Loadouts/Jobs/Civilian/musician.yml
@@ -39,17 +39,3 @@
   effects:
   - !type:GroupLoadoutEffect
     proto: MasterMusician
-
-- type: loadoutGroup
-  id: MusicianShoes
-  name: loadout-group-musician-shoes
-  loadouts:
-  - BlackShoes
-  - MusicianMikuShoes
-
-- type: loadoutGroup
-  id: MusicianHat
-  name: loadout-group-musician-hat
-  minLimit: 0
-  loadouts:
-  - MusicianMikuHead

--- a/Resources/Prototypes/_Omu/Loadouts/Jobs/Misc/assistant.yml
+++ b/Resources/Prototypes/_Omu/Loadouts/Jobs/Misc/assistant.yml
@@ -2,3 +2,13 @@
   id: Loungewear
   equipment:
     jumpsuit: ClothingUniformJumpsuitLoungewear
+
+- type: loadout
+  id: LaceupBoots
+  equipment:
+    shoes: ClothingShoesBootsLaceup
+
+- type: loadout
+  id: LeatherShoes
+  equipment:
+    shoes: ClothingShoesLeather

--- a/Resources/Prototypes/_Omu/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Omu/Loadouts/loadout_groups.yml
@@ -447,3 +447,15 @@
   - HeadSlimeHead
   - HeadFlowerHead
   - HeadbandSkull
+
+#Civillian Formal
+- type: loadoutGroup
+  id: CivilianFormalShoes
+  name: loadout-group-civilian_formal-shoes
+  minLimit: 1
+  maxLimit: 1
+  loadouts:
+  - LaceupBoots
+  - WhiteShoes
+  - LeatherShoes
+  - WinterBoots

--- a/Resources/Prototypes/_Omu/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Omu/Loadouts/loadout_groups.yml
@@ -454,6 +454,8 @@
   name: loadout-group-musician-shoes
   loadouts:
   - BlackShoes
+  - LaceupBoots
+  - LeatherShoes
   - MusicianMikuShoes
 
 - type: loadoutGroup

--- a/Resources/Prototypes/_Omu/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Omu/Loadouts/loadout_groups.yml
@@ -419,4 +419,16 @@
   - HeadSlimeHead
   - HeadFlowerHead
   - HeadbandSkull
-  
+
+## Formal Shoes
+#Civillian Formal
+- type: loadoutGroup
+  id: CivilianFormalShoes
+  name: loadout-group-civilian_formal-shoes
+  minLimit: 1
+  maxLimit: 1
+  loadouts:
+  - LaceupBoots
+  - WhiteShoes
+  - LeatherShoes
+  - WinterBoots

--- a/Resources/Prototypes/_Omu/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Omu/Loadouts/loadout_groups.yml
@@ -448,6 +448,21 @@
   - HeadFlowerHead
   - HeadbandSkull
 
+# musician
+- type: loadoutGroup
+  id: MusicianShoes
+  name: loadout-group-musician-shoes
+  loadouts:
+  - BlackShoes
+  - MusicianMikuShoes
+
+- type: loadoutGroup
+  id: MusicianHat
+  name: loadout-group-musician-hat
+  minLimit: 0
+  loadouts:
+  - MusicianMikuHead
+
 #Civillian Formal
 - type: loadoutGroup
   id: CivilianFormalShoes

--- a/Resources/Prototypes/_StarLight/Loadouts/Jobs/loadout_groups.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/Jobs/loadout_groups.yml
@@ -13,6 +13,8 @@
   - WhiteShoes
   - ChemistWinterBoots
   - MedicalWinterBoots
+  - LaceupBoots # Omu
+  - LeatherShoes # Omu
 
 - type: loadoutGroup
   id: ChemistPDA


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
tl;dr
Adds formal shoes and leather shoes to a load of loadouts, mostly civilian medical science and command.
only admin assistant has changes that removed old options, those being black and brown shoes.
Moves the loadout groups from PR #1149 to the correct location

**New loadout group (CivilianFormalShoes) made of the follow shoes**
white / winter / leather / laceup

**Roles that have gained loadout options for shoes:**
Lawyer Librarian Chaplain Psychologist Reporter Captain HoP (all gaining CivilianFormalShoes)
**Roles that have had their loadouts set to something new**
AdminAssistant (CivilianFormalShoes)
**Roles that have gained loadout options to their existing options:**
Assistant Musician QM RD CMO CE Scientist Roboticist Medical(all but intern) (gaining leather/laceups)

## Why / Balance
Style Points

## Technical details
Adds a CivilianFormalShoes loadout group for most of the changes and disables the default shoes set by roles in favour of a loadout option, a few are done by setting the specific premade shoe groups such as CMO and QMs

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Formal shoes such as leather and laceups are now available on a lot more jobs as loadout options.
- removed: AAs have lost access to their informal footwear.