### PR TITLE
Fix experimental shipment being impossible

### DIFF
--- a/Resources/Prototypes/_Goobstation/Recipes/Construction/Graphs/shipments/shipment_experimental.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Construction/Graphs/shipments/shipment_experimental.yml
@@ -22,7 +22,7 @@
                 key: "enum.ConstructionVisuals.Key"
                 data: 1
           - material: Bananium
-            amount: 30
+            amount: 10
             doAfter: 0.1
           - material: BSCrystal
             amount: 5


### PR DESCRIPTION
## About the PR
Change bananium required from 30 to 10, bugfix.

## Why / Balance
bugfix

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Experimental shipments now only need 10 bananium instead of 30
