### PR TITLE
Removed RemoveMarkupOrThrow in ChatSystem to allow invalid markdown from being set as chat messages

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -758,10 +758,18 @@ public sealed partial class ChatSystem : SharedChatSystem
             return;
 
         // The Original Message [-] Einstein Engines - Language
-        // Omu - RemoveMarkupOrThrow() ... throws an error when it's a invalid message, resulting in the message not appearing in chat.
-        // This could happen when for example someone sends a `[` or other things.
-        //var message = FormattedMessage.RemoveMarkupOrThrow(originalMessage);  // Remove markup before transforming. Omu - Line commented out
-        var message = FormattedMessage.EscapeText(originalMessage); // Escape after removing markup. Omu - variable changed
+        // Omu begin - Switched to the more permissive parser, so it doesn't immediately throw an error when you send a single bracket.
+        var message = originalMessage;
+        try
+        {
+            message = FormattedMessage.RemoveMarkupPermissive(message);
+        }
+        catch (Exception)
+        {
+            // Despite the method's name, this method also throws exceptions when it fails to parse, so let's catch it and just send the message as is.
+        }
+        message = FormattedMessage.EscapeText(message); // Escape after removing markup.
+        // Omu end
         message = TransformSpeech(source, message, language);
 
         if (message.Length == 0)

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -758,8 +758,10 @@ public sealed partial class ChatSystem : SharedChatSystem
             return;
 
         // The Original Message [-] Einstein Engines - Language
-        var message = FormattedMessage.RemoveMarkupOrThrow(originalMessage);  // Remove markup before transforming.
-        message = FormattedMessage.EscapeText(message); // Escape after removing markup
+        // Omu - RemoveMarkupOrThrow() ... throws an error when it's a invalid message, resulting in the message not appearing in chat.
+        // This could happen when for example someone sends a `[` or other things.
+        //var message = FormattedMessage.RemoveMarkupOrThrow(originalMessage);  // Remove markup before transforming. Omu - Line commented out
+        var message = FormattedMessage.EscapeText(originalMessage); // Escape after removing markup. Omu - variable changed
         message = TransformSpeech(source, message, language);
 
         if (message.Length == 0)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Sending a message like `[` would throw an exception and not allow the message to be sent. This is a PR to allow messages containing invalid markdown. 

## Why / Balance
Let creatures send their messages instead of not doing anything when hitting enter.

## Technical details
Before sending a chat message, there's a `FormattedMessage.RemoveMarkupOrThrow(originalMessage);` which should strip the message of all formatting.

However, since this a `OrThrow()` message, this means that the method crashes when a creature sends an "invalid formatted" message, like `Hello [`.

We decided that the player should be able to actually send what they type so we removed that line.

## Media
<img width="3418" height="369" alt="image" src="https://github.com/user-attachments/assets/77209ef7-cd96-44c1-8ca6-9c7ef2f3d7f3" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] I have read and agree to the Contributor License Agreement.
<!-- See CLA.md for the CLA -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Quill
- fix: Fixed chat messages from not sending because of invalid markdown tags.

