### PR TITLE
Added EG1 to corpsman loadout

### DIFF
--- a/Resources/Prototypes/_Omu/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Omu/Loadouts/loadout_groups.yml
@@ -418,6 +418,7 @@
   - SecurityOfficerGunCase
   - SecurityOfficerMk58
   - SecurityOfficerSecurityDutyRevolver
+  - SecurityOfficerEG1
   - BrigmedTerminus
   - WeaponPistolMk58Gold
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Added the ability to select the EG-1 Taro for corpsman in the loadout screen

## Why / Balance
It was not up to parity with the other security loadout screens

## Technical details
literally one line of yml

## Media
<img width="997" height="1002" alt="image" src="https://github.com/user-attachments/assets/7d2995bd-0410-4b94-9d46-e67d96aaea52" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] I have read and agree to the Contributor License Agreement.
<!-- See CLA.md for the CLA -->

**Changelog**
- fix: The EG-1 Taro now appears in the corpsman loadout menu
