### PR TITLE
Fix CPR Logic & Missing Text

### DIFF
--- a/Content.Server/_EinsteinEngines/Medical/CPR/CPRSystem.cs
+++ b/Content.Server/_EinsteinEngines/Medical/CPR/CPRSystem.cs
@@ -16,6 +16,7 @@ using Content.Shared.Atmos.Rotting;
 using Content.Shared.Damage;
 using Content.Shared.DoAfter;
 using Content.Shared.Inventory;
+using Content.Shared.Nutrition; // Omu
 
 using Content.Shared.Medical.CPR;
 using Content.Shared.Mobs;
@@ -44,6 +45,7 @@ public sealed class CPRSystem : EntitySystem
     [Dependency] private readonly RottingSystem _rottingSystem = default!;
     [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly AudioSystem _audio = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!; // Omu
 
     public override void Initialize()
     {
@@ -90,7 +92,35 @@ public sealed class CPRSystem : EntitySystem
         }
 
         if (!_ingestionSystem.HasMouthAvailable(performer, performer) || !_ingestionSystem.HasMouthAvailable(performer, target)) // Omu, swap parameters to correctly check if target is wearing a blocker
+        {
+            // Omu, fixes the ingestion blocker text not appearing.
+            // Yes, this is shitcode. I am sorry but I don't know how to do this better.
+
+            // first, check if the range requirement is why the interaction failed
+            if (!_transform.GetMapCoordinates(performer).InRange(_transform.GetMapCoordinates(target), IngestionSystem.MaxFeedDistance))
+            {
+                _popupSystem.PopupEntity(Loc.GetString("interaction-system-user-interaction-cannot-reach"), performer, performer);
+                return;
+            }
+
+            // if not range, then check if it's because someone can't do ingesting
+            var attempt = new IngestionAttemptEvent(IngestionSystem.DefaultFlags);
+            if(!_ingestionSystem.HasMouthAvailable(performer, performer)) // first check if the performer has a mask
+            {
+                RaiseLocalEvent(performer, ref attempt);
+                if (attempt.Blocker != null)
+                    _popupSystem.PopupEntity(Loc.GetString("ingestion-remove-mask", ("entity", attempt.Blocker.Value)), performer, performer);
+
+            } else if (!_ingestionSystem.HasMouthAvailable(performer, target)) // if not, check if the target has a mask; this is to prevent mixing textboxes
+            {
+                RaiseLocalEvent(target, ref attempt);
+                if (attempt.Blocker != null)
+                    _popupSystem.PopupEntity(Loc.GetString("ingestion-remove-mask", ("entity", attempt.Blocker.Value)), performer, performer);
+            }
             return;
+            // Omu end
+        }
+
 
         _popupSystem.PopupEntity(Loc.GetString("cpr-start-second-person", ("target", target)), target, performer);
         _popupSystem.PopupEntity(Loc.GetString("cpr-start-second-person-patient", ("user", performer)), target, target);

--- a/Content.Server/_EinsteinEngines/Medical/CPR/CPRSystem.cs
+++ b/Content.Server/_EinsteinEngines/Medical/CPR/CPRSystem.cs
@@ -89,7 +89,7 @@ public sealed class CPRSystem : EntitySystem
             return;
         }
 
-        if (!_ingestionSystem.HasMouthAvailable(performer, performer) || !_ingestionSystem.HasMouthAvailable(target, performer))
+        if (!_ingestionSystem.HasMouthAvailable(performer, performer) || !_ingestionSystem.HasMouthAvailable(performer, target)) // Omu, swap parameters to correctly check if target is wearing a blocker
             return;
 
         _popupSystem.PopupEntity(Loc.GetString("cpr-start-second-person", ("target", target)), target, performer);

--- a/Content.Server/_EinsteinEngines/Medical/CPR/CPRSystem.cs
+++ b/Content.Server/_EinsteinEngines/Medical/CPR/CPRSystem.cs
@@ -71,44 +71,7 @@ public sealed class CPRSystem : EntitySystem
 
     private void StartCPR(Entity<CPRTrainingComponent> performer, EntityUid target)
     {
-        if (HasComp<RottingComponent>(target))
-        {
-            _popupSystem.PopupEntity(Loc.GetString("cpr-target-rotting", ("entity", target)), performer, performer);
-            return;
-        }
-
-        if (!HasComp<RespiratorComponent>(target) || !HasComp<RespiratorComponent>(performer))
-        {
-            _popupSystem.PopupEntity(Loc.GetString("cpr-target-cantbreathe", ("entity", target)), performer, performer);
-            return;
-        }
-
-        if (_inventory.TryGetSlotEntity(target, "outerClothing", out var outer))
-        {
-            _popupSystem.PopupEntity(Loc.GetString("cpr-must-remove", ("clothing", outer)), performer, performer);
-            return;
-        }
-
-        // Omu, fix CPR not showing a message for being out of range or for having a blocker
-        // Separated into two checks so that the out variables don't end up unassigned
-        if (!_ingestionSystem.HasMouthAvailable(performer, performer, out string? performerMessage))
-        { 
-            if (!string.IsNullOrEmpty(performerMessage)) // If the message isn't null, then report the message via popup
-            {
-                _popupSystem.PopupEntity(performerMessage, performer, performer);
-            }
-            return;
-        }
-        if (!_ingestionSystem.HasMouthAvailable(performer, target, out string? targetMessage)) // Omu, swap parameters to correctly check if target is wearing a blocker
-        {
-            if (!string.IsNullOrEmpty(targetMessage))
-            {
-                _popupSystem.PopupEntity(targetMessage, performer, performer);
-            }
-            return;
-        }
-        // Omu end
-            
+        if (ShouldCPRStop(performer, target)) { return; } // Omu, use new Omu-provided reusable function to check if CPR is okay to start and which text to display if not
 
         _popupSystem.PopupEntity(Loc.GetString("cpr-start-second-person", ("target", target)), target, performer);
         _popupSystem.PopupEntity(Loc.GetString("cpr-start-second-person-patient", ("user", performer)), target, target);
@@ -133,26 +96,11 @@ public sealed class CPRSystem : EntitySystem
 
     private void OnCPRDoAfter(Entity<CPRTrainingComponent> performer, ref CPRDoAfterEvent args)
     {
-        if (args.Cancelled || args.Handled || !args.Target.HasValue)
+        if (args.Cancelled || args.Handled || !args.Target.HasValue || ShouldCPRStop(performer, args.Target.Value)) // Omu, fixes CPR being able to continue; 
         {
             performer.Comp.CPRPlayingStream = _audio.Stop(performer.Comp.CPRPlayingStream);
             return;
         }
-        // Omu start; fixes CPR being able to continue even when conditions to start CPR are no longer met
-        var target = args.Target.Value;
-
-        if (HasComp<RottingComponent>(target) || // Check on every CPR cycle if you're actually meant to be able to do CPR
-            !HasComp<RespiratorComponent>(target) || // If you're not, then you finish CPR
-            !HasComp<RespiratorComponent>(performer) ||
-            _inventory.TryGetSlotEntity(target, "outerClothing", out _) ||
-            !_ingestionSystem.HasMouthAvailable(performer, performer) ||
-            !_ingestionSystem.HasMouthAvailable(performer, target))
-        {
-            // This is repeated since HasMouthAvailable must take a non-optional target
-            performer.Comp.CPRPlayingStream = _audio.Stop(performer.Comp.CPRPlayingStream);
-            return;
-        }
-        // Omu end
 
         if (!performer.Comp.CPRHealing.Empty)
             _damageable.TryChangeDamage(args.Target, performer.Comp.CPRHealing, true, origin: performer, targetPart: TargetBodyPart.All); // Shitmed Change
@@ -185,4 +133,63 @@ public sealed class CPRSystem : EntitySystem
         if (isAlive)
             performer.Comp.CPRPlayingStream = _audio.Stop(performer.Comp.CPRPlayingStream);
     }
+
+    // Omu start; adds reusable method to check for when CPR should stop and what text it should output when stopped
+    // Returns true if CPR should stop
+    // Displays appropriate popup text if CPR should stop
+    private bool ShouldCPRStop(EntityUid performer, EntityUid target)
+    {
+        if (!HasComp<RespiratorComponent>(performer)) // Omu, check respiratorcomponents first before rotting
+        {
+            _popupSystem.PopupEntity(Loc.GetString("omu-cpr-performer-cantbreathe"), performer, performer);
+            return true;
+        }
+
+        if (!HasComp<RespiratorComponent>(target)) // Omu, separated performer and target respiratorcomponent checks
+        {
+            _popupSystem.PopupEntity(Loc.GetString("omu-cpr-target-cantbreathe", ("entity", target)), performer, performer);
+            return true;
+        }
+
+        if (HasComp<RottingComponent>(target))
+        {
+            _popupSystem.PopupEntity(Loc.GetString("cpr-target-rotting", ("entity", target)), performer, performer);
+            return true;
+        }
+
+        if (_inventory.TryGetSlotEntity(target, "outerClothing", out var outer))
+        {
+            _popupSystem.PopupEntity(Loc.GetString("cpr-must-remove", ("clothing", outer)), performer, performer);
+            return true;
+        }
+
+        if (!_ingestionSystem.HasMouthAvailable(performer, performer, out string? performerMessage, out EntityUid? performerBlocker))
+        {
+            if (performerBlocker != null)
+            { // If blocker exists, use unique "remove-own-mask" line to reduce ambiguity
+                _popupSystem.PopupEntity(Loc.GetString("omu-cpr-must-remove-own-mask", ("clothing", performerBlocker)), performer, performer);
+            }
+            else if (!string.IsNullOrEmpty(performerMessage))
+            { // Fall back on given ingestion message if there is one
+                _popupSystem.PopupEntity(performerMessage, performer, performer);
+            }
+            return true;
+        }
+
+        if (!_ingestionSystem.HasMouthAvailable(performer, target, out string? targetMessage, out EntityUid? targetBlocker)) // Omu, swap arguments to correctly check if target is wearing a blocker
+        {
+            if (targetBlocker != null)
+            { // If blocker exists, use the "cpr-must-remove" line to reduce ambiguity
+                _popupSystem.PopupEntity(Loc.GetString("cpr-must-remove", ("clothing", targetBlocker)), performer, performer);
+            }
+            else if (!string.IsNullOrEmpty(targetMessage))
+            { // Fall back on given ingestion message if there is one
+                _popupSystem.PopupEntity(targetMessage, performer, performer);
+            }
+            return true;
+        }
+
+        return false;
+    }
+    // Omu end
 }

--- a/Content.Server/_EinsteinEngines/Medical/CPR/CPRSystem.cs
+++ b/Content.Server/_EinsteinEngines/Medical/CPR/CPRSystem.cs
@@ -119,15 +119,7 @@ public sealed class CPRSystem : EntitySystem
         {
             BreakOnMove = true,
             NeedHand = true,
-            BlockDuplicate = true,
-            // Omu, check if you're no longer able to do CPR during the doafter
-            // This is using a deprecated feature to avoid dealing with events from other namespaces
-            AttemptFrequency = AttemptFrequency.StartAndEnd,
-            ExtraCheck = () => !(HasComp<RottingComponent>(target) || // cancels on false, so invert all the previous checks
-            !HasComp<RespiratorComponent>(target) || !HasComp<RespiratorComponent>(performer) ||
-            _inventory.TryGetSlotEntity(target, "outerClothing", out _) ||
-            !_ingestionSystem.HasMouthAvailable(performer, performer) || !_ingestionSystem.HasMouthAvailable(performer, target))
-            // Omu end
+            BlockDuplicate = true
         };
 
         _doAfterSystem.TryStartDoAfter(doAfterArgs);

--- a/Content.Server/_EinsteinEngines/Medical/CPR/CPRSystem.cs
+++ b/Content.Server/_EinsteinEngines/Medical/CPR/CPRSystem.cs
@@ -131,7 +131,15 @@ public sealed class CPRSystem : EntitySystem
         {
             BreakOnMove = true,
             NeedHand = true,
-            BlockDuplicate = true
+            BlockDuplicate = true,
+            // Omu, check if you're no longer able to do CPR during the doafter
+            // This is using a deprecated feature to avoid dealing with events from other namespaces
+            AttemptFrequency = AttemptFrequency.StartAndEnd,
+            ExtraCheck = () => !(HasComp<RottingComponent>(target) || // cancels on false, so invert all the previous checks
+            !HasComp<RespiratorComponent>(target) || !HasComp<RespiratorComponent>(performer) ||
+            _inventory.TryGetSlotEntity(target, "outerClothing", out _) ||
+            !_ingestionSystem.HasMouthAvailable(performer, performer) || !_ingestionSystem.HasMouthAvailable(performer, target))
+            // Omu end
         };
 
         _doAfterSystem.TryStartDoAfter(doAfterArgs);

--- a/Content.Server/_EinsteinEngines/Medical/CPR/CPRSystem.cs
+++ b/Content.Server/_EinsteinEngines/Medical/CPR/CPRSystem.cs
@@ -16,7 +16,6 @@ using Content.Shared.Atmos.Rotting;
 using Content.Shared.Damage;
 using Content.Shared.DoAfter;
 using Content.Shared.Inventory;
-using Content.Shared.Nutrition; // Omu
 
 using Content.Shared.Medical.CPR;
 using Content.Shared.Mobs;
@@ -45,7 +44,6 @@ public sealed class CPRSystem : EntitySystem
     [Dependency] private readonly RottingSystem _rottingSystem = default!;
     [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly AudioSystem _audio = default!;
-    [Dependency] private readonly SharedTransformSystem _transform = default!; // Omu
 
     public override void Initialize()
     {
@@ -91,36 +89,8 @@ public sealed class CPRSystem : EntitySystem
             return;
         }
 
-        if (!_ingestionSystem.HasMouthAvailable(performer, performer) || !_ingestionSystem.HasMouthAvailable(performer, target)) // Omu, swap arguments to correctly check if target is wearing a blocker
-        {
-            // Omu, fixes the ingestion blocker text not appearing.
-            // Yes, this is shitcode. I am sorry but I don't know how to do this better.
-
-            // first, check if the range requirement is why the interaction failed
-            if (!_transform.GetMapCoordinates(performer).InRange(_transform.GetMapCoordinates(target), IngestionSystem.MaxFeedDistance))
-            {
-                _popupSystem.PopupEntity(Loc.GetString("interaction-system-user-interaction-cannot-reach"), performer, performer);
-                return;
-            }
-
-            // if not range, then check if it's because someone can't do ingesting
-            var attempt = new IngestionAttemptEvent(IngestionSystem.DefaultFlags);
-            if(!_ingestionSystem.HasMouthAvailable(performer, performer)) // first check if the performer has a mask
-            {
-                RaiseLocalEvent(performer, ref attempt);
-                if (attempt.Blocker != null)
-                    _popupSystem.PopupEntity(Loc.GetString("ingestion-remove-mask", ("entity", attempt.Blocker.Value)), performer, performer);
-
-            } else if (!_ingestionSystem.HasMouthAvailable(performer, target)) // if not, check if the target has a mask; this is to prevent mixing textboxes
-            {
-                RaiseLocalEvent(target, ref attempt);
-                if (attempt.Blocker != null)
-                    _popupSystem.PopupEntity(Loc.GetString("ingestion-remove-mask", ("entity", attempt.Blocker.Value)), performer, performer);
-            }
+        if (!_ingestionSystem.HasMouthAvailable(performer, performer) || !_ingestionSystem.HasMouthAvailable(performer, target)) // Omu, swap parameters to correctly check if target is wearing a blocker
             return;
-            // Omu end
-        }
-
 
         _popupSystem.PopupEntity(Loc.GetString("cpr-start-second-person", ("target", target)), target, performer);
         _popupSystem.PopupEntity(Loc.GetString("cpr-start-second-person-patient", ("user", performer)), target, target);

--- a/Content.Server/_EinsteinEngines/Medical/CPR/CPRSystem.cs
+++ b/Content.Server/_EinsteinEngines/Medical/CPR/CPRSystem.cs
@@ -91,7 +91,7 @@ public sealed class CPRSystem : EntitySystem
             return;
         }
 
-        if (!_ingestionSystem.HasMouthAvailable(performer, performer) || !_ingestionSystem.HasMouthAvailable(performer, target)) // Omu, swap parameters to correctly check if target is wearing a blocker
+        if (!_ingestionSystem.HasMouthAvailable(performer, performer) || !_ingestionSystem.HasMouthAvailable(performer, target)) // Omu, swap arguments to correctly check if target is wearing a blocker
         {
             // Omu, fixes the ingestion blocker text not appearing.
             // Yes, this is shitcode. I am sorry but I don't know how to do this better.

--- a/Content.Server/_EinsteinEngines/Medical/CPR/CPRSystem.cs
+++ b/Content.Server/_EinsteinEngines/Medical/CPR/CPRSystem.cs
@@ -89,8 +89,26 @@ public sealed class CPRSystem : EntitySystem
             return;
         }
 
-        if (!_ingestionSystem.HasMouthAvailable(performer, performer) || !_ingestionSystem.HasMouthAvailable(performer, target)) // Omu, swap parameters to correctly check if target is wearing a blocker
+        // Omu, fix CPR not showing a message for being out of range or for having a blocker
+        // Separated into two checks so that the out variables don't end up unassigned
+        if (!_ingestionSystem.HasMouthAvailable(performer, performer, out string performerMessage))
+        { 
+            if (performerMessage.Length > 0) // Check if message is an empty string; if it isn't, then report it via popup
+            {
+                _popupSystem.PopupEntity(performerMessage, performer, performer);
+            }
             return;
+        }
+        if (!_ingestionSystem.HasMouthAvailable(performer, target, out string targetMessage)) // Omu, swap parameters to correctly check if target is wearing a blocker
+        {
+            if (targetMessage.Length > 0)
+            {
+                _popupSystem.PopupEntity(targetMessage, performer, performer);
+            }
+            return;
+        }
+        // Omu end
+            
 
         _popupSystem.PopupEntity(Loc.GetString("cpr-start-second-person", ("target", target)), target, performer);
         _popupSystem.PopupEntity(Loc.GetString("cpr-start-second-person-patient", ("user", performer)), target, target);

--- a/Content.Server/_EinsteinEngines/Medical/CPR/CPRSystem.cs
+++ b/Content.Server/_EinsteinEngines/Medical/CPR/CPRSystem.cs
@@ -91,17 +91,17 @@ public sealed class CPRSystem : EntitySystem
 
         // Omu, fix CPR not showing a message for being out of range or for having a blocker
         // Separated into two checks so that the out variables don't end up unassigned
-        if (!_ingestionSystem.HasMouthAvailable(performer, performer, out string performerMessage))
+        if (!_ingestionSystem.HasMouthAvailable(performer, performer, out string? performerMessage))
         { 
-            if (performerMessage.Length > 0) // Check if message is an empty string; if it isn't, then report it via popup
+            if (!string.IsNullOrEmpty(performerMessage)) // If the message isn't null, then report the message via popup
             {
                 _popupSystem.PopupEntity(performerMessage, performer, performer);
             }
             return;
         }
-        if (!_ingestionSystem.HasMouthAvailable(performer, target, out string targetMessage)) // Omu, swap parameters to correctly check if target is wearing a blocker
+        if (!_ingestionSystem.HasMouthAvailable(performer, target, out string? targetMessage)) // Omu, swap parameters to correctly check if target is wearing a blocker
         {
-            if (targetMessage.Length > 0)
+            if (!string.IsNullOrEmpty(targetMessage))
             {
                 _popupSystem.PopupEntity(targetMessage, performer, performer);
             }

--- a/Content.Server/_EinsteinEngines/Medical/CPR/CPRSystem.cs
+++ b/Content.Server/_EinsteinEngines/Medical/CPR/CPRSystem.cs
@@ -138,6 +138,21 @@ public sealed class CPRSystem : EntitySystem
             performer.Comp.CPRPlayingStream = _audio.Stop(performer.Comp.CPRPlayingStream);
             return;
         }
+        // Omu start; fixes CPR being able to continue even when conditions to start CPR are no longer met
+        var target = args.Target.Value;
+
+        if (HasComp<RottingComponent>(target) || // Check on every CPR cycle if you're actually meant to be able to do CPR
+            !HasComp<RespiratorComponent>(target) || // If you're not, then you finish CPR
+            !HasComp<RespiratorComponent>(performer) ||
+            _inventory.TryGetSlotEntity(target, "outerClothing", out _) ||
+            !_ingestionSystem.HasMouthAvailable(performer, performer) ||
+            !_ingestionSystem.HasMouthAvailable(performer, target))
+        {
+            // This is repeated since HasMouthAvailable must take a non-optional target
+            performer.Comp.CPRPlayingStream = _audio.Stop(performer.Comp.CPRPlayingStream);
+            return;
+        }
+        // Omu end
 
         if (!performer.Comp.CPRHealing.Empty)
             _damageable.TryChangeDamage(args.Target, performer.Comp.CPRHealing, true, origin: performer, targetPart: TargetBodyPart.All); // Shitmed Change

--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.API.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.API.cs
@@ -74,7 +74,14 @@ public sealed partial class IngestionSystem
     /// Omu, option to take the message for use in server-side logic
     public bool HasMouthAvailable(EntityUid user, EntityUid target, out string? message)
     {
-        return HasMouthAvailable(user, target, DefaultFlags, out message);
+        return HasMouthAvailable(user, target, DefaultFlags, out message, out _);
+    }
+
+    /// <inheritdoc cref="HasMouthAvailable(EntityUid, EntityUid)"/>
+    /// Omu, option to additionally take the blocker for use in server-side logic
+    public bool HasMouthAvailable(EntityUid user, EntityUid target, out string? message, out EntityUid? blocker)
+    {
+        return HasMouthAvailable(user, target, DefaultFlags, out message, out blocker);
     }
 
     /// <inheritdoc cref="HasMouthAvailable(EntityUid, EntityUid)"/>
@@ -103,9 +110,11 @@ public sealed partial class IngestionSystem
     /// <inheritdoc cref="HasMouthAvailable(EntityUid, EntityUid, SlotFlags)"/>
     /// Omu, allows for taking the reason why the interaction failed
     /// "message" will be null if the interaction succeeded or did not fail due to distance or a blocker
-    public bool HasMouthAvailable(EntityUid user, EntityUid target, SlotFlags flags, out string? message)
+    /// "blocker" will be null if the interaction does not fail due to a blocker (i.e. succeeds, is cancelled or fails due to range)
+    public bool HasMouthAvailable(EntityUid user, EntityUid target, SlotFlags flags, out string? message, out EntityUid? blocker)
     {
         message = null; // leave the message null if it succeeded or the fail wasn't due to reach or a blocker
+        blocker = null; // the blocker will only be set if the attempt is not cancelled
 
         if (!_transform.GetMapCoordinates(user).InRange(_transform.GetMapCoordinates(target), MaxFeedDistance))
         {
@@ -122,6 +131,7 @@ public sealed partial class IngestionSystem
 
         if (attempt.Blocker != null)
         {
+            blocker = attempt.Blocker;
             message = Loc.GetString("ingestion-remove-mask", ("entity", attempt.Blocker.Value));
             _popup.PopupClient(message, target, user);
         }

--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.API.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.API.cs
@@ -72,7 +72,7 @@ public sealed partial class IngestionSystem
 
     /// <inheritdoc cref="HasMouthAvailable(EntityUid, EntityUid)"/>
     /// Omu, option to take the message for use in server-side logic
-    public bool HasMouthAvailable(EntityUid user, EntityUid target, out string message)
+    public bool HasMouthAvailable(EntityUid user, EntityUid target, out string? message)
     {
         return HasMouthAvailable(user, target, DefaultFlags, out message);
     }
@@ -102,10 +102,10 @@ public sealed partial class IngestionSystem
 
     /// <inheritdoc cref="HasMouthAvailable(EntityUid, EntityUid, SlotFlags)"/>
     /// Omu, allows for taking the reason why the interaction failed
-    /// "message" will be an empty string if the interaction did not fail due to distance or a blocker
-    public bool HasMouthAvailable(EntityUid user, EntityUid target, SlotFlags flags, out string message)
+    /// "message" will be null if the interaction succeeded or did not fail due to distance or a blocker
+    public bool HasMouthAvailable(EntityUid user, EntityUid target, SlotFlags flags, out string? message)
     {
-        message = ""; // leave the message empty if nothing is stopping you
+        message = null; // leave the message null if it succeeded or the fail wasn't due to reach or a blocker
 
         if (!_transform.GetMapCoordinates(user).InRange(_transform.GetMapCoordinates(target), MaxFeedDistance))
         {

--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.API.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.API.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using Content.Goobstation.Maths.FixedPoint;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Components.SolutionManager;

--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.API.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.API.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using Content.Goobstation.Maths.FixedPoint;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Components.SolutionManager;
@@ -71,6 +71,13 @@ public sealed partial class IngestionSystem
     }
 
     /// <inheritdoc cref="HasMouthAvailable(EntityUid, EntityUid)"/>
+    /// Omu, option to take the message for use in server-side logic
+    public bool HasMouthAvailable(EntityUid user, EntityUid target, out string message)
+    {
+        return HasMouthAvailable(user, target, DefaultFlags, out message);
+    }
+
+    /// <inheritdoc cref="HasMouthAvailable(EntityUid, EntityUid)"/>
     /// Overflow which takes custom flags for a mouth being blocked, in case the entity has a mouth not on the face.
     public bool HasMouthAvailable(EntityUid user, EntityUid target, SlotFlags flags)
     {
@@ -89,6 +96,35 @@ public sealed partial class IngestionSystem
 
         if (attempt.Blocker != null)
             _popup.PopupClient(Loc.GetString("ingestion-remove-mask", ("entity", attempt.Blocker.Value)), target, user);
+
+        return false;
+    }
+
+    /// <inheritdoc cref="HasMouthAvailable(EntityUid, EntityUid, SlotFlags)"/>
+    /// Omu, allows for taking the reason why the interaction failed
+    /// "message" will be an empty string if the interaction did not fail due to distance or a blocker
+    public bool HasMouthAvailable(EntityUid user, EntityUid target, SlotFlags flags, out string message)
+    {
+        message = ""; // leave the message empty if nothing is stopping you
+
+        if (!_transform.GetMapCoordinates(user).InRange(_transform.GetMapCoordinates(target), MaxFeedDistance))
+        {
+            message = Loc.GetString("interaction-system-user-interaction-cannot-reach");
+            _popup.PopupClient(message, user, user);
+            return false;
+        }
+
+        var attempt = new IngestionAttemptEvent(flags);
+        RaiseLocalEvent(target, ref attempt);
+
+        if (!attempt.Cancelled)
+            return true;
+
+        if (attempt.Blocker != null)
+        {
+            message = Loc.GetString("ingestion-remove-mask", ("entity", attempt.Blocker.Value));
+            _popup.PopupClient(message, target, user);
+        }
 
         return false;
     }

--- a/Resources/Locale/en-US/_Omu/medical/components/cpr-training-component.ftl
+++ b/Resources/Locale/en-US/_Omu/medical/components/cpr-training-component.ftl
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
+# SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+omu-cpr-must-remove-own-mask = You must remove your {$clothing}.
+omu-cpr-target-cantbreathe = {CAPITALIZE($entity)} is incapable of breathing.
+omu-cpr-performer-cantbreathe = You are incapable of breathing.


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
fixed a logic error allowing you to start CPR when your patient has a mask on
fixed people being able to continue doing CPR even when they're not supposed to be able to start it
added appropriate text popups when you're unable to do CPR and for what reason

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
i JUST found out that you're not supposed to be able to perform CPR if you/the victim has a mask on. (this mean you're using mouth-to-mouth. yucky)
having proper text (and the proper mask interactions) makes things WAY less confusing for the average doctor

## Technical details
<!-- Summary of code changes for easier review. -->
changes are to EE's `CPRSystem.cs` for handling mask logic and getting CPR to stop
changes to wizden `IngestionSystem.API.cs` to add additional overloads of `HasMouthAvailable` to provide nullable `out` for possible messages (the message is `null` if the message isn't set by being out of range or having a face blocker) and nullable `out` for the ingestion blocked (used for proper text reasons of what's actually preventing you from doing CPR)
added omu-specific `cpr-training-component.ftl` to avoid messing with anything on EE's version

for the mask logic fix, simply switched two ~~parameters~~ ARGUMENTS i meant arguments
for the text to show up, i added the overloads of `HasMouthAvailable`, changed the checks to use the new version with a nullable `out` for the message and blocker, and split the checks for the performer and target to have unique text for each explaining who exactly has the problem
for the CPR to stop when you're not supposed to do CPR, i abstracted the whole-ass check in `StartCPR()` to helper method  `ShouldCPRStop()` that would check the reasons why you shouldn't be able to start and show the text popup corresponding to that reason. after that, i added a check for `ShouldCPRStop()` in the callback `OnCPRDoAfter` which stops you from doing CPR at the end of the current CPR cycle

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://youtu.be/1G0f6wmot3o

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] I have read and agree to the Contributor License Agreement.
<!-- See CLA.md for the CLA -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Duuckie
- tweak: CPR now has proper text popups for when you're not able to do it.
- fix: CPR now stops you from continuing if you're not meant to be able to start CPR. You also can no longer do CPR to people who have masks on.