### PR TITLE
Make mechs require CanPilot

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -218,6 +218,9 @@
     pilotWhitelist:
       components:
         - HumanoidAppearance
+      tags: # Omu start
+        - CanPilot
+      requireAll: true # Omu end
   - type: MeleeWeapon
     hidden: true
     attackRate: 1
@@ -268,7 +271,10 @@
     airtight: true # Goobstation - Space Honk is real.
     pilotWhitelist:
       components:
-      - HumanoidAppearance
+        - HumanoidAppearance
+      tags: # Omu start
+        - CanPilot
+      requireAll: true # Omu end
 
 - type: entity
   parent: MechHonker

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
@@ -83,6 +83,9 @@
     pilotWhitelist:
       components:
         - HumanoidAppearance
+      tags: # Omu start
+        - CanPilot
+      requireAll: true # Omu end
   - type: MeleeWeapon
     hidden: true
     attackRate: 1
@@ -141,6 +144,9 @@
     pilotWhitelist:
       components:
         - HumanoidAppearance
+      tags: # Omu start
+        - CanPilot
+      requireAll: true # Omu end
   - type: MeleeWeapon
     hidden: true
     attackRate: 1
@@ -212,6 +218,9 @@
     pilotWhitelist:
       components:
         - HumanoidAppearance
+      tags: # Omu start
+        - CanPilot
+      requireAll: true # Omu end
   - type: MeleeWeapon
     hidden: true
     attackRate: 1
@@ -272,6 +281,9 @@
     pilotWhitelist:
       components:
         - HumanoidAppearance
+      tags: # Omu start
+        - CanPilot
+      requireAll: true # Omu end
   - type: MeleeWeapon
     hidden: true
     attackRate: 1
@@ -340,6 +352,9 @@
     pilotWhitelist:
       components:
         - HumanoidAppearance
+      tags: # Omu start
+        - CanPilot
+      requireAll: true # Omu end
   - type: MeleeWeapon
     hidden: true
     attackRate: 1
@@ -413,6 +428,9 @@
     pilotWhitelist:
       components:
         - HumanoidAppearance
+      tags: # Omu start
+        - CanPilot
+      requireAll: true # Omu end
   - type: MeleeWeapon
     hidden: true
     attackRate: 1
@@ -489,6 +507,9 @@
     pilotWhitelist:
       components:
         - HumanoidAppearance
+      tags: # Omu start
+        - CanPilot
+      requireAll: true # Omu end
   - type: MeleeWeapon
     hidden: true
     attackRate: 1
@@ -562,6 +583,9 @@
     pilotWhitelist:
       components:
         - HumanoidAppearance
+      tags: # Omu start
+        - CanPilot
+      requireAll: true # Omu end
   - type: MeleeWeapon
     hidden: true
     attackRate: 1


### PR DESCRIPTION
## About the PR
Makes all standard mechs (not VIM or HAMTR) require the CanPilot tag as well as the current HumanoidAppearance component

## Why / Balance
I don't think entities that are not "smart" enough to pilot things should be piloting mechs.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have read and agree to the Contributor License Agreement.

**Changelog**
:cl:
- tweak: You now require the "CanPilot" tag to pilot mechs, this means that mobs like monkeys cannot pilot a mech, HAMTR and VIM are unaffected by this.
