### PR TITLE
Traitor spawns

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -917,8 +917,8 @@
     - prefRoles: [ TraitorSleeper ]
       fallbackRoles: [ Traitor ]
       min: 1
-      max: 3
-      playerRatio: 15 # Omu changed so it will actually scale at 15/30/45 pop rather than how it was at 15/20 ppop
+      max: 2
+      playerRatio: 15 # Omu changed so it will actually scale at 15/30 pop rather than how it was at 15/20 ppop
       chaosScore: 200 # Goobstation - same as roundstart traitor gamerule
       blacklist:
         components:

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -902,7 +902,7 @@
     latestStart: 100 # OmuStation (1hr 40min max)
     weight: 8
     minimumPlayers: 15
-    maxOccurrences: 1 # can only happen once per round
+    maxOccurrences: 2 # can only happen twice(omu up from 1) per round
     startAnnouncement: station-event-communication-interception
     startAudio:
       path: /Audio/Announcements/intercept.ogg
@@ -917,8 +917,8 @@
     - prefRoles: [ TraitorSleeper ]
       fallbackRoles: [ Traitor ]
       min: 1
-      max: 2
-      playerRatio: 10
+      max: 3
+      playerRatio: 15 # Omu changed so it will actually scale at 15/30/45 pop rather than how it was at 15/20 ppop
       chaosScore: 200 # Goobstation - same as roundstart traitor gamerule
       blacklist:
         components:


### PR DESCRIPTION
## About the PR
Increase to mid-round Traitor spawns

## Why / Balance
asked in staff discussion

## Technical details
changed it so 3 sleepers can spawn in a sleeper agent call
Changed so sleepers can be called in twice per shift

## Media
its yaml

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Increased spawn rate of sleeper agents
