### PR TITLE
Space garbage component fix for steal targets

### DIFF
--- a/Content.Server/Shuttles/Systems/SpaceGarbageSystem.cs
+++ b/Content.Server/Shuttles/Systems/SpaceGarbageSystem.cs
@@ -33,6 +33,7 @@ public sealed class SpaceGarbageSystem : EntitySystem
         if (args.OtherBody.BodyType != BodyType.Static)
             return;
 
+        // omu todo this is bad and hardcoded, fix parenting on corgi meat later.
         // Omu Start -- Steal targets like Prime-cut Corgi meat will no longer delete
         if (HasComp<StealTargetComponent>(uid))
             return;

--- a/Content.Server/Shuttles/Systems/SpaceGarbageSystem.cs
+++ b/Content.Server/Shuttles/Systems/SpaceGarbageSystem.cs
@@ -7,6 +7,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Server.Objectives.Components.Targets;
 using Content.Server.Shuttles.Components;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Events;
@@ -31,6 +32,11 @@ public sealed class SpaceGarbageSystem : EntitySystem
     {
         if (args.OtherBody.BodyType != BodyType.Static)
             return;
+
+        // Omu Start -- Steal targets like Prime-cut Corgi meat will no longer delete
+        if (HasComp<StealTargetComponent>(uid))
+            return;
+        // Omu End
 
         var ourXform = _xformQuery.GetComponent(uid);
         var otherXform = _xformQuery.GetComponent(args.OtherEntity);


### PR DESCRIPTION
## About the PR
Removes space garbage on collide being applied to steal targets like prime cut corgi meat

## Why / Balance
its a bug

## Technical details
added check to see if certain components are existing on entity before deleting

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Space Garbage component will no longer delete Steal targets (Prime cut corgi meat) on collision