### PR TITLE
Give xenos structural, make barricades unable to be climbed

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Walls/barricades.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Walls/barricades.yml
@@ -16,13 +16,14 @@
         mask:
         - FullTileMask
         layer:
-        - TableLayer
+        #- TableLayer # Omu
+        - MidImpassable # Omu
         - LowImpassable # no mice or crawling chuds allowed, its flush with the floor
   - type: RotationDrawDepth
     southDrawDepth: OverMobs
   - type: Anchorable
   - type: Rotatable
-  - type: Climbable
+  #- type: Climbable # Omu, no climing the barricades.
   - type: InteractionOutline
   - type: Damageable
     damageContainer: Barricade

--- a/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/base.yml
+++ b/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/base.yml
@@ -194,6 +194,17 @@
     - DoorBumpOpener
     - FootstepSound
   - type: XenomorphShoveTracker
+  - type: MeleeWeapon # Omu, make it so they do structural damage.
+    altDisarm: true
+    angle: 0
+    soundHit:
+      collection: AlienClaw
+    animation: WeaponArcBite
+    damage:
+      groups:
+        Brute: 25
+      types:
+        Structural: 20
 
 - type: entity
   id: BaseMobXenomorphDungeon

--- a/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/praetorian.yml
+++ b/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/praetorian.yml
@@ -57,6 +57,8 @@
     damage:
       groups:
         Brute: 30
+      types: # Omu, give them structural damage.
+        Structural: 30
   # - type: GuideHelp
   #   guides:
   #   - XenomorphPraetorian

--- a/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/queen.yml
+++ b/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/queen.yml
@@ -62,6 +62,8 @@
     damage:
       groups:
         Brute: 50
+      types: # Omu, give them structural damage.
+        Structural: 40
   - type: Deathgasp
     prototype: XenomorphQueenDeathgasp
   - type: Speech


### PR DESCRIPTION
## About the PR
Some changes that should hopefully make xenos a bit better to play, I would have prefered to give them the acid action back but its very broken now, and I was not able to fix it easily, so this will do.

Barricades loose the ability to be climbed / crawled over, making them actually function for defensive lines, given that you can instantly toggle the gate parts, this shouldn't be a major balance issue, but rather makes them more useful and interesting.

## Why / Balance
Xenos needed a way to break through things, and barricades needed to actually stop people. done in the same pr as to not break ballance while the other one is not merged. (Tested xenos against the barricades and they can break through them with relative ease).

## Technical details
Adds MidImpassable to the barricades, and removes TableLayer, preventing crawling over, then removes Climbable so they cannot be climbed onto.

All adult xenos now deal a base of 20 structural, with Praetorians doing 30, and the Queen doing 40.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have read and agree to the Contributor License Agreement.

**Changelog**
:cl:
- tweak: Barricades cannot be climbed or crawled over any more.
- tweak: Xenos now deal structural (20 for adult xenos, 30 for Praetorians, 40 for Queens).