### PR TITLE
Replaced chef/botany medical smart fridges with their respective botany counterparts

### DIFF
--- a/Resources/Maps/_Omu/atlas.yml
+++ b/Resources/Maps/_Omu/atlas.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 266.0.0
   forkId: ""
   forkVersion: ""
-  time: 05/16/2026 14:40:51
+  time: 07/25/2026 19:26:37
   entityCount: 9572
 maps:
 - 1
@@ -51110,13 +51110,15 @@ entities:
     - type: Transform
       pos: -22.282597,-30.265938
       parent: 2
-- proto: SmartFridgeMedical
+- proto: SmartFridgeBotany
   entities:
   - uid: 7339
     components:
     - type: Transform
       pos: -13.5,-0.5
       parent: 2
+- proto: SmartFridgeMedical
+  entities:
   - uid: 7340
     components:
     - type: Transform

--- a/Resources/Maps/_Omu/bagel.yml
+++ b/Resources/Maps/_Omu/bagel.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 266.0.0
   forkId: ""
   forkVersion: ""
-  time: 05/16/2026 14:41:30
+  time: 07/25/2026 19:31:37
   entityCount: 25161
 maps:
 - 1
@@ -130856,13 +130856,15 @@ entities:
     - type: Transform
       pos: -75.5,-1.5
       parent: 2
-- proto: SmartFridgeMedical
+- proto: SmartFridgeBotany
   entities:
   - uid: 11523
     components:
     - type: Transform
       pos: 27.5,-30.5
       parent: 2
+- proto: SmartFridgeMedical
+  entities:
   - uid: 19652
     components:
     - type: Transform

--- a/Resources/Maps/_Omu/box.yml
+++ b/Resources/Maps/_Omu/box.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 266.0.0
   forkId: ""
   forkVersion: ""
-  time: 05/26/2026 13:09:07
+  time: 07/25/2026 19:28:51
   entityCount: 27399
 maps:
 - 1
@@ -141779,17 +141779,19 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 4.5,49.5
       parent: 2
+- proto: SmartFridgeBotany
+  entities:
+  - uid: 21125
+    components:
+    - type: Transform
+      pos: 41.5,-4.5
+      parent: 2
 - proto: SmartFridgeMedical
   entities:
   - uid: 22059
     components:
     - type: Transform
       pos: 20.5,-23.5
-      parent: 2
-  - uid: 22060
-    components:
-    - type: Transform
-      pos: 41.5,-4.5
       parent: 2
   - uid: 22061
     components:

--- a/Resources/Maps/_Omu/fland.yml
+++ b/Resources/Maps/_Omu/fland.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 266.0.0
   forkId: ""
   forkVersion: ""
-  time: 05/16/2026 14:46:39
+  time: 07/25/2026 19:33:02
   entityCount: 36106
 maps:
 - 1
@@ -190499,13 +190499,15 @@ entities:
     - type: Transform
       pos: -8.5,33.5
       parent: 2
-- proto: SmartFridgeMedical
+- proto: SmartFridgeBotany
   entities:
   - uid: 28150
     components:
     - type: Transform
       pos: -10.5,27.5
       parent: 2
+- proto: SmartFridgeMedical
+  entities:
   - uid: 28152
     components:
     - type: Transform

--- a/Resources/Maps/_Omu/marathon.yml
+++ b/Resources/Maps/_Omu/marathon.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 266.0.0
   forkId: ""
   forkVersion: ""
-  time: 05/16/2026 14:53:42
+  time: 07/25/2026 19:34:49
   entityCount: 23155
 maps:
 - 1
@@ -120965,13 +120965,15 @@ entities:
     - type: Transform
       pos: 51.5,13.5
       parent: 2
-- proto: SmartFridgeMedical
+- proto: SmartFridgeBotany
   entities:
   - uid: 17819
     components:
     - type: Transform
       pos: -18.5,9.5
       parent: 2
+- proto: SmartFridgeMedical
+  entities:
   - uid: 17820
     components:
     - type: Transform

--- a/Resources/Maps/_Omu/packed.yml
+++ b/Resources/Maps/_Omu/packed.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 266.0.0
   forkId: ""
   forkVersion: ""
-  time: 05/16/2026 14:58:35
+  time: 07/25/2026 19:35:50
   entityCount: 15717
 maps:
 - 1
@@ -82057,13 +82057,15 @@ entities:
     - type: Transform
       pos: 76.5,18.5
       parent: 2
-- proto: SmartFridgeMedical
+- proto: SmartFridgeBotany
   entities:
   - uid: 11800
     components:
     - type: Transform
       pos: 40.5,-6.5
       parent: 2
+- proto: SmartFridgeMedical
+  entities:
   - uid: 11801
     components:
     - type: Transform

--- a/Resources/Maps/_Omu/saltern.yml
+++ b/Resources/Maps/_Omu/saltern.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 266.0.0
   forkId: ""
   forkVersion: ""
-  time: 05/16/2026 14:59:03
+  time: 07/25/2026 19:36:54
   entityCount: 12559
 maps:
 - 1
@@ -63533,17 +63533,19 @@ entities:
     - type: Transform
       pos: -1.5,-33.5
       parent: 2
+- proto: SmartFridgeBotany
+  entities:
+  - uid: 5547
+    components:
+    - type: Transform
+      pos: -15.5,1.5
+      parent: 2
 - proto: SmartFridgeMedical
   entities:
   - uid: 5546
     components:
     - type: Transform
       pos: 16.5,-3.5
-      parent: 2
-  - uid: 5547
-    components:
-    - type: Transform
-      pos: -15.5,1.5
       parent: 2
 - proto: SMESAdvanced
   entities:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
I replaced medical smart fridges in chef/botany areas with botany smart fridges in:
* Atlas
* Box
* Bagel
* Fland
* Marathon
* Packed
* Saltern


## Why / Balance
Chefs/Botany should have access to those fridges as it's right in their department. The medical team should not have access to those.

## Technical details
I loaded all the maps with the `mapping` command, deleted the old fridge and added the new one.

## Media
| Old | New |
| --- | --- |
| <img width="933" height="469" alt="image" src="https://github.com/user-attachments/assets/6165fc33-efd7-4d85-858b-18c4d2e120de" /> | <img width="933" height="469" alt="image" src="https://github.com/user-attachments/assets/679006fb-fea3-4f59-83d5-87756c93c395" /> |

Proof that with the SmartFridge [Botany] Chefs and Botanists get access to them:
<img width="2589" height="570" alt="image" src="https://github.com/user-attachments/assets/118d42a5-4d24-4bd3-8cdd-8a233d991df0" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Quill
- fix: Swapped out the medical smart fridge with a botany smart fridge between hydro and kitchen in most maps.
