### PR TITLE
Oops all traitors (not the cursed version) and conspirators change

### DIFF
--- a/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
@@ -53,7 +53,8 @@
     CorporateAgent: 0.035 # Omu - Increase from 0.025 due to rev removal
     XenomorphsInfestationRoundstart: 0.07 # Omu - Increase from 0.05 due to rev
     OopsAllThieves: 0.05
-    Conspirators: 0.1   #Omu starting it quite high so we see it a bit, for testing etc
+    Conspirators: 0.05   #Omu
+    OopsAllTraitors: 0.05 #Omu
 
 # all roundstart antags
 - type: weightedRandom
@@ -73,7 +74,7 @@
     CosmicCult: 0.07 # Omu - Increase from 0.05 due to rev removal
     CorporateAgent: 0.035 # Omu - Increase from 0.025 due to rev removal
     XenomorphsInfestationRoundstart: 0.02
-    Conspirators: 0.2   #Omu starting it quite high so we see it a bit, for testing etc
+    Conspirators: 0.15   #Omu
 
 
 # ⠀⠀⠀⠀⠀⠀⠀⢀⡀⠴⠤⠤⠴⠄⡄⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀

--- a/Resources/Prototypes/_Omu/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Omu/GameRules/roundstart.yml
@@ -4,7 +4,7 @@
   components:
   - type: GameRule
     minPlayers: 30
-    chaosScore: 1250
+    chaosScore: 1500
   - type: AntagSelection
     definitions:
     - prefRoles: [ Traitor ]

--- a/Resources/Prototypes/_Omu/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Omu/GameRules/roundstart.yml
@@ -1,0 +1,18 @@
+- type: entity
+  parent: BaseTraitorRule
+  id: OopsAllTraitors
+  components:
+  - type: GameRule
+    minPlayers: 30
+    chaosScore: 1250
+  - type: AntagSelection
+    definitions:
+    - prefRoles: [ Traitor ]
+      max: 10
+      playerRatio: 7
+      blacklist:
+        components:
+        - AntagImmune
+      lateJoinAdditional: true
+      mindRoles:
+      - MindRoleTraitor


### PR DESCRIPTION
## About the PR
Added new gamemode and changed conspirator spawn rate

## Why / Balance
Community loves high traitor rounds; and are not large fans of conspirators

## Technical details
added new gamerule and added it to the roll able list

## Media
yaml

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Slightly reduce conspirator spawn rate.
- add: New game rule "Oops all traitors" a counterpart to "Oops all thieves"