### PR TITLE
Prevent Oni from using any guns

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_wieldable.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_wieldable.yml
@@ -18,13 +18,13 @@
   - type: GunWieldBonus
     minAngle: -20
     maxAngle: -30
-  - type: RestrictGunshotsByUserTag # Goobstation
-    doesntContain:
-    - Oni
-    messages:
-    - oni-cannot-shoot-guns-1
-    - oni-cannot-shoot-guns-2
-    - oni-cannot-shoot-guns-3
+  #- type: RestrictGunshotsByUserTag # Goobstation # Omu, move this to the oni species proto instead.
+  #  doesntContain:
+  #  - Oni
+  #  messages:
+  #  - oni-cannot-shoot-guns-1
+  #  - oni-cannot-shoot-guns-2
+  #  - oni-cannot-shoot-guns-3
   - type: Gun
     minAngle: 21
     maxAngle: 32

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -331,13 +331,13 @@
       shader: unshaded
   - type: Item
     sprite: Objects/Weapons/Guns/Battery/svalinn.rsi
-  - type: RestrictGunshotsByUserTag # Goobstation
-    doesntContain:
-    - Oni
-    messages:
-    - oni-cannot-shoot-guns-1
-    - oni-cannot-shoot-guns-2
-    - oni-cannot-shoot-guns-3
+  #- type: RestrictGunshotsByUserTag # Goobstation # Omu, move this to the oni species proto instead.
+  #  doesntContain:
+  #  - Oni
+  #  messages:
+  #  - oni-cannot-shoot-guns-1
+  #  - oni-cannot-shoot-guns-2
+  #  - oni-cannot-shoot-guns-3
   - type: MagazineVisuals
     magState: mag
     steps: 5
@@ -373,13 +373,13 @@
     - state: mag-unshaded-4
       map: ["enum.GunVisualLayers.MagUnshaded"]
       shader: unshaded
-  - type: RestrictGunshotsByUserTag # Goobstation
-    doesntContain:
-    - Oni
-    messages:
-    - oni-cannot-shoot-guns-1
-    - oni-cannot-shoot-guns-2
-    - oni-cannot-shoot-guns-3
+  #- type: RestrictGunshotsByUserTag # Goobstation # Omu, move this to the oni species proto instead.
+  #  doesntContain:
+  #  - Oni
+  #  messages:
+  #  - oni-cannot-shoot-guns-1
+  #  - oni-cannot-shoot-guns-2
+  #  - oni-cannot-shoot-guns-3
   - type: HitscanBatteryAmmoProvider
     proto: RedMediumLaser
     fireCost: 62.5
@@ -403,13 +403,13 @@
     - state: mag-unshaded-4
       map: ["enum.GunVisualLayers.MagUnshaded"]
       shader: unshaded
-  - type: RestrictGunshotsByUserTag # Goobstation
-    doesntContain:
-    - Oni
-    messages:
-    - oni-cannot-shoot-guns-1
-    - oni-cannot-shoot-guns-2
-    - oni-cannot-shoot-guns-3
+  #- type: RestrictGunshotsByUserTag # Goobstation # Omu, move this to the oni species proto instead.
+  #  doesntContain:
+  #  - Oni
+  #  messages:
+  #  - oni-cannot-shoot-guns-1
+  #  - oni-cannot-shoot-guns-2
+  #  - oni-cannot-shoot-guns-3
   - type: MagazineVisuals
     magState: mag
     steps: 5
@@ -775,13 +775,13 @@
     steps: 5
     zeroVisible: true
   - type: Appearance
-  - type: RestrictGunshotsByUserTag # Goobstation
-    doesntContain:
-    - Oni
-    messages:
-    - oni-cannot-shoot-guns-1
-    - oni-cannot-shoot-guns-2
-    - oni-cannot-shoot-guns-3
+  #- type: RestrictGunshotsByUserTag # Goobstation # Omu, move this to the oni species proto instead.
+  #  doesntContain:
+  #  - Oni
+  #  messages:
+  #  - oni-cannot-shoot-guns-1
+  #  - oni-cannot-shoot-guns-2
+  #  - oni-cannot-shoot-guns-3
   # Goobstation
   - type: Tag
     tags:
@@ -1037,13 +1037,13 @@
   - type: BatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 30
-  - type: RestrictGunshotsByUserTag # Goobstation
-    doesntContain:
-    - Oni
-    messages:
-    - oni-cannot-shoot-guns-1
-    - oni-cannot-shoot-guns-2
-    - oni-cannot-shoot-guns-3
+  #- type: RestrictGunshotsByUserTag # Goobstation # Omu, move this to the oni species proto instead.
+  #  doesntContain:
+  #  - Oni
+  #  messages:
+  #  - oni-cannot-shoot-guns-1
+  #  - oni-cannot-shoot-guns-2
+  #  - oni-cannot-shoot-guns-3
   - type: MagazineVisuals
     magState: mag
     steps: 5

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -117,13 +117,13 @@
     delay: 1
   - type: Multishot # Goobstation V
     missChance: 0.4 #MISS CHANCE DOESNT WORK LMAO
-  - type: RestrictGunshotsByUserTag # Goobstation
-    doesntContain:
-    - Oni
-    messages:
-    - oni-cannot-shoot-guns-1
-    - oni-cannot-shoot-guns-2
-    - oni-cannot-shoot-guns-3
+  #- type: RestrictGunshotsByUserTag # Goobstation # Omu, move this to the oni species proto instead.
+  #  doesntContain:
+  #  - Oni
+  #  messages:
+  #  - oni-cannot-shoot-guns-1
+  #  - oni-cannot-shoot-guns-2
+  #  - oni-cannot-shoot-guns-3
   # Goobstation edit start
   - type: EmitSoundOnPickup
     sound:
@@ -153,13 +153,13 @@
     magState: mag
     steps: 4
     zeroVisible: true
-  - type: RestrictGunshotsByUserTag # Goobstation
-    doesntContain:
-    - Oni
-    messages:
-    - oni-cannot-shoot-guns-1
-    - oni-cannot-shoot-guns-2
-    - oni-cannot-shoot-guns-3
+  #- type: RestrictGunshotsByUserTag # Goobstation # Omu, move this to the oni species proto instead.
+  #  doesntContain:
+  #  - Oni
+  #  messages:
+  #  - oni-cannot-shoot-guns-1
+  #  - oni-cannot-shoot-guns-2
+  #  - oni-cannot-shoot-guns-3
   - type: Appearance
   - type: StaticPrice
     price: 10000
@@ -201,13 +201,13 @@
     - type: Battery
       maxCharge: 10000
       startingCharge: 10000
-    - type: RestrictGunshotsByUserTag # Goobstation
-      doesntContain:
-      - Oni
-      messages:
-      - oni-cannot-shoot-guns-1
-      - oni-cannot-shoot-guns-2
-      - oni-cannot-shoot-guns-3
+    #- type: RestrictGunshotsByUserTag # Goobstation # Omu, move this to the oni species proto instead.
+    #  doesntContain:
+    #  - Oni
+    #  messages:
+    #  - oni-cannot-shoot-guns-1
+    #  - oni-cannot-shoot-guns-2
+    #  - oni-cannot-shoot-guns-3
     - type: BatterySelfRecharger
       autoRecharge: true
       autoRechargeRate: 25

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -173,13 +173,13 @@
     missChance: 0.4
     spreadMultiplier: 2
     spreadAddition: 40
-  - type: RestrictGunshotsByUserTag # Goobstation
-    doesntContain:
-    - Oni
-    messages:
-    - oni-cannot-shoot-guns-1
-    - oni-cannot-shoot-guns-2
-    - oni-cannot-shoot-guns-3
+  #- type: RestrictGunshotsByUserTag # Goobstation # Omu, move this to the oni species proto instead.
+  #  doesntContain:
+  #  - Oni
+  #  messages:
+  #  - oni-cannot-shoot-guns-1
+  #  - oni-cannot-shoot-guns-2
+  #  - oni-cannot-shoot-guns-3
   - type: EmitSoundOnPickup
     sound:
       collection: PistolsPickUp

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -121,13 +121,13 @@
   - type: EmitSoundOnDrop
     sound:
       collection: RevolversDrop
-  - type: RestrictGunshotsByUserTag # Goobstation
-    doesntContain:
-    - Oni
-    messages:
-    - oni-cannot-shoot-guns-1
-    - oni-cannot-shoot-guns-2
-    - oni-cannot-shoot-guns-3
+  #- type: RestrictGunshotsByUserTag # Goobstation # Omu, move this to the oni species proto instead.
+  #  doesntContain:
+  #  - Oni
+  #  messages:
+  #  - oni-cannot-shoot-guns-1
+  #  - oni-cannot-shoot-guns-2
+  #  - oni-cannot-shoot-guns-3
   - type: EmitSoundOnLand
     sound:
       collection: RevolversDrop

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -155,13 +155,13 @@
   - type: EmitSoundOnPickup
     sound:
       collection: RiflesPickUp
-  - type: RestrictGunshotsByUserTag # Goobstation
-    doesntContain:
-    - Oni
-    messages:
-    - oni-cannot-shoot-guns-1
-    - oni-cannot-shoot-guns-2
-    - oni-cannot-shoot-guns-3
+  #- type: RestrictGunshotsByUserTag # Goobstation # Omu, move this to the oni species proto instead.
+  #  doesntContain:
+  #  - Oni
+  #  messages:
+  #  - oni-cannot-shoot-guns-1
+  #  - oni-cannot-shoot-guns-2
+  #  - oni-cannot-shoot-guns-3
   - type: EmitSoundOnDrop
     sound:
       collection: RiflesDrop

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -132,13 +132,13 @@
   - type: EmitSoundOnLand
     sound:
       collection: SMGDrop
-  - type: RestrictGunshotsByUserTag # Goobstation
-    doesntContain:
-    - Oni
-    messages:
-    - oni-cannot-shoot-guns-1
-    - oni-cannot-shoot-guns-2
-    - oni-cannot-shoot-guns-3
+  #- type: RestrictGunshotsByUserTag # Goobstation # Omu, move this to the oni species proto instead.
+  #  doesntContain:
+  #  - Oni
+  #  messages:
+  #  - oni-cannot-shoot-guns-1
+  #  - oni-cannot-shoot-guns-2
+  #  - oni-cannot-shoot-guns-3
   # Goobstation edit end
   - type: Multishot # Goobstation V
     missChance: 0.4

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -127,13 +127,13 @@
   - type: EmitSoundOnLand
     sound:
       collection: ShotgunsDrop
-  - type: RestrictGunshotsByUserTag
-    doesntContain:
-    - Oni
-    messages:
-    - oni-cannot-shoot-guns-1
-    - oni-cannot-shoot-guns-2
-    - oni-cannot-shoot-guns-3
+  #- type: RestrictGunshotsByUserTag # Omu, move this to the oni species proto instead.
+  #  doesntContain:
+  #  - Oni
+  #  messages:
+  #  - oni-cannot-shoot-guns-1
+  #  - oni-cannot-shoot-guns-2
+  #  - oni-cannot-shoot-guns-3
   # Goobstation edit end
   - type: AltFireMelee # Goobstation V
     attackType: Heavy
@@ -203,13 +203,13 @@
   - type: Appearance
   - type: StaticPrice
     price: 5000
-  - type: RestrictGunshotsByUserTag # Goobstation
-    doesntContain:
-    - Oni
-    messages:
-    - oni-cannot-shoot-guns-1
-    - oni-cannot-shoot-guns-2
-    - oni-cannot-shoot-guns-3
+  #- type: RestrictGunshotsByUserTag # Goobstation # Omu, move this to the oni species proto instead.
+  #  doesntContain:
+  #  - Oni
+  #  messages:
+  #  - oni-cannot-shoot-guns-1
+  #  - oni-cannot-shoot-guns-2
+  #  - oni-cannot-shoot-guns-3
 
 - type: entity
   name: double-barreled shotgun

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/flare_gun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/flare_gun.yml
@@ -84,13 +84,13 @@
       path: /Audio/_Goobstation/Items/handling/gun_drop.ogg
       params:
         volume: -8
-  - type: RestrictGunshotsByUserTag
-    doesntContain:
-    - Oni
-    messages:
-    - oni-cannot-shoot-guns-1
-    - oni-cannot-shoot-guns-2
-    - oni-cannot-shoot-guns-3
+  #- type: RestrictGunshotsByUserTag # Omu, move this to the oni species proto instead.
+  #  doesntContain:
+  #  - Oni
+  #  messages:
+  #  - oni-cannot-shoot-guns-1
+  #  - oni-cannot-shoot-guns-2
+  #  - oni-cannot-shoot-guns-3
   # Goobstation edit end
 
 - type: entity

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/Oni.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/Oni.yml
@@ -69,6 +69,13 @@
         - MobMask
         layer:
         - MobLayer
+  - type: RestrictGunshotsByUserTag # Omu
+    doesntContain:
+    - Oni
+    messages:
+    - oni-cannot-shoot-guns-1
+    - oni-cannot-shoot-guns-2
+    - oni-cannot-shoot-guns-3
 
   - type: Stamina
     critThreshold: 115

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Magazines/smartgun.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Magazines/smartgun.yml
@@ -46,13 +46,13 @@
       map: ["enum.GunVisualLayers.Base"]
     - state: mag-1
       map: ["enum.GunVisualLayers.Mag"]
-  - type: RestrictGunshotsByUserTag # Goobstation
-    doesntContain:
-    - Oni
-    messages:
-    - oni-cannot-shoot-guns-1
-    - oni-cannot-shoot-guns-2
-    - oni-cannot-shoot-guns-3
+  #- type: RestrictGunshotsByUserTag # Goobstation # Omu, move this to the oni species proto instead.
+  #  doesntContain:
+  #  - Oni
+  #  messages:
+  #  - oni-cannot-shoot-guns-1
+  #  - oni-cannot-shoot-guns-2
+  #  - oni-cannot-shoot-guns-3
   - type: MagazineVisuals
     magState: mag
     steps: 2

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -74,13 +74,13 @@
     wideAnimationRotation: 90 # -90 if it takes bayonets (hits with muzzle) 90 if not (hits with butt)
     soundHit:
       collection: MetalThud # Goobstation ^
-  - type: RestrictGunshotsByUserTag # Goobstation
-    doesntContain:
-    - Oni
-    messages:
-    - oni-cannot-shoot-guns-1
-    - oni-cannot-shoot-guns-2
-    - oni-cannot-shoot-guns-3
+  #- type: RestrictGunshotsByUserTag # Goobstation # Omu, move this to the oni species proto instead.
+  #  doesntContain:
+  #  - Oni
+  #  messages:
+  #  - oni-cannot-shoot-guns-1
+  #  - oni-cannot-shoot-guns-2
+  #  - oni-cannot-shoot-guns-3
   - type: BatteryDrinkerSource # Goobstation - Energycrit
     maxAmount: 180
   - type: Multishot # Goobstation V
@@ -237,13 +237,13 @@
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
     soundEmpty:
       path: /Audio/_DV/Weapons/Guns/Empty/dry_fire.ogg
-  - type: RestrictGunshotsByUserTag # Goobstation
-    doesntContain:
-    - Oni
-    messages:
-    - oni-cannot-shoot-guns-1
-    - oni-cannot-shoot-guns-2
-    - oni-cannot-shoot-guns-3
+  #- type: RestrictGunshotsByUserTag # Goobstation # Omu, move this to the oni species proto instead.
+  #  doesntContain:
+  #  - Oni
+  #  messages:
+  #  - oni-cannot-shoot-guns-1
+  #  - oni-cannot-shoot-guns-2
+  #  - oni-cannot-shoot-guns-3
   - type: ItemSlots
     slots:
       gun_magazine:
@@ -367,13 +367,13 @@
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
     soundEmpty:
       path: /Audio/_DV/Weapons/Guns/Empty/dry_fire.ogg
-  - type: RestrictGunshotsByUserTag # Goobstation
-    doesntContain:
-    - Oni
-    messages:
-    - oni-cannot-shoot-guns-1
-    - oni-cannot-shoot-guns-2
-    - oni-cannot-shoot-guns-3
+  #- type: RestrictGunshotsByUserTag # Goobstation # Omu, move this to the oni species proto instead.
+  #  doesntContain:
+  #  - Oni
+  #  messages:
+  #  - oni-cannot-shoot-guns-1
+  #  - oni-cannot-shoot-guns-2
+  #  - oni-cannot-shoot-guns-3
   - type: ItemSlots
     slots:
       gun_magazine:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Pistols/pistol.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Pistols/pistol.yml
@@ -109,13 +109,13 @@
     rechargeCooldown: 4
     rechargeSound:
       path: /Audio/Weapons/Guns/Cock/shotgun_close.ogg
-  - type: RestrictGunshotsByUserTag # Goobstation
-    doesntContain:
-    - Oni
-    messages:
-    - oni-cannot-shoot-guns-1
-    - oni-cannot-shoot-guns-2
-    - oni-cannot-shoot-guns-3
+  #- type: RestrictGunshotsByUserTag # Goobstation # Omu, move this to the oni species proto instead.
+  #  doesntContain:
+  #  - Oni
+  #  messages:
+  #  - oni-cannot-shoot-guns-1
+  #  - oni-cannot-shoot-guns-2
+  #  - oni-cannot-shoot-guns-3
   - type: AmmoCounter
   - type: ContainerContainer
     containers:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/SMGs/smartgun.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/SMGs/smartgun.yml
@@ -93,10 +93,10 @@
   - type: EyeCursorOffset
     maxOffset: 1.5
     pvsIncrease: 0.15
-  - type: RestrictGunshotsByUserTag
-    doesntContain:
-    - Oni
-    messages:
-    - oni-cannot-shoot-guns-1
-    - oni-cannot-shoot-guns-2
-    - oni-cannot-shoot-guns-3
+  #- type: RestrictGunshotsByUserTag # Omu, move this to the oni species proto instead.
+  #  doesntContain:
+  #  - Oni
+  #  messages:
+  #  - oni-cannot-shoot-guns-1
+  #  - oni-cannot-shoot-guns-2
+  #  - oni-cannot-shoot-guns-3

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -60,10 +60,10 @@
     steps: 1
     zeroVisible: true
   - type: Appearance
-  - type: RestrictGunshotsByUserTag
-    doesntContain:
-    - Oni
-    messages:
-    - oni-cannot-shoot-guns-1
-    - oni-cannot-shoot-guns-2
-    - oni-cannot-shoot-guns-3
+  #- type: RestrictGunshotsByUserTag # Omu, move this to the oni species proto instead.
+  #  doesntContain:
+  #  - Oni
+  #  messages:
+  #  - oni-cannot-shoot-guns-1
+  #  - oni-cannot-shoot-guns-2
+  #  - oni-cannot-shoot-guns-3

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -67,13 +67,13 @@
       gun_magazine: !type:ContainerSlot
       gun_chamber: !type:ContainerSlot
   - type: ChamberMagazineAmmoProvider
-  - type: RestrictGunshotsByUserTag # Goobstation
-    doesntContain:
-    - Oni
-    messages:
-    - oni-cannot-shoot-guns-1
-    - oni-cannot-shoot-guns-2
-    - oni-cannot-shoot-guns-3
+  #- type: RestrictGunshotsByUserTag # Goobstatio # Omu, move this to the oni species proto instead.
+  #  doesntContain:
+  #  - Oni
+  #  messages:
+  #  - oni-cannot-shoot-guns-1
+  #  - oni-cannot-shoot-guns-2
+  #  - oni-cannot-shoot-guns-3
   - type: MagazineVisuals
     magState: mag
     steps: 1

--- a/Resources/Prototypes/_Omu/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Omu/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -31,13 +31,13 @@
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
     soundEmpty:
       path: /Audio/_DV/Weapons/Guns/Empty/dry_fire.ogg
-  - type: RestrictGunshotsByUserTag # Goobstation
-    doesntContain:
-    - Oni
-    messages:
-    - oni-cannot-shoot-guns-1
-    - oni-cannot-shoot-guns-2
-    - oni-cannot-shoot-guns-3
+  #- type: RestrictGunshotsByUserTag # Goobstation # Omu, move this to the oni species proto instead.
+  #  doesntContain:
+  #  - Oni
+  #  messages:
+  #  - oni-cannot-shoot-guns-1
+  #  - oni-cannot-shoot-guns-2
+  #  - oni-cannot-shoot-guns-3
   - type: ItemSlots
     slots:
       gun_magazine:


### PR DESCRIPTION
Fixes #980 

## About the PR
Makes it so oni are unable to use any guns (aka, remove them being able to use things like the lawbringer etc)

## Why / Balance
The melee species which has the thing of "can't use guns" shouldn't be using any guns.

## Technical details
Comments out RestrictGunshotsByUserTag from every gun that had it, and instead applies it direct to the oni species.

## Media
<img width="432" height="179" alt="image" src="https://github.com/user-attachments/assets/f31b6bc4-fe66-43ad-9b26-4cc9ed32abca" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have read and agree to the Contributor License Agreement.

**Changelog**
:cl:
- tweak: Oni are now unable to use any gun.