### PR TITLE
Events late in shift time

### DIFF
--- a/Content.Server/StationEvents/BasicStationEventSchedulerSystem.cs
+++ b/Content.Server/StationEvents/BasicStationEventSchedulerSystem.cs
@@ -202,7 +202,7 @@ namespace Content.Server.StationEvents
             if (!_stationEvent.TryBuildLimitedEvents(basicScheduler.ScheduledGameRules, available, out var untimedEvents))
                 yield break;
 
-            var events = untimedEvents.Where(pair => pair.Value.EarliestStart <= timemins).ToList();
+            var events = untimedEvents.Where(pair => pair.Value.EarliestStart <= timemins).Where(pair => pair.Value.LatestStart >= timemins).ToList(); //Omu edit, add latest start
 
             var totalWeight = events.Sum(x => x.Value.Weight); // same subsetting issue as lsprob.
 

--- a/Content.Server/StationEvents/Components/StationEventComponent.cs
+++ b/Content.Server/StationEvents/Components/StationEventComponent.cs
@@ -140,6 +140,14 @@ public sealed partial class StationEventComponent : Component
     [DataField]
     public int EarliestStart = 5;
 
+    // Omu Edit start
+    /// <summary>
+    ///     In minutes, when is the latest this event can start -- Default of null
+    /// </summary>
+    [DataField]
+    public int LatestStart;
+    // Omu Edit End
+
     /// <summary>
     ///     In minutes, the amount of time before the same event can occur again
     /// </summary>

--- a/Content.Server/StationEvents/EventManagerSystem.cs
+++ b/Content.Server/StationEvents/EventManagerSystem.cs
@@ -362,7 +362,9 @@ public sealed class EventManagerSystem : EntitySystem
             return false;
         }
 
-        if (currentTime != TimeSpan.Zero && currentTime.TotalMinutes < stationEvent.EarliestStart / EventSpeedup)
+        if (currentTime != TimeSpan.Zero &&
+            currentTime.TotalMinutes < stationEvent.EarliestStart / EventSpeedup
+            && (stationEvent.LatestStart != 0 || currentTime.TotalMinutes > stationEvent.LatestStart / EventSpeedup))
         {
             return false;
         }

--- a/Content.Server/StationEvents/EventManagerSystem.cs
+++ b/Content.Server/StationEvents/EventManagerSystem.cs
@@ -364,7 +364,7 @@ public sealed class EventManagerSystem : EntitySystem
 
         if (currentTime != TimeSpan.Zero &&
             currentTime.TotalMinutes < stationEvent.EarliestStart / EventSpeedup
-            && (stationEvent.LatestStart != 0 || currentTime.TotalMinutes > stationEvent.LatestStart / EventSpeedup))
+            && (stationEvent.LatestStart != 0 && currentTime.TotalMinutes > stationEvent.LatestStart / EventSpeedup))
         {
             return false;
         }

--- a/Content.Server/StationEvents/EventManagerSystem.cs
+++ b/Content.Server/StationEvents/EventManagerSystem.cs
@@ -364,7 +364,7 @@ public sealed class EventManagerSystem : EntitySystem
 
         if (currentTime != TimeSpan.Zero &&
             currentTime.TotalMinutes < stationEvent.EarliestStart / EventSpeedup
-            && (stationEvent.LatestStart != 0 || currentTime.TotalMinutes > stationEvent.LatestStart / EventSpeedup))
+            && (stationEvent.LatestStart != 0 || currentTime.TotalMinutes > stationEvent.LatestStart / EventSpeedup)) //OMU edit
         {
             return false;
         }

--- a/Content.Server/StationEvents/EventManagerSystem.cs
+++ b/Content.Server/StationEvents/EventManagerSystem.cs
@@ -364,7 +364,7 @@ public sealed class EventManagerSystem : EntitySystem
 
         if (currentTime != TimeSpan.Zero &&
             currentTime.TotalMinutes < stationEvent.EarliestStart / EventSpeedup
-            && (stationEvent.LatestStart != 0 || currentTime.TotalMinutes > stationEvent.LatestStart / EventSpeedup)) //OMU edit
+            && (stationEvent.LatestStart == 0 || currentTime.TotalMinutes > stationEvent.LatestStart / EventSpeedup)) //OMU edit
         {
             return false;
         }

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -805,6 +805,7 @@
   components:
   - type: StationEvent
     earliestStart: 60 # Goobstation - was 90 (impossible on goob)
+    latestStart: 100 # OmuStation (1hr 40min max)
     minimumPlayers: 40
     weight: 1 # Zombies was happening basically every single survival round, so now it's super rare
     duration: 1
@@ -847,6 +848,7 @@
   components:
   - type: StationEvent
     earliestStart: 60 # OMU change - make lone-ops spawn later
+    latestStart: 100 # OmuStation (1hr 40min max) Im tired of last second shuttle bombing
     weight: 5.5       #Omu
     minimumPlayers: 20 #Omu keeping it lower for now cause playercount
     duration: 720 # Goobstation - required for custom nuke music. 720s to ensure loneop can hear the music and still have space for other midrounds incase of failure
@@ -897,6 +899,7 @@
   components:
   - type: StationEvent
     earliestStart: 30
+    latestStart: 100 # OmuStation (1hr 40min max)
     weight: 8
     minimumPlayers: 15
     maxOccurrences: 1 # can only happen once per round


### PR DESCRIPTION
## About the PR
Adds in ability to disable ability for an event to fire after a certain shift time

## Why / Balance
Having zombies/sleepers/lone op spawn in the last 10-15 minutes feels terrible for the antag(s)/crew

## Technical details
adds `LatestStart` to the event component to limit the time an event can spawn at

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Zombies/Sleepers/Lone Op can no longer occur after a point in the shift
