### PR TITLE
Remove random chinese characters from autodoc

### DIFF
--- a/Resources/Locale/en-US/_Shitmed/autodoc.ftl
+++ b/Resources/Locale/en-US/_Shitmed/autodoc.ftl
@@ -41,55 +41,32 @@ autodoc-error-hand-full = ITEM MANIPULATOR FULL
 autodoc-error-storage-full = ITEM TRAYS FULL
 autodoc-error-patient-unsedated = PATIENT REQUIRES SEDATION
 
-# These intentionally have chinese alongside them for aesthetic purposes.
-# I barely speak chinese, but I double checked I wasn't saying a slur with google translate, so this should be ok. Especially since 99.9% of our players don't speak chinese anyway.
-
-# Chinese text translates approximately to "People's Glorious Automatic Surgery Machine"
-autodoc-title = AUTODOC 人民辉煌自动手术机 MK.XIV
-# Chinese text translates approximately to "New Plan"
-autodoc-create-program = NEW PROGRAM 新计划
-# Chinese text translates approximately to "Plan Title"
-autodoc-program-title = PROGRAM TITLE 计划标题
+autodoc-title = AUTODOC MK.XIV
+autodoc-create-program = NEW PROGRAM
+autodoc-program-title = PROGRAM TITLE
 autodoc-program-title-placeholder = Program {$number}
-# Chinese text translates approximately to "Quit"
-autodoc-abort-program = ABORT PROGRAM 退出
+autodoc-abort-program = ABORT PROGRAM
 
-# Chinese text translates approximately to "View Plan"
-autodoc-view-program-title = VIEW PROGRAM 查看计划
-# Chinese text translates approximately to "Ensure Safety"
-autodoc-safety-enabled = SAFETY ON 确保安全
-# Chinese text translates literally to "No Ensure Safety" (it probably makes sense in Chinese grammar, I think. I hope.)
-autodoc-safety-disabled = SAFETY OFF 不确保安全
-# Chinese text translates approximately to "Delete Plan"
-autodoc-remove-program = REMOVE PROGRAM 删除计划
-# Chinese text translates approximately to "Add a Step"
-autodoc-add-step = ADD STEP 添加一步
-# Chinese text translates approximately to "Remove a Step"
-autodoc-remove-step = REMOVE STEP 删除一步
-# Chinese text translates approximately to "Launch the Glorious People's Project" (as with all these long sentences, im not super sure on the translation making sense)
-autodoc-start-program = START PROGRAM 发起光荣人民计划
-# Chinese text translates approximately to "import program")
-autodoc-import-program = IMPORT PROGRAM 进口计划
-# Chinese text translates approximately to "import program")
-autodoc-export-program = EXPORT PROGRAM 出口计划
+autodoc-view-program-title = VIEW PROGRAM
+autodoc-safety-enabled = SAFETY ON
+autodoc-safety-disabled = SAFETY OFF
+autodoc-remove-program = REMOVE PROGRAM
+autodoc-add-step = ADD STEP
+autodoc-remove-step = REMOVE STEP
+autodoc-start-program = START PROGRAM
+autodoc-import-program = IMPORT PROGRAM
+autodoc-export-program = EXPORT PROGRAM
 
-# Chinese text translates approximately to "Start Surgical Operation"
-autodoc-add-step-surgery = PERFORM SURGERY 开始手术
-# Chinese text translates approximately to "Take Item"
-autodoc-add-step-grab-item = GRAB ITEM 拿走物品
+autodoc-add-step-surgery = PERFORM SURGERY
+autodoc-add-step-grab-item = GRAB ITEM
 autodoc-add-step-grab-item-prompt = Item name
 autodoc-add-step-grab-item-placeholder = dwarf heart
-# Chinese text translates approximately to "Take Organ"
-autodoc-add-step-grab-organ = GRAB ORGAN 拿管风琴
-# Chinese text translates approximately to "Pick up body part"
-autodoc-add-step-grab-part = GRAB BODY PART 拾起身体部位
-# Chinese text translates approximately to "Place item in storage space", this is overly long because I don't know how to write it shorter!!
-autodoc-add-step-store-item = STORE ITEM 将物品放入存储空间
-# Chinese text translates approximately to "Set Label"
-autodoc-add-step-set-label = SET LABEL 设置标签
+autodoc-add-step-grab-organ = GRAB ORGAN
+autodoc-add-step-grab-part = GRAB BODY PART
+autodoc-add-step-store-item = STORE ITEM
+autodoc-add-step-set-label = SET LABEL
 autodoc-add-step-set-label-prompt = Label
-# Chinese text translates approximately to "Wait" this is probably the most impolite way you can say it, but im stupid and this is all i know :)
-autodoc-add-step-wait = WAIT 等
+autodoc-add-step-wait = WAIT
 autodoc-add-step-wait-prompt = Seconds to wait
 
 autodoc-body-part-Other = Other

--- a/Resources/Locale/en-US/_Shitmed/autodoc.ftl
+++ b/Resources/Locale/en-US/_Shitmed/autodoc.ftl
@@ -41,6 +41,7 @@ autodoc-error-hand-full = ITEM MANIPULATOR FULL
 autodoc-error-storage-full = ITEM TRAYS FULL
 autodoc-error-patient-unsedated = PATIENT REQUIRES SEDATION
 
+# Omu start - remove random chinese characters from the ui
 autodoc-title = AUTODOC MK.XIV
 autodoc-create-program = NEW PROGRAM
 autodoc-program-title = PROGRAM TITLE
@@ -67,6 +68,7 @@ autodoc-add-step-store-item = STORE ITEM
 autodoc-add-step-set-label = SET LABEL
 autodoc-add-step-set-label-prompt = Label
 autodoc-add-step-wait = WAIT
+# Omu end
 autodoc-add-step-wait-prompt = Seconds to wait
 
 autodoc-body-part-Other = Other


### PR DESCRIPTION
## About the PR
Removes random chinese characters from the autodoc ui

## Why / Balance
There is no reason for them to be there and it just makes it harder to read.

## Technical details
Remove some stuff from a ftl file

## Media
<img width="1395" height="729" alt="image" src="https://github.com/user-attachments/assets/ae021058-175e-40fc-a9bf-aff18e1de95d" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- remove: Removed the random chinese characters from the autodoc.