### PR TITLE
DescSquad 2 

### DIFF
--- a/Content.Omu.Shared/DescSquad/DescSquadComponent.cs
+++ b/Content.Omu.Shared/DescSquad/DescSquadComponent.cs
@@ -9,11 +9,23 @@ public sealed partial class DescSquadComponent : Component
     public string Color = "#00000000"; // Color of the text,
 
     [DataField]
+    public string Verb = "glow"; // "Her eyes * purple with a vivid wurble"
+
+    [DataField]
     public string Description = ""; // "Her eyes glow * with a vivid wurble"
+
+    [DataField]
+    public string Determiner = "with a"; // "Her eyes glow purple * vivid wurble"
 
     [DataField]
     public string Adjective = "vivid"; // "Her eyes glow purple with a * wurble"
 
     [DataField]
     public string Word = "hatred"; // "Her eyes glow purple with a vivid *"
+
+    [DataField]
+    public bool IsCustom;
+
+    [DataField]
+    public string FullCustom = ""; // blank have fun
 }

--- a/Content.Omu.Shared/DescSquad/DescSquadSystem.cs
+++ b/Content.Omu.Shared/DescSquad/DescSquadSystem.cs
@@ -21,13 +21,27 @@ public sealed class DescSquadSystem : EntitySystem
         {
             desc += " ";
         }
+        string details;
 
-        var details = Loc.GetString("desc-squad-examined",
-            ("color", descSquad.Comp.Color),
-            ("target", Identity.Entity(descSquad, EntityManager)),
-            ("description", desc),
-            ("adjective", descSquad.Comp.Adjective),
-            ("word", descSquad.Comp.Word));
+        if (descSquad.Comp.IsCustom)
+        {
+            details = Loc.GetString("desc-squad-custom",
+                ("color", descSquad.Comp.Color),
+                ("target", Identity.Entity(descSquad, EntityManager)),
+                ("fullcustom", descSquad.Comp.FullCustom));
+        }
+        else
+        {
+            details = Loc.GetString("desc-squad-examined",
+                ("color", descSquad.Comp.Color),
+                ("target", Identity.Entity(descSquad, EntityManager)),
+                ("verb", descSquad.Comp.Verb),
+                ("description", desc),
+                ("determiner", descSquad.Comp.Determiner),
+                ("adjective", descSquad.Comp.Adjective),
+                ("word", descSquad.Comp.Word));
+        }
+
         args.PushMarkup(details, -1);
     }
 }

--- a/Resources/Locale/en-US/_Omu/descSquad/descsquad.ftl
+++ b/Resources/Locale/en-US/_Omu/descSquad/descsquad.ftl
@@ -1,1 +1,2 @@
-desc-squad-examined = [color={$color}]{CAPITALIZE(POSS-ADJ($target))} eyes glow {$description}with a {$adjective} {$word}.[/color]
+desc-squad-examined = [color={$color}]{CAPITALIZE(POSS-ADJ($target))} eyes {$verb} {$description}{$determiner} {$adjective} {$word}.[/color]
+desc-squad-custom = [color={$color}]{CAPITALIZE(POSS-ADJ($target))} {$fullcustom}.[/color]


### PR DESCRIPTION
## About the PR
Adds in further customization for the `descSquad` component; giving full customizable descriptions

## Why / Balance
Just a bit more of silly.

## Technical details
adds in new datafields into the descsquad components and system

## Media
`Non-custom / Exec A`
<img width="835" height="621" alt="image" src="https://github.com/user-attachments/assets/03017951-44b1-4c7e-b737-0da09b7b21ba" />
```
> self comp:ensure DescSquad
wait 10
> self do "vvwrite entity/$ID/DescSquad/Adjective 'vivid'"
> self do "vvwrite entity/$ID/DescSquad/Color '#c559ff'"
> self do "vvwrite entity/$ID/DescSquad/Verb 'shimmer'"
> self do "vvwrite entity/$ID/DescSquad/Determiner 'with a'"
> self do "vvwrite entity/$ID/DescSquad/Description 'purple'"
> self do "vvwrite entity/$ID/DescSquad/Word 'wurble'"
```
`Custom / Exec B`
<img width="1054" height="497" alt="image" src="https://github.com/user-attachments/assets/89b858a0-5aeb-4143-9172-8ae70024c0ae" />
```
> self comp:ensure DescSquad
wait 10
> self do "vvwrite entity/$ID/DescSquad/FullCustom \"whimsy knows [italic]no bounds[/italic]\""
> self do "vvwrite entity/$ID/DescSquad/IsCustom 'true'"
> self do "vvwrite entity/$ID/DescSquad/Color '#c559ff'"
```

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Added further customization to the 'DescSquad' Component
