### PR TITLE
Cognizine Tweaks

### DIFF
--- a/Content.Server/EntityEffects/EntityEffectSystem.cs
+++ b/Content.Server/EntityEffects/EntityEffectSystem.cs
@@ -47,6 +47,7 @@ using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
+using Content.Shared.NPC.Systems; // Omu
 
 using TemperatureCondition = Content.Shared.EntityEffects.EffectConditions.Temperature; // disambiguate the namespace
 using PolymorphEffect = Content.Shared.EntityEffects.Effects.Polymorph;
@@ -81,7 +82,7 @@ public sealed class EntityEffectSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _xform = default!;
     [Dependency] private readonly VomitSystem _vomit = default!;
     [Dependency] private readonly TurfSystem _turf = default!; //todo Goobstation? The only thing im using this for is meant to be in RT? Fix if you havent
-
+    [Dependency] private readonly NpcFactionSystem _npcFactionSystem = default!; // Omu
     public override void Initialize()
     {
         base.Initialize();
@@ -752,7 +753,13 @@ public sealed class EntityEffectSystem : EntitySystem
     private void OnExecuteMakeSentient(ref ExecuteEntityEffectEvent<MakeSentient> args)
     {
         var uid = args.Args.TargetEntity;
-
+        // Omu start
+        var nanotrasenFaction = "NanoTrasen";
+        if (_npcFactionSystem.IsFactionHostile(nanotrasenFaction, uid)) // If its hostile to NT then don't allow cognizine to work (Without using xenobio to pacify the mob first)
+        {
+            return;
+        }
+        // Omu end
         // Let affected entities speak normally to make this effect different from, say, the "random sentience" event
         // This also works on entities that already have a mind
         // We call this before the mind check to allow things like player-controlled mice to be able to benefit from the effect

--- a/Resources/Locale/en-US/_Mono/guidebook/chemistry/effects.ftl
+++ b/Resources/Locale/en-US/_Mono/guidebook/chemistry/effects.ftl
@@ -306,11 +306,12 @@ reagent-effect-guidebook-ignite =
         *[other] ignite
     } the metabolizer
 
+# Omu, add "if it is not hostile" to make-sentient
 reagent-effect-guidebook-make-sentient =
     { $chance ->
         [1] Makes
         *[other] make
-    } the metabolizer sentient
+    } the metabolizer sentient if it is not hostile
 
 reagent-effect-guidebook-make-polymorph =
     { $chance ->


### PR DESCRIPTION
## About the PR
Made it so cognizine requires the target mob must not be hostile to NT (basically all crew will have this faction so it's a rough estimate of "is this mob hostile to players"), to cognizine a hostile mob crew must first use Xenobio pink jelly on it to pacify it, then use cognizine.

## Why / Balance
Too many crew dragons.

## Technical details
Adds in a check for factions, if the ent that would be made sentient is hostile to NT, then return early and do not attempt making it sentient.

I have tested this both on hostile mobs and non hostile ones, with it working both times.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Cognizine now requires the entity be non-hostile
