### PR TITLE
`DescSquadComponent` Admin/Event Component

### DIFF
--- a/Content.Omu.Shared/DescSquad/DescSquadComponent.cs
+++ b/Content.Omu.Shared/DescSquad/DescSquadComponent.cs
@@ -1,0 +1,19 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Omu.Shared.DescSquad;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class DescSquadComponent : Component
+{
+    [DataField]
+    public string Color = "#00000000"; // Color of the text,
+
+    [DataField]
+    public string Description = ""; // "Her eyes glow * with a vivid wurble"
+
+    [DataField]
+    public string Adjective = "vivid"; // "Her eyes glow purple with a * wurble"
+
+    [DataField]
+    public string Word = "hatred"; // "Her eyes glow purple with a vivid *"
+}

--- a/Content.Omu.Shared/DescSquad/DescSquadSystem.cs
+++ b/Content.Omu.Shared/DescSquad/DescSquadSystem.cs
@@ -1,0 +1,33 @@
+using Content.Shared.Examine;
+using Content.Shared.IdentityManagement;
+
+namespace Content.Omu.Shared.DescSquad;
+
+public sealed class DescSquadSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<DescSquadComponent, ExaminedEvent>(OnExamined);
+    }
+
+    private void OnExamined(Entity<DescSquadComponent> descSquad, ref ExaminedEvent args)
+    {
+        if (!args.IsInDetailsRange)
+            return;
+        var desc = descSquad.Comp.Description;
+        if (desc != "")
+        {
+            desc += " ";
+        }
+
+        var details = Loc.GetString("desc-squad-examined",
+            ("color", descSquad.Comp.Color),
+            ("target", Identity.Entity(descSquad, EntityManager)),
+            ("description", desc),
+            ("adjective", descSquad.Comp.Adjective),
+            ("word", descSquad.Comp.Word));
+        args.PushMarkup(details, -1);
+    }
+}

--- a/Resources/Locale/en-US/_Omu/descSquad/descsquad.ftl
+++ b/Resources/Locale/en-US/_Omu/descSquad/descsquad.ftl
@@ -1,0 +1,1 @@
+desc-squad-examined = [color={$color}]{CAPITALIZE(POSS-ADJ($target))} eyes glow {$description}with a {$adjective} {$word}.[/color]


### PR DESCRIPTION
## About the PR
Adds in component for custom deathsquad like messages on character description for events/admin usage.
ex "Her eyes glow purple with a vivid wurble."

## Why / Balance
Just a bit of silly.

## Technical details
adds `DescSquadComponent` and `DescSquadSystem` classes as well as accompanying FTL file 

```
> self comp:ensure DescSquad
wait 10
> self do "vvwrite entity/$ID/DescSquad/Adjective 'vivid'"
> self do "vvwrite entity/$ID/DescSquad/Color '#c559ff'"
> self do "vvwrite entity/$ID/DescSquad/Description 'purple'"
> self do "vvwrite entity/$ID/DescSquad/Word 'wurble'"
```

## Media
<img width="494" height="429" alt="image" src="https://github.com/user-attachments/assets/af287bb8-759d-4415-a95a-46ba6425f7ea" />
<img width="582" height="163" alt="image" src="https://github.com/user-attachments/assets/a669cb45-c19c-4d5e-9a6f-f24e5665a3a5" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Added 'DescSquad' Component for events and Admin usage
