### PR TITLE
Ai can no longer play in the dispo unit

### DIFF
--- a/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.cs
+++ b/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.cs
@@ -148,6 +148,7 @@ using Content.Shared.Movement.Events;
 using Content.Shared.Popups;
 using Content.Shared.Power;
 using Content.Shared.Power.EntitySystems;
+using Content.Shared.Silicons.StationAi;
 using Content.Shared.Storage.Components;
 using Content.Shared.Throwing;
 using Content.Shared.Verbs;
@@ -585,6 +586,12 @@ public abstract class SharedDisposalUnitSystem : EntitySystem
         var storable = HasComp<ItemComponent>(entity);
         if (!storable && !HasComp<MobStateComponent>(entity))
             return false;
+
+        //Omu Start -- Keep AI from jumping into dispo
+        if (HasComp<StationAiOverlayComponent>(entity)
+            && HasComp<StationAiCustomizationComponent>(entity))
+            return false;
+        //Omu End
 
         if (_whitelistSystem.IsBlacklistPass(component.Blacklist, entity) ||
             _whitelistSystem.IsWhitelistFail(component.Whitelist, entity))


### PR DESCRIPTION
## About the PR
Removes AI's ability to play in dispo

## Why / Balance
its a bug

## Technical details
added check to see if certain components are existing on entity before displaying "jump inside"

## Media

<img width="545" height="331" alt="image" src="https://github.com/user-attachments/assets/8a523917-d662-42e3-a04a-939a2643ce72" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Ai can no longer play in the dispo bin 