### PR TITLE
The great bioluminescence update

### DIFF
--- a/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
+++ b/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
@@ -212,13 +212,15 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
             ? profile.Appearance.SkinColor.WithAlpha(hairAlpha)
             : profile.Appearance.HairColor;
         var hair = new Marking(profile.Appearance.HairStyleId,
-            new[] { hairColor });
+            new[] { hairColor },
+            false); // Omu
 
         var facialHairColor = _markingManager.MustMatchSkin(profile.Species, HumanoidVisualLayers.FacialHair, out var facialHairAlpha, _prototypeManager)
             ? profile.Appearance.SkinColor.WithAlpha(facialHairAlpha)
             : profile.Appearance.FacialHairColor;
         var facialHair = new Marking(profile.Appearance.FacialHairStyleId,
-            new[] { facialHairColor });
+            new[] { facialHairColor },
+            false); // Omu
 
         if (_markingManager.CanBeApplied(profile.Species, profile.Sex, hair, _prototypeManager))
         {
@@ -238,7 +240,7 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
                 profile.Appearance.EyeColor,
                 markings
             );
-            markings.AddBack(prototype.MarkingCategory, new Marking(marking.MarkingId, markingColors));
+            markings.AddBack(prototype.MarkingCategory, new Marking(marking.MarkingId, markingColors, marking.GlowyBits)); // Omu
         }
 
         markings.EnsureSpecies(profile.Species, profile.Appearance.SkinColor, _markingManager, _prototypeManager);
@@ -281,7 +283,7 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
             {
                 if (_markingManager.TryGetMarking(marking, out var markingPrototype))
                 {
-                    ApplyMarking(markingPrototype, marking.MarkingColors, marking.Visible, entity);
+                    ApplyMarking(markingPrototype, marking.MarkingColors, marking.GlowyBits, marking.Visible, entity); // Omu
                 }
             }
         }
@@ -340,6 +342,7 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
     }
     private void ApplyMarking(MarkingPrototype markingPrototype,
         IReadOnlyList<Color>? colors,
+        uint glowyBits, // Omu
         bool visible,
         Entity<HumanoidAppearanceComponent, SpriteComponent> entity)
     {
@@ -414,6 +417,13 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
 
             if (humanoid.MarkingsDisplacement.TryGetValue(markingPrototype.BodyPart, out var displacementData) && markingPrototype.CanBeDisplaced)
                 _displacement.TryAddDisplacement(displacementData, (entity.Owner, sprite), targetLayer + j + 1, layerId, out _);
+
+            // Omu begin
+            // Gets the current glowy bit from the loop
+            var isGlowy = (glowyBits & (1u << j)) != 0;
+            if (isGlowy)
+                sprite.LayerSetShader(layerId, "unshaded");
+            // Omu end
         }
     }
 
@@ -468,7 +478,7 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
             foreach (var marking in markingList)
             {
                 if (_markingManager.TryGetMarking(marking, out var markingPrototype) && markingPrototype.BodyPart == layer)
-                    ApplyMarking(markingPrototype, marking.MarkingColors, marking.Visible, (ent, ent.Comp, sprite));
+                    ApplyMarking(markingPrototype, marking.MarkingColors, marking.GlowyBits, marking.Visible, (ent, ent.Comp, sprite)); // Omu
             }
         }
     }

--- a/Content.Client/Humanoid/MarkingPicker.xaml.cs
+++ b/Content.Client/Humanoid/MarkingPicker.xaml.cs
@@ -453,6 +453,34 @@ public sealed partial class MarkingPicker : Control
                 ColorChanged(colorIndex);
             };
             colorSelector.OnColorChanged += colorChanged;
+
+            // Omu begin
+            var glowyToggle = new CheckBox
+            {
+                Text = Loc.GetString("ui-marking-glowing"),
+                Pressed = listing[listing.Count - 1 - item.ItemIndex].GetGlowingIndex(i),
+            };
+
+            glowyToggle.OnToggled += o =>
+            {
+                if (_selectedMarking is null)
+                    return;
+
+                var markingPrototype = (MarkingPrototype) _selectedMarking.Metadata!;
+                var markingIndex = _currentMarkings.FindIndexOf(_selectedMarkingCategory, markingPrototype.ID);
+
+                if (markingIndex < 0)
+                    return;
+
+                var marking = new Marking(_currentMarkings.Markings[_selectedMarkingCategory][markingIndex]);
+                marking.SetGlowing(colorIndex, o.Pressed);
+                _currentMarkings.Replace(_selectedMarkingCategory, markingIndex, marking);
+
+                OnMarkingColorChange?.Invoke(_currentMarkings);
+            };
+
+            CMarkingColors.AddChild(glowyToggle);
+            // Omu end
         }
 
         CMarkingColors.Visible = true;

--- a/Content.Client/Humanoid/SingleMarkingPicker.xaml.cs
+++ b/Content.Client/Humanoid/SingleMarkingPicker.xaml.cs
@@ -48,6 +48,14 @@ public sealed partial class SingleMarkingPicker : BoxContainer
     /// </summary>
     public Action<(int slot, Marking marking)>? OnColorChanged;
 
+    // Omu begin
+    /// <summary>
+    /// What happens if a marking's glowing state is changed.
+    /// Sends a 'slot' number, and the marking in question.
+    /// </summary>
+    public Action<(int slot, Marking marking)>? OnGlowingChanged;
+    // Omu end
+
     // current selected slot
     private int _slot = -1;
     private int Slot
@@ -250,6 +258,29 @@ public sealed partial class SingleMarkingPicker : BoxContainer
             };
 
             ColorSelectorContainer.AddChild(selector);
+
+            // Omu begin
+            var glowyToggle = new CheckBox
+            {
+                Text = Loc.GetString("ui-marking-glowing"),
+                Pressed = marking.GetGlowingIndex(colorIndex),
+            };
+
+            glowyToggle.OnToggled += o =>
+            {
+                if (_markings == null ||
+                    _markings.Count == 0 ||
+                    !_markingManager.TryGetMarking(_markings[Slot], out _))
+                {
+                    return;
+                }
+
+                marking.SetGlowing(colorIndex, o.Pressed);
+                OnGlowingChanged?.Invoke((_slot, marking));
+            };
+
+            ColorSelectorContainer.AddChild(glowyToggle);
+            // Omu end
         }
     }
 

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -1913,11 +1913,11 @@ namespace Content.Client.Lobby.UI
             }
             var hairMarking = Profile.Appearance.HairStyleId == HairStyles.DefaultHairStyle
                 ? new List<Marking>()
-                : new() { new(Profile.Appearance.HairStyleId, new List<Color>() { Profile.Appearance.HairColor }) };
+                : new() { new(Profile.Appearance.HairStyleId, new List<Color>() { Profile.Appearance.HairColor }, false) }; // Omu
 
             var facialHairMarking = Profile.Appearance.FacialHairStyleId == HairStyles.DefaultFacialHairStyle
                 ? new List<Marking>()
-                : new() { new(Profile.Appearance.FacialHairStyleId, new List<Color>() { Profile.Appearance.FacialHairColor }) };
+                : new() { new(Profile.Appearance.FacialHairStyleId, new List<Color>() { Profile.Appearance.FacialHairColor }, false) }; // Omu
 
             HairStylePicker.UpdateData(
                 hairMarking,
@@ -1956,7 +1956,7 @@ namespace Content.Client.Lobby.UI
             }
             if (hairColor != null)
             {
-                Markings.HairMarking = new(Profile.Appearance.HairStyleId, new List<Color>() { hairColor.Value });
+                Markings.HairMarking = new(Profile.Appearance.HairStyleId, new List<Color>() { hairColor.Value }, false); // Omu
             }
             else
             {
@@ -1990,7 +1990,7 @@ namespace Content.Client.Lobby.UI
             }
             if (facialHairColor != null)
             {
-                Markings.FacialHairMarking = new(Profile.Appearance.FacialHairStyleId, new List<Color>() { facialHairColor.Value });
+                Markings.FacialHairMarking = new(Profile.Appearance.FacialHairStyleId, new List<Color>() { facialHairColor.Value }, false); // Omu
             }
             else
             {

--- a/Content.Client/_Shitcode/Wizard/MagicMirror/WizardMirrorWindow.xaml.cs
+++ b/Content.Client/_Shitcode/Wizard/MagicMirror/WizardMirrorWindow.xaml.cs
@@ -609,7 +609,7 @@ public sealed partial class WizardMirrorWindow : DefaultWindow
         var hairMarking = Profile.Appearance.HairStyleId switch
         {
             "HairBald" => new List<Marking>(),
-            _ => new() { new(Profile.Appearance.HairStyleId, new List<Color>() { Profile.Appearance.HairColor }) },
+            _ => new() { new(Profile.Appearance.HairStyleId, new List<Color>() { Profile.Appearance.HairColor }, false) }, // Omu
         };
 
         var facialHairMarking = Profile.Appearance.FacialHairStyleId switch
@@ -617,7 +617,7 @@ public sealed partial class WizardMirrorWindow : DefaultWindow
             "FacialHairShaved" => new List<Marking>(),
             _ => new()
             {
-                new(Profile.Appearance.FacialHairStyleId, new List<Color>() { Profile.Appearance.FacialHairColor })
+                new(Profile.Appearance.FacialHairStyleId, new List<Color>() { Profile.Appearance.FacialHairColor }, false) // Omu
             },
         };
 
@@ -657,7 +657,7 @@ public sealed partial class WizardMirrorWindow : DefaultWindow
 
         if (hairColor != null)
         {
-            Markings.HairMarking = new(Profile.Appearance.HairStyleId, new List<Color>() { hairColor.Value });
+            Markings.HairMarking = new(Profile.Appearance.HairStyleId, new List<Color>() { hairColor.Value }, false); // Omu
         }
         else
         {
@@ -691,7 +691,7 @@ public sealed partial class WizardMirrorWindow : DefaultWindow
         if (facialHairColor != null)
         {
             Markings.FacialHairMarking = new(Profile.Appearance.FacialHairStyleId,
-                new List<Color>() { facialHairColor.Value });
+                new List<Color>() { facialHairColor.Value }, false); // Omu
         }
         else
         {

--- a/Content.Goobstation.Server/Shadowling/Systems/Abilities/CollectiveMind/ShadowlingBlackRecuperationSystem.cs
+++ b/Content.Goobstation.Server/Shadowling/Systems/Abilities/CollectiveMind/ShadowlingBlackRecuperationSystem.cs
@@ -140,7 +140,7 @@ public sealed class ShadowlingBlackRecuperationSystem : EntitySystem
             EntityManager.AddComponents(newUid.Value, comps);
 
             if (TryComp<HumanoidAppearanceComponent>(newUid.Value, out var human))
-                _humanoidAppearance.AddMarking(newUid.Value, component.MarkingId, Color.Red, true, true, human);
+                _humanoidAppearance.AddMarking(newUid.Value, component.MarkingId, Color.Red, false, true, true, human); // Omu
 
             Spawn(component.BlackRecuperationEffect, Transform(newUid.Value).Coordinates);
 

--- a/Content.Server/_Shitcode/Wizard/Systems/WizardMirrorSystem.cs
+++ b/Content.Server/_Shitcode/Wizard/Systems/WizardMirrorSystem.cs
@@ -136,7 +136,7 @@ public sealed class WizardMirrorSystem : SharedWizardMirrorSystem
 
             if (!prototype.ForcedColoring)
             {
-                _humanoid.AddMarking(target, marking.MarkingId, marking.MarkingColors, false);
+                _humanoid.AddMarking(target, marking.MarkingId, marking.MarkingColors, marking.GlowyBits, false); // Omu
             }
             else
             {
@@ -169,7 +169,7 @@ public sealed class WizardMirrorSystem : SharedWizardMirrorSystem
                 profile.Appearance.EyeColor,
                 humanoid.MarkingSet
             );
-            _humanoid.AddMarking(target, marking.MarkingId, markingColors, false);
+            _humanoid.AddMarking(target, marking.MarkingId, markingColors, marking.GlowyBits, false); // Omu
         }
 
         humanoid.MarkingSet.EnsureSpecies(profile.Species, profile.Appearance.SkinColor, _markingManager, _proto);

--- a/Content.Shared/Humanoid/Markings/Marking.cs
+++ b/Content.Shared/Humanoid/Markings/Marking.cs
@@ -23,20 +23,51 @@ namespace Content.Shared.Humanoid.Markings
         [DataField("markingColor")]
         private List<Color> _markingColors = new();
 
+        // Omu begin
+        /// <summary>
+        /// A bitwise index of which markingColors are glowing.
+        /// </summary>
+        [DataField]
+        public uint GlowyBits { get; private set; }
+        // Omu end
+
         private Marking()
         {
         }
 
+        // Omu begin
         public Marking(string markingId,
-            List<Color> markingColors)
+            List<Color> markingColors,
+            bool glowy) // Omu
         {
             MarkingId = markingId;
             _markingColors = markingColors;
+            SetGlowing(glowy);
         }
+        // Omu end
 
         public Marking(string markingId,
-            IReadOnlyList<Color> markingColors)
-            : this(markingId, new List<Color>(markingColors))
+            List<Color> markingColors,
+            uint glowyBits) // Omu
+        {
+            MarkingId = markingId;
+            _markingColors = markingColors;
+            GlowyBits = glowyBits; // Omu
+        }
+
+        // Omu begin
+        public Marking(string markingId,
+            IReadOnlyList<Color> markingColors,
+            bool isGlowy)
+            : this(markingId, new List<Color>(markingColors), isGlowy)
+        {
+        }
+        // Omu end
+
+        public Marking(string markingId,
+            IReadOnlyList<Color> markingColors,
+            uint glowyBits)
+            : this(markingId, new List<Color>(markingColors), glowyBits) // Omu
         {
         }
 
@@ -55,6 +86,7 @@ namespace Content.Shared.Humanoid.Markings
             _markingColors = new(other.MarkingColors);
             Visible = other.Visible;
             Forced = other.Forced;
+            GlowyBits = other.GlowyBits; // Omu
         }
 
         /// <summary>
@@ -92,6 +124,40 @@ namespace Content.Shared.Humanoid.Markings
             }
         }
 
+        // Omu begin
+        /// <summary>
+        /// Sets the whole bit representation to 1 or 0, meaning either all colors in the marking are glowing or not glowing.
+        /// </summary>
+        /// <param name="isGlowing">If it should glow or not.</param>
+        public void SetGlowing(bool isGlowing)
+        {
+            GlowyBits = isGlowing ? uint.MaxValue : 0;
+        }
+
+        /// <summary>
+        /// Sets the glowing state of a specific color index in the marking.
+        /// </summary>
+        /// <param name="colorIndex">The color index of the marking to set the glowing state of.</param>
+        /// <param name="isGlowing">If it should glow or not.</param>
+        public void SetGlowing(int colorIndex, bool isGlowing)
+        {
+            if (isGlowing)
+                GlowyBits |= (uint) (1 << colorIndex);
+            else
+                GlowyBits &= (uint) ~(1 << colorIndex);
+        }
+
+        /// <summary>
+        /// Gets the glowing state of a specific color index in the marking.
+        /// </summary>
+        /// <param name="colorIndex">The color index of the marking to get the glowing state of.</param>
+        /// <returns>If it should glow or not.</returns>
+        public bool GetGlowingIndex(int colorIndex)
+        {
+            return (GlowyBits & (uint) (1 << colorIndex)) != 0;
+        }
+        // Omu End
+
         public int CompareTo(Marking? marking)
         {
             if (marking == null)
@@ -119,7 +185,8 @@ namespace Content.Shared.Humanoid.Markings
             return MarkingId.Equals(other.MarkingId)
                 && _markingColors.SequenceEqual(other._markingColors)
                 && Visible.Equals(other.Visible)
-                && Forced.Equals(other.Forced);
+                && Forced.Equals(other.Forced)
+                && GlowyBits.Equals(other.GlowyBits); // Omu
         }
 
         // VERY BIG TODO: TURN THIS INTO JSONSERIALIZER IMPLEMENTATION
@@ -141,19 +208,34 @@ namespace Content.Shared.Humanoid.Markings
             foreach (Color color in _markingColors)
                 colorStringList.Add(color.ToHex());
 
-            return $"{sanitizedName}@{String.Join(',', colorStringList)}";
+            return $"{sanitizedName}@{string.Join(',', colorStringList)}@{GlowyBits}"; // Omu
         }
 
         public static Marking? ParseFromDbString(string input)
         {
             if (input.Length == 0) return null;
             var split = input.Split('@');
-            if (split.Length != 2) return null;
-            List<Color> colorList = new();
-            foreach (string color in split[1].Split(','))
-                colorList.Add(Color.FromHex(color));
 
-            return new Marking(split[0], colorList);
+            // Omu begin
+            if (split.Length == 2)
+            {
+                List<Color> colorList = new();
+                foreach (string color in split[1].Split(','))
+                    colorList.Add(Color.FromHex(color));
+
+                return new Marking(split[0], colorList, 0); // Omu
+            }
+
+            if (split.Length == 3)
+            {
+                var colorList = split[1].Split(',').Select(color => Color.FromHex(color)).ToList();
+                var isGlowing = uint.Parse(split[2]);
+
+                return new Marking(split[0], colorList, isGlowing);
+            }
+
+            return null;
+            // Omu End
         }
     }
 }

--- a/Content.Shared/Humanoid/Markings/MarkingsSet.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingsSet.cs
@@ -309,7 +309,7 @@ public sealed partial class MarkingSet
                             eyeColor,
                             this
                         );
-                    var marking = new Marking(points.DefaultMarkings[index], colors);
+                    var marking = new Marking(points.DefaultMarkings[index], colors, false); // Omu
 
                     AddBack(category, marking);
                 }

--- a/Content.Shared/Humanoid/SharedHumanoidAppearanceSystem.cs
+++ b/Content.Shared/Humanoid/SharedHumanoidAppearanceSystem.cs
@@ -524,7 +524,7 @@ public abstract class SharedHumanoidAppearanceSystem : EntitySystem
             {
                 if (!prototype.ForcedColoring)
                 {
-                    AddMarking(uid, marking.MarkingId, marking.MarkingColors, false);
+                    AddMarking(uid, marking.MarkingId, marking.MarkingColors, marking.GlowyBits, false); // Omu
                 }
                 else
                 {
@@ -563,7 +563,7 @@ public abstract class SharedHumanoidAppearanceSystem : EntitySystem
                 profile.Appearance.EyeColor,
                 humanoid.MarkingSet
             );
-            AddMarking(uid, marking.MarkingId, markingColors, false);
+            AddMarking(uid, marking.MarkingId, markingColors, marking.GlowyBits, false); // Omu
         }
 
         EnsureDefaultMarkings(uid, humanoid);
@@ -598,10 +598,11 @@ public abstract class SharedHumanoidAppearanceSystem : EntitySystem
     /// <param name="uid">Humanoid mob's UID</param>
     /// <param name="marking">Marking ID to use</param>
     /// <param name="color">Color to apply to all marking layers of this marking</param>
+    /// <param name="isGlowing">If the markings color should glow</param>
     /// <param name="sync">Whether to immediately sync this marking or not</param>
     /// <param name="forced">If this marking was forced (ignores marking points)</param>
     /// <param name="humanoid">Humanoid component of the entity</param>
-    public void AddMarking(EntityUid uid, string marking, Color? color = null, bool sync = true, bool forced = false, HumanoidAppearanceComponent? humanoid = null)
+    public void AddMarking(EntityUid uid, string marking, Color? color = null, bool isGlowing = false, bool sync = true, bool forced = false, HumanoidAppearanceComponent? humanoid = null) // Omu
     {
         if (!Resolve(uid, ref humanoid)
             || !_markingManager.Markings.TryGetValue(marking, out var prototype))
@@ -618,6 +619,8 @@ public abstract class SharedHumanoidAppearanceSystem : EntitySystem
                 markingObject.SetColor(i, color.Value);
             }
         }
+
+        markingObject.SetGlowing(isGlowing); // Omu
 
         humanoid.MarkingSet.AddBack(prototype.MarkingCategory, markingObject);
 
@@ -640,10 +643,11 @@ public abstract class SharedHumanoidAppearanceSystem : EntitySystem
     /// <param name="uid">Humanoid mob's UID</param>
     /// <param name="marking">Marking ID to use</param>
     /// <param name="colors">Colors to apply against this marking's set of sprites.</param>
+    /// <param name="glowyBits">A bitwise representation of which colors in the marking are glowing.</param>
     /// <param name="sync">Whether to immediately sync this marking or not</param>
     /// <param name="forced">If this marking was forced (ignores marking points)</param>
     /// <param name="humanoid">Humanoid component of the entity</param>
-    public void AddMarking(EntityUid uid, string marking, IReadOnlyList<Color> colors, bool sync = true, bool forced = false, HumanoidAppearanceComponent? humanoid = null)
+    public void AddMarking(EntityUid uid, string marking, IReadOnlyList<Color> colors, uint glowyBits = 0, bool sync = true, bool forced = false, HumanoidAppearanceComponent? humanoid = null) // Omu
     {
         if (!Resolve(uid, ref humanoid)
             || !_markingManager.Markings.TryGetValue(marking, out var prototype))
@@ -651,7 +655,7 @@ public abstract class SharedHumanoidAppearanceSystem : EntitySystem
             return;
         }
 
-        var markingObject = new Marking(marking, colors);
+        var markingObject = new Marking(marking, colors, glowyBits); // Omu
         markingObject.Forced = forced;
         humanoid.MarkingSet.AddBack(prototype.MarkingCategory, markingObject);
 

--- a/Content.Shared/_Shitmed/Body/Systems/SharedBodySystem.PartAppearance.cs
+++ b/Content.Shared/_Shitmed/Body/Systems/SharedBodySystem.PartAppearance.cs
@@ -83,7 +83,7 @@ public partial class SharedBodySystem
         {
             var category = MarkingCategoriesConversion.FromHumanoidVisualLayers(layer);
             if (bodyAppearance.MarkingSet.Markings.TryGetValue(category, out var markingList))
-                markingsByLayer[layer] = markingList.Select(m => new Marking(m.MarkingId, m.MarkingColors.ToList())).ToList();
+                markingsByLayer[layer] = markingList.Select(m => new Marking(m.MarkingId, m.MarkingColors.ToList(), m.GlowyBits)).ToList(); // Omu
         }
 
         component.Markings = markingsByLayer;
@@ -124,10 +124,10 @@ public partial class SharedBodySystem
                     bodyAppearance.MarkingSet
                 );
 
-            var marking = new Marking(markingId, markingColors);
+            var marking = new Marking(markingId, markingColors, 0); // Omu
 
             _humanoid.SetLayerVisibility((uid, bodyAppearance), targetLayer, true);
-            _humanoid.AddMarking(uid, markingId, markingColors, true, true, bodyAppearance);
+            _humanoid.AddMarking(uid, markingId, markingColors, 0, true, true, bodyAppearance); // Omu
             if (!partAppearance.Comp.Markings.ContainsKey(targetLayer))
                 partAppearance.Comp.Markings[targetLayer] = new List<Marking>();
 
@@ -197,7 +197,7 @@ public partial class SharedBodySystem
             _humanoid.SetLayerVisibility((target, bodyAppearance), visualLayer, true);
             foreach (var marking in markingList)
             {
-                _humanoid.AddMarking(target, marking.MarkingId, marking.MarkingColors, true, true, bodyAppearance);
+                _humanoid.AddMarking(target, marking.MarkingId, marking.MarkingColors, marking.GlowyBits, true, true, bodyAppearance); // Omu
             }
         }
 

--- a/Resources/Locale/en-US/_Omu/ui/charactereditor.ftl
+++ b/Resources/Locale/en-US/_Omu/ui/charactereditor.ftl
@@ -1,0 +1,1 @@
+ui-marking-glowing = Glowing


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Added a "glowing" checkbox to every color in the marking system.

All characters **must** glow.


This is a partial modified port of https://github.com/ss14Starlight/space-station-14/pull/641

I decided against porting the eye/hair/facial hair changes right now as those require a database change and I wanted to port the simpler thing first.

## Why / Balance
Currently only specific markings were allowed to glow, which kind of sucks and doesn't make a lot sense why *this one* tattoo could glow, but the other one could not.

## Technical details
I added a `glowyBits` bit field to the marking system. This is a bit field which indiciates which color index of a marking is either glowing or not.

I decided to use a bit field as it is similar to the `bool` variable of the starlight system and a lot simpler to handle than a `List<bool>`.

Then I upgraded all references in the humanoid appearance system, wizard system, and changeling system.

And then I added checkboxes to the single marking picker and marking picker to support that change.

## Media

<img width="588" height="569" alt="image" src="https://github.com/user-attachments/assets/2c608ed8-5cbf-44bb-b422-ac1f1308e26b" />

<img width="1032" height="708" alt="image" src="https://github.com/user-attachments/assets/ca941916-73a4-49f9-bdf3-8fefe5cb3d31" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] I have read and agree to the Contributor License Agreement.
<!-- See CLA.md for the CLA -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Quill
- add: Added per color glowing toggles to markings.
