### PR TITLE
disable paradox clone

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -196,7 +196,7 @@
     - id: DragonSpawn
     - id: KingRatMigration
     - id: NinjaSpawn
-    - id: ParadoxCloneSpawn
+    #- id: ParadoxCloneSpawn # omu weird bug casuing extreme lag
     #- id: RevenantSpawn  # GoobStation - removed till rework
     - id: SleeperAgents
     - id: ZombieOutbreak


### PR DESCRIPTION
## About the PR
causing rapid spawning of the paradox'd person

## Why / Balance
its a critical bug atm

## Technical details
disables paradox clone until we discover a fix

## Media
yaml

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- remove: Paradox clone disabled due to urgent bug. Will be enabled in the future