### PR TITLE
Prevent parcel wrapping unintented objects

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/parcel_wrap.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/parcel_wrap.yml
@@ -22,6 +22,8 @@
       components:
       - NukeDisk # Don't try to hide the disk.
       - WrappedParcel # No wrapping wrapped things.
+      - Storage # Omu, otherwise people can just bypass blacklist/whitelist.
+      - EntityStorage # Omu, otherwise people can just bypass blacklist/whitelist.
       tags:
       - ParcelWrapBlacklist
       - FakeNukeDisk # So you can't tell if the nuke disk is real or fake depending on if it can be wrapped or not.


### PR DESCRIPTION
## About the PR
Makes it so you can't parcel wrap items that can contain other items, or items that can contain mobs.

## Why / Balance
Allowing either of these encourages bypassing the blacklists and whitelists set in place, from locking mobs in inescapable parcels, to hiding the nuke disk.

## Technical details
2 lines of yaml.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have read and agree to the Contributor License Agreement.

**Changelog**
:cl:
- tweak: You can no longer parcel wrap entities with storage.
