### PR TITLE
Make monkeys not randomly become sentient on spawning

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1826,14 +1826,14 @@
   - type: SentienceTarget
     flavorKind: station-event-random-sentience-flavor-primate
   - type: AlwaysRevolutionaryConvertible
-  - type: GhostRole
-    prob: 0.05
-    makeSentient: true
-    name: ghost-role-information-monkey-name
-    description: ghost-role-information-monkey-description
-    rules: ghost-role-information-sentientanimal-rules # Goobstation Sentient Animal PR
-    mindRoles:
-    - MindRoleGhostRoleSentientAnimal # Goobstation Sentient Animal PR
+  #- type: GhostRole # Omu, only should be sentient when targeted by an event.
+  #  prob: 0.05
+  #  makeSentient: true
+  #  name: ghost-role-information-monkey-name
+  #  description: ghost-role-information-monkey-description
+  #  rules: ghost-role-information-sentientanimal-rules # Goobstation Sentient Animal PR
+  #  mindRoles:
+  #  - MindRoleGhostRoleSentientAnimal # Goobstation Sentient Animal PR
   - type: GhostTakeoverAvailable
   - type: Skinnable # Goobstation - Fuck pun-pun
   - type: Clumsy


### PR DESCRIPTION
## About the PR
Removes the default chance for monkeys to be sentient on spawn.

## Why / Balance
Makes it so the sentience event is a bit more meaningful, and gets rid of a roll that's often used to just be a pain as there is no mechanical enforcement for them being meant to be "dumb" creatures.

## Technical details
comment out some yaml.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- remove: Monkeys no longer randomly become sentient on spawn.