### PR TITLE
Add a Contributor License Agreement

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,9 +14,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
 <!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
-<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
-The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
-integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
+<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
+The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
+integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
 Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
 <!--- LICENSE: AGPL -->
 ## About the PR
@@ -37,6 +37,8 @@ Small fixes/refactors are exempt. Media may be used in SS14 progress reports wit
 - [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
 - [ ] I have added media to this PR or it does not require an ingame showcase.
 <!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
+- [ ] I have read and agree to the Contributor License Agreement
+<!-- See CLA.md for the CLA -->
 
 ## Breaking changes
 <!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,7 +37,7 @@ Small fixes/refactors are exempt. Media may be used in SS14 progress reports wit
 - [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
 - [ ] I have added media to this PR or it does not require an ingame showcase.
 <!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
-- [ ] I have read and agree to the Contributor License Agreement
+- [ ] I have read and agree to the Contributor License Agreement.
 <!-- See CLA.md for the CLA -->
 
 ## Breaking changes

--- a/CLA.md
+++ b/CLA.md
@@ -13,7 +13,7 @@ Subject to the terms and conditions of this agreement, You grant to the Projects
 
 ## 2. Grant of Patent License
 
-Subject to the terms and conditions of this agreement, You grant to the Projects’ maintainers, contributors, users and to Project Omu a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer your contributions, where such license applies only to those patent claims licensable by you that are necessarily infringed by your contribution or by combination of your contribution with the project to which this contribution was submitted.
+Subject to the terms and conditions of this agreement, You grant to the Projects’ maintainers, contributors, users and to Project Omu a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, import, and otherwise transfer your contributions, where such license applies only to those patent claims licensable by you that are necessarily infringed by your contribution or by combination of your contribution with the project to which this contribution was submitted.
 
 If any entity institutes patent litigation - including cross-claim or counterclaim in a lawsuit - against You alleging that your contribution or any project it was submitted to constitutes or is responsible for direct or contributory patent infringement, then any patent licenses granted to that entity under this agreement shall terminate as of the date such litigation is filed.
 

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,22 @@
+# Contributor License Agreement
+
+The following terms are used throughout this agreement:
+
+* You - the person or legal entity including its affiliates asked to accept this agreement. An affiliate is any entity that controls or is controlled by the legal entity, or is under common control with it.
+* Project - is an umbrella term that refers to any and all Project Omu open source projects.
+* Contribution - any type of work that is submitted to a Project, including any modifications or additions to existing work.
+* Submitted - conveyed to a Project via a pull request, commit, issue, or any form of electronic, written, or verbal communication with Project Omu, contributors or maintainers.
+
+## 1. Grant of Copyright License
+
+Subject to the terms and conditions of this agreement, You grant to the Projects’ maintainers, contributors, users and to Project Omu a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your contributions and such derivative works. Except for this license, You reserve all rights, title, and interest in your contributions.
+
+## 2. Grant of Patent License
+
+Subject to the terms and conditions of this agreement, You grant to the Projects’ maintainers, contributors, users and to Project Omu a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer your contributions, where such license applies only to those patent claims licensable by you that are necessarily infringed by your contribution or by combination of your contribution with the project to which this contribution was submitted.
+
+If any entity institutes patent litigation - including cross-claim or counterclaim in a lawsuit - against You alleging that your contribution or any project it was submitted to constitutes or is responsible for direct or contributory patent infringement, then any patent licenses granted to that entity under this agreement shall terminate as of the date such litigation is filed.
+
+## 3. Source of Contribution
+
+Your contribution is either your original creation, based upon previous work that, to the best of your knowledge, is covered under an appropriate open source license and you have the right under that license to submit that work with modifications, whether created in whole or in part by you, or you have clearly identified the source of the contribution and any license or other restriction (like related patents, trademarks, and license agreements) of which you are personally aware.


### PR DESCRIPTION
## About the PR
Adds a Contributor License Agreement so that Project Omu can relicense if needed.

## Why / Balance
So that Project Omu can relicense if needed, given the mass of servers doing so currently.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have read and agree to the Contributor License Agreement.

**Changelog**
