### PR TITLE
Change to spawn prototype to utilize getMap Coordinates

### DIFF
--- a/Content.Server/Construction/Completions/SpawnPrototype.cs
+++ b/Content.Server/Construction/Completions/SpawnPrototype.cs
@@ -40,7 +40,8 @@ namespace Content.Server.Construction.Completions
             if (string.IsNullOrEmpty(Prototype))
                 return;
 
-            var coordinates = entityManager.GetComponent<TransformComponent>(uid).Coordinates;
+            // var coordinates = entityManager.GetComponent<TransformComponent>(uid).Coordinates; Omu Remove
+            var coordinates = entityManager.EntitySysManager.GetEntitySystem<SharedTransformSystem>().GetMapCoordinates(uid); // Omu - Change to map coordinates to allow crafting/deconning to work
 
             if (EntityPrototypeHelpers.HasComponent<StackComponent>(Prototype))
             {


### PR DESCRIPTION
## About the PR
Fixes crafting "spawn prototype" to utilize mapcoordinates instead of just coordinates

## Why / Balance
Allows crafting of things like spirit candles, and deconning of glasses and folding chairs even while in inventories

## Technical details
Changed transform component to shared transform system (Ty Marty)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Crafting while the items are in inventory works correctly now; fixing things like spirit candles and taking apart items.