### PR TITLE
[FIX] Give slasher's meat spike a collision fixture

### DIFF
--- a/Resources/Prototypes/_Goobstation/Slasher/items.yml
+++ b/Resources/Prototypes/_Goobstation/Slasher/items.yml
@@ -207,6 +207,16 @@
   - type: AntiRotOnBuckle
   - type: Fixtures
     fixtures:
+      fix1: # Omu, give it colision
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.45,-0.45,0.45,0.45"
+        density: 60
+        mask:
+        - MachineMask
+        layer:
+        - MidImpassable
+        - LowImpassable
       spike:
         shape: !type:PhysShapeAabb { bounds: "-0.25,-0.25,0.25,0.25" }
         density: 5


### PR DESCRIPTION
## About the PR
Adds a fixture to it so it can collide with things.

## Why / Balance
They overrode the fixtures to add a special one for slasher but never added back the collision fixture for some reason, this fixes that.

## Technical details
Copy over the fixture from basestructure

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have read and agree to the Contributor License Agreement.

**Changelog**
:cl:
- fix: Fixed the Ominous meat spike not having collision. 
