### PR TITLE
[FIX] Fix lifeline not dropping held items.

### DIFF
--- a/Content.Goobstation.Server/BSOLifeline/Systems/BSOLifelineSystem.cs
+++ b/Content.Goobstation.Server/BSOLifeline/Systems/BSOLifelineSystem.cs
@@ -38,8 +38,8 @@ public sealed class GoobLifelineSystem : EntitySystem
     private void WarpParent(EntityUid uid, WarpParentOnTriggerComponent component)
     {
 
-        var dropHandItemsEvent = new DropHandItemsEvent();
-        RaiseLocalEvent(uid, ref dropHandItemsEvent);
+        //var dropHandItemsEvent = new DropHandItemsEvent(); // Omu, moved further down.
+        //RaiseLocalEvent(uid, ref dropHandItemsEvent);
 
         var location = FindWarpPoint(component.WarpLocation);
 
@@ -49,6 +49,9 @@ public sealed class GoobLifelineSystem : EntitySystem
         var parentUid = transform.ParentUid;
         if (parentUid == EntityUid.Invalid || !HasComp<MobStateComponent>(parentUid))
             return;
+
+        var dropHandItemsEvent = new DropHandItemsEvent(); // Omu, move this here otherwise it doesn't work.
+        RaiseLocalEvent(parentUid, ref dropHandItemsEvent);
 
         // Reset mind - can be considered if greentext is a concern
         if (_configurationManager.GetCVar(GoobCVars.LifeLineResetMind))


### PR DESCRIPTION
## About the PR
Fixes the lifeline implant not dropping held items on lifeline.

## Why / Balance
Its meant to drop held items.

## Technical details
Move the dropitems event later, and raise it against parentUid instead of uid, it now correctly drops the item before teleporting you, rather than not dropping items at all.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed Lifeline not dropping items.