### PR TITLE
[FIX] Hopefully prevent the game trying to make aghosts antags.

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -145,6 +145,7 @@
   name: admin observer
   categories: [ HideSpawnMenu ]
   components:
+  - type: AntagImmune # Omu
   - type: ContentEye
     maxZoom: 8.916104, 8.916104
   - type: Tag


### PR DESCRIPTION
## About the PR
Add AntagImmune to aghosts

## Why / Balance
It was noticed that the game tried to roll an aghost as a antag.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed the game trying to roll aghosts as antags
