### PR TITLE
Allow oni to use terminus

### DIFF
--- a/Content.Shared/_Shitmed/Restrict/RestrictGunshotsByUserTag.cs
+++ b/Content.Shared/_Shitmed/Restrict/RestrictGunshotsByUserTag.cs
@@ -22,4 +22,9 @@ public sealed partial class RestrictGunshotsByUserTagComponent : Component
     public List<string> Messages = [];
 
     public TimeSpan LastPopup;
+
+    // Omu start - Any weapon with these tags ignores the restrictions
+    [DataField, AutoNetworkedField]
+    public List<ProtoId<TagPrototype>> BypassTags = [];
+    // Omu end
 }

--- a/Content.Shared/_Shitmed/Restrict/SharedRestrictSystem.cs
+++ b/Content.Shared/_Shitmed/Restrict/SharedRestrictSystem.cs
@@ -53,7 +53,7 @@ public sealed partial class SharedRestrictSystem : EntitySystem
 
     private void OnAttemptGunshot(Entity<RestrictGunshotsByUserTagComponent> ent, ref ShotAttemptedEvent args)
     {
-        if(!_tagSystem.HasAllTags(args.User, ent.Comp.Contains) || _tagSystem.HasAnyTag(args.User, ent.Comp.DoesntContain))
+        if ((!_tagSystem.HasAllTags(args.User, ent.Comp.Contains) || _tagSystem.HasAnyTag(args.User, ent.Comp.DoesntContain)) && !_tagSystem.HasAnyTag(args.Used, ent.Comp.BypassTags)) // Omu, check for bypasstags
         {
             var time = _timing.CurTime;
 

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/Oni.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/Oni.yml
@@ -76,7 +76,7 @@
     - oni-cannot-shoot-guns-1
     - oni-cannot-shoot-guns-2
     - oni-cannot-shoot-guns-3
-    bypassTags:
+    bypassTags: # Omu
     - AllowedOniGun
 
   - type: Stamina

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/Oni.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/Oni.yml
@@ -76,6 +76,8 @@
     - oni-cannot-shoot-guns-1
     - oni-cannot-shoot-guns-2
     - oni-cannot-shoot-guns-3
+    bypassTags:
+    - AllowedOniGun
 
   - type: Stamina
     critThreshold: 115

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Objects/Weapons/Melee/terminus.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Objects/Weapons/Melee/terminus.yml
@@ -66,3 +66,6 @@
   - type: Prying
   - type: UseDelay # Omu, this means the crowbar function has a cooldown
     delay: 0.9
+  - type: Tag # Omu
+    tags:
+      - AllowedOniGun

--- a/Resources/Prototypes/_Omu/tags.yml
+++ b/Resources/Prototypes/_Omu/tags.yml
@@ -69,6 +69,9 @@
 
 - type: Tag
   id: NinjutsuWeapon
-  
+
 - type: Tag
   id: RollerBed
+
+- type: Tag
+  id: AllowedOniGun


### PR DESCRIPTION
## About the PR
Fix an oversight in my PR

## Why / Balance
Bugfix thing or something like that I got pinged about this so yeah.

## Technical details
Adds a list to Content.Shared/_Shitmed/Restrict/RestrictGunshotsByUserTag.cs that contains a list of tags that bypass checks, currently only used with oni with the "AllowedOniGun" tag, which is in turn, only used on the terminus.

## Media
<img width="870" height="244" alt="image" src="https://github.com/user-attachments/assets/3f2cd055-f600-4463-97ca-ff0324091027" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed Oni being unable to use the Terminus.