### PR TITLE
Improved the ERT loadouts a bit

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -1039,6 +1039,10 @@
   - type: PointLight
     color: "#f4ffad"
   - type: EyeProtection # goob
+  - type: Armor
+    modifiers:
+      coefficients:
+        Radiation: 0 # Omu
 
 #ERT Medical Hardsuit
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -1329,6 +1329,10 @@
       head: ClothingHeadHelmetHardsuitERTEngineer
   - type: FireProtection
     reduction: 0.8
+  - type: Armor
+    modifiers:
+      coefficients:
+        Radiation: 0 # Omu
 
 #ERT Medic Hardsuit
 - type: entity

--- a/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -343,6 +343,7 @@
   storage:
     back:
     - trayScanner
+    # - RCD # Omu
     - RCDExperimental # Omu
     - RPD # Omu
     - RCDAmmo
@@ -374,6 +375,7 @@
   storage:
     back:
     - trayScanner
+    # - RCD # Omu
     - RCDExperimental # Omu
     - RPD # Omu
     - RCDAmmo

--- a/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -160,6 +160,7 @@
     - CrowbarRed
     - ERTSecurityUndeterminedWeapon
     # - MagazineMagnum - No need
+    - BoxSurvivalSlotsEngineering # Omu
 
 - type: startingGear
   id: ERTLeaderGearEVA
@@ -185,6 +186,7 @@
     - CrowbarRed
     - ERTSecurityUndeterminedWeapon
     # Goobstation - MagazineMagnum
+    - BoxSurvivalSlotsEngineering # Omu
 
 - type: chameleonOutfit
   id: ERTLeaderChameleonOutfit
@@ -253,6 +255,7 @@
     - Nullrod # Goobstation
     - Lighter
     - ExecutiveIDCard # Goobstation - Executive Access!
+    - BoxSurvivalSlotsEngineering # Omu
 
 - type: startingGear
   id: ERTChaplainGearEVA
@@ -282,10 +285,11 @@
     - FoodBakedBunHotX
     - FoodBakedBunHotX
     - FoodBakedBunHotX
-    - FoodBakedBunHotX
+    # - FoodBakedBunHotX # Omu - Three buns so the survival box fits
     - Lighter
     - Nullrod # Goobstation
     - ExecutiveIDCard # Goobstation - Executive Access!
+    - BoxSurvivalSlotsEngineering # Omu
 
 - type: chameleonOutfit
   id: ERTChaplainChameleonOutfit
@@ -339,7 +343,8 @@
   storage:
     back:
     - trayScanner
-    - RCD
+    - RCDExperimental # Omu
+    - RPD # Omu
     - RCDAmmo
     - RCDAmmo
     - CableMVStack
@@ -348,6 +353,7 @@
     - SheetPlasteel
     - SheetSteel
     - SheetGlass
+    - BoxSurvivalSlotsEngineering # Omu
 
 - type: startingGear
   id: ERTEngineerGearEVA
@@ -368,7 +374,8 @@
   storage:
     back:
     - trayScanner
-    - RCD
+    - RCDExperimental # Omu
+    - RPD # Omu
     - RCDAmmo
     - RCDAmmo
     - CableMVStack
@@ -377,6 +384,7 @@
     - SheetPlasteel
     - SheetSteel
     - SheetGlass
+    - BoxSurvivalSlotsEngineering # Omu
 
 - type: chameleonOutfit
   id: ERTEngineerChameleonOutfit
@@ -433,6 +441,7 @@
     - CrowbarRed
     - ERTSecurityUndeterminedWeapon
    # - MagazinePistol
+    - BoxSurvivalSlotsEngineering # Omu
 
 - type: startingGear
   id: ERTSecurityGearEVA
@@ -458,6 +467,7 @@
     - CrowbarRed
     - ERTSecurityUndeterminedWeapon
    # - MagazinePistol
+    - BoxSurvivalSlotsEngineering # Omu
 
 # Every time an admin spawns a lecter ERT instead of an annie ert i lose a part of my soul. USE THE DAMN GUN MADE FOR THE ERTS, OR SPAWN THE OTHER PROTO. THIS IS REDUNDANT!!
 # - type: startingGear
@@ -545,6 +555,7 @@
     - CartridgeAtropine
     - CartridgeAtropine
     - MedicalBeamGunBattery
+    - BoxSurvivalSlotsEngineering # Omu
 
 - type: startingGear
   id: ERTMedicalGearEVA
@@ -572,6 +583,7 @@
     - CartridgeAtropine
     - CartridgeAtropine
     - MedicalBeamGunBattery
+    - BoxSurvivalSlotsEngineering # Omu
 
 - type: chameleonOutfit
   id: ERTMedicalChameleonOutfit
@@ -620,9 +632,15 @@
     pocket1: WeaponPulsePistol # Literally described as "Favored sidearm of NT ERT operatives".
   storage:
     back:
-    - LightReplacer
+    # - LightReplacer # Omu - There's one in the belt already
     - BoxLightMixed
-    - BoxLightMixed
+    # - BoxLightMixed # Omu - Let's fill up the bag with more useful things instead of two light boxes
+    - TrashBag # Omu
+    - CleanerGrenade # Omu
+    - CleanerGrenade # Omu
+    - CleanerGrenade # Omu
+    - CleanerGrenade # Omu
+    - BoxSurvivalSlotsEngineering # Omu
     - Soap
     - CrowbarRed
     - AdvMopItem
@@ -643,9 +661,15 @@
     pocket1: WeaponPulsePistol # Literally described as "Favored sidearm of NT ERT operatives".
   storage:
     back:
-    - LightReplacer
+    # - LightReplacer # Omu - There's one in the belt already
     - BoxLightMixed
-    - BoxLightMixed
+    # - BoxLightMixed # Omu - Let's fill up the bag with more useful things instead of two light boxes
+    - TrashBag # Omu
+    - CleanerGrenade # Omu
+    - CleanerGrenade # Omu
+    - CleanerGrenade # Omu
+    - CleanerGrenade # Omu
+    - BoxSurvivalSlotsEngineering # Omu
     - Soap
     - CrowbarRed
     - AdvMopItem

--- a/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -342,7 +342,7 @@
     pocket2: GasAnalyzer
   storage:
     back:
-    - trayScanner
+    # - trayScanner # Omu - There's already one in the belt
     # - RCD # Omu
     - RCDExperimental # Omu
     - RPD # Omu
@@ -374,7 +374,7 @@
     pocket2: GasAnalyzer
   storage:
     back:
-    - trayScanner
+    # - trayScanner # Omu - Belt already has one
     # - RCD # Omu
     - RCDExperimental # Omu
     - RPD # Omu

--- a/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -641,7 +641,7 @@
     - CleanerGrenade # Omu
     - CleanerGrenade # Omu
     - BoxSurvivalSlotsEngineering # Omu
-    - Soap
+    # - Soap # Omu - There's one in the belt already
     - CrowbarRed
     - AdvMopItem
 
@@ -670,7 +670,7 @@
     - CleanerGrenade # Omu
     - CleanerGrenade # Omu
     - BoxSurvivalSlotsEngineering # Omu
-    - Soap
+    # - Soap # Omu - There's one in the belt already
     - CrowbarRed
     - AdvMopItem
 

--- a/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -343,8 +343,7 @@
   storage:
     back:
     # - trayScanner # Omu - There's already one in the belt
-    # - RCD # Omu
-    - RCDExperimental # Omu
+    - RCD
     - RPD # Omu
     - RCDAmmo
     - RCDAmmo
@@ -375,8 +374,7 @@
   storage:
     back:
     # - trayScanner # Omu - Belt already has one
-    # - RCD # Omu
-    - RCDExperimental # Omu
+    - RCD
     - RPD # Omu
     - RCDAmmo
     - RCDAmmo

--- a/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -534,6 +534,7 @@
     back: ClothingBackpackERTMedical
     shoes: ClothingShoesBootsMagEmergencyResponseTeam # Goobstation
     head: ClothingHeadHelmetERTMedic
+    mask: ClothingMaskSterileGreen # Omu
     neck: ExecutiveIDCard # Goobstation - Executive Access!
     eyes: ClothingEyesGlassesMedSec # Goobstation
     gloves: ClothingHandsGlovesNitrile
@@ -551,9 +552,13 @@
     - ChemistryBottleOmnizine
     - JugOxandrolone
     - JugSalicylicAcid
-    - ParamedHypo
-    - CartridgeAtropine
-    - CartridgeAtropine
+    # - ParamedHypo # Omu
+    # - CartridgeAtropine # Omu
+    # - CartridgeAtropine # Omu
+    - JugArtiplates # Omu
+    - EmergencyMedipen # Omu
+    - EmergencyMedipen # Omu
+    - AntiPoisonMedipen # Omu
     - MedicalBeamGunBattery
     - BoxSurvivalSlotsEngineering # Omu
 
@@ -577,11 +582,16 @@
     - CentCommHypo
     - MedkitAdvancedFilled
     - CrowbarRed
+    - ChemistryBottleOmnizine # Omu
     - JugOxandrolone
     - JugSalicylicAcid
-    - ParamedHypo
-    - CartridgeAtropine
-    - CartridgeAtropine
+    # - ParamedHypo # Omu
+    # - CartridgeAtropine # Omu
+    # - CartridgeAtropine # Omu
+    - JugArtiplates # Omu
+    - EmergencyMedipen # Omu
+    - EmergencyMedipen # Omu
+    - AntiPoisonMedipen # Omu
     - MedicalBeamGunBattery
     - BoxSurvivalSlotsEngineering # Omu
 

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Modsuits/engineering-responsory.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Modsuits/engineering-responsory.yml
@@ -95,7 +95,7 @@
           Heat: 0.15
           Cold: 0.10
           Shock: 0.15
-          Radiation: 0.1
+          Radiation: 0 # Omu
           Caustic: 0.1
     - type: FlashImmunity # Goobstation
     - type: FlashSoundSuppression # Goobstation
@@ -140,7 +140,7 @@
           Heat: 0.10
           Cold: 0.10
           Shock: 0.15
-          Radiation: 0.1
+          Radiation: 0 # Omu
           Caustic: 0.1
     - type: SealableClothingVisuals
       spriteLayer: sealed

--- a/Resources/Prototypes/_Omu/Entities/Objects/Specific/Chemistry/chemistry-jugs.yml
+++ b/Resources/Prototypes/_Omu/Entities/Objects/Specific/Chemistry/chemistry-jugs.yml
@@ -1,0 +1,14 @@
+- type: entity
+  parent: Jug
+  suffix: artiplates
+  id: JugArtiplates
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Label
+    currentLabel: reagent-name-artiplates
+  - type: SolutionContainerManager
+    solutions:
+      beaker:
+        reagents:
+        - ReagentId: Artiplates
+          Quantity: 200

--- a/Resources/Prototypes/_Omu/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/_Omu/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -48,6 +48,7 @@
     - EnergySpeedloaderLethal
     - EnergySpeedloaderLethal
     - EnergySpeedloaderDisabler
+    - BoxSurvivalSlotsEngineering
 
 # ERT Security
 
@@ -98,6 +99,7 @@
     - BoxMagazineRifle
     - MedkitCombatFilled
     - CrowbarRed
+    - BoxSurvivalSlotsEngineering
 
 # ERT Medical
 
@@ -145,6 +147,7 @@
     - BoxAutoinjectorCartidges
     - MedkitCombatFilled
     - CrowbarRed
+    - BoxSurvivalSlotsEngineering
 
 # ERT Janitor
 
@@ -189,7 +192,13 @@
   storage:
     back:
     - BoxLightMixed
-    - BoxLightMixed
+    - TrashBag
+    - CleanerGrenade
+    - CleanerGrenade
+    - CleanerGrenade
+    - CleanerGrenade
+    - BoxSurvivalSlotsEngineering
+    - Soap
     - CrowbarRed
     - AdvMopItem
 
@@ -235,7 +244,8 @@
     pocket2: FlashlightSeclite
   storage:
     back:
-    - RCD
+    - trayScanner
+    - RCDExperimental
     - RPD
     - RCDAmmo
     - RCDAmmo
@@ -245,6 +255,7 @@
     - SheetPlasteel
     - SheetSteel
     - SheetGlass
+    - BoxSurvivalSlotsEngineering
 
 # ERT Chaplain
 
@@ -307,4 +318,4 @@
     - FoodBakedBunHotX
     - Nullrod
     - Lighter
-    - DrinkWaterBottleFull
+    - BoxSurvivalSlotsEngineering

--- a/Resources/Prototypes/_Omu/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/_Omu/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -243,7 +243,7 @@
     pocket2: FlashlightSeclite
   storage:
     back:
-    - RCDExperimental
+    - RCD
     - RPD
     - RCDAmmo
     - RCDAmmo

--- a/Resources/Prototypes/_Omu/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/_Omu/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -198,7 +198,6 @@
     - CleanerGrenade
     - CleanerGrenade
     - BoxSurvivalSlotsEngineering
-    - Soap
     - CrowbarRed
     - AdvMopItem
 

--- a/Resources/Prototypes/_Omu/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/_Omu/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -134,7 +134,8 @@
     back: ClothingBackpackERTMedical
     shoes: ClothingShoesBootsJack
     eyes: ClothingEyesGlassesMedChemFlash
-    gloves: ClothingHandsGlovesNitrile
+    gloves: ClothingHandsGlovesSurgical
+    mask: ClothingMaskSterileBlue
     outerClothing: ClothingOuterArmorBasicSlim
     id: ERTMedicPDABlue
     ears: ClothingHeadsetAltCentComMed
@@ -143,11 +144,12 @@
     pocket2: FlashlightSeclite
   storage:
     back:
-    - MedkitAdvancedFilled
+    - BoxSurvivalSlotsEngineering
     - BoxAutoinjectorCartidges
+    - ParamedHypo
     - MedkitCombatFilled
     - CrowbarRed
-    - BoxSurvivalSlotsEngineering
+    - OmnimedTool
 
 # ERT Janitor
 

--- a/Resources/Prototypes/_Omu/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/_Omu/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -243,7 +243,6 @@
     pocket2: FlashlightSeclite
   storage:
     back:
-    - trayScanner
     - RCDExperimental
     - RPD
     - RCDAmmo


### PR DESCRIPTION
## About the PR
* All loadouts get a extended survival box
* The engi loadouts get upgraded from an RCD to an experimental RCD and get an RPD.
* The eva and blue engi loadouts get 100% rad armor.
* Removed the second light box and light replacer from the jani loadout and replaced it with a couple cleanades and a trash bag

## Why / Balance
Jani loadout didn't make a lot of sense, also no survival kits is meh and having no RPD as engi is annoying.

## Technical details
Yamlslop

## Media
Funny testing area
<img width="1082" height="903" alt="image" src="https://github.com/user-attachments/assets/a47cb0f4-9026-443a-92fd-aa1d76b7b181" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Quill
- tweak: Adjusted all ERT loadouts.

