### PR TITLE
EAd escape pod airlocks

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
@@ -1268,7 +1268,7 @@
       - HideLabel
   - type: ContainerFill
     containers:
-      board: [ DoorElectronicsExternal ]
+      board: [ DoorElectronics ] # Omu, allow all crew to go into escape pods and not only crew with external access.
 
 #HighSecDoors
 - type: entity


### PR DESCRIPTION
## About the PR
I changed the required access level from "external" to "everyone" for escape pod airlocks.

## Why / Balance
It kinda sucks that in emergencies crew can't use escape pods without jaws or any other way of accessing them.

## Technical details
Changed the airlocks board from external to their parent.

## Media


<img width="485" height="237" alt="image" src="https://github.com/user-attachments/assets/6e56ee4b-387c-4789-a6ac-4628bb1ea13c" />
<img width="893" height="520" alt="image" src="https://github.com/user-attachments/assets/44c113a1-5bdc-48f8-9708-e5b4d7059e73" />


(No escape pod because dev env)
<img width="343" height="269" alt="image" src="https://github.com/user-attachments/assets/6fe3dd31-9faf-45ca-b322-e7653b8bce49" />

<img width="857" height="659" alt="image" src="https://github.com/user-attachments/assets/74c5bc56-cb5f-4fcc-9b33-1af84663a4a9" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Quill
- fix: Allowed everyone to open escape pod airlocks.
