### PR TITLE
[FIX] Fix the sprite path for drill sergeant headset

### DIFF
--- a/Resources/Prototypes/_Omu/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/_Omu/Entities/Clothing/Ears/headsets_alt.yml
@@ -115,4 +115,4 @@
   - type: Sprite
     sprite: _Omu/Clothing/Ears/Headsets/drillsergeant.rsi
   - type: Clothing
-    sprite: _GOmu/Clothing/Ears/Headsets/drillsergeant.rsi
+    sprite: _Omu/Clothing/Ears/Headsets/drillsergeant.rsi


### PR DESCRIPTION
## About the PR
_GOmu to _Omu

## Why / Balance
bugfix

## Technical details
Gomu

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed Drill sergeant headset not rendering
