### PR TITLE
Sound change for IAA Spawn

### DIFF
--- a/Resources/Prototypes/_DV/GameRules/events.yml
+++ b/Resources/Prototypes/_DV/GameRules/events.yml
@@ -89,7 +89,7 @@
     maxOccurrences: 1
     startAnnouncement: station-event-communication-interception
     startAudio:
-      path: /Audio/_DV/Announcements/attention.ogg
+      path: /Audio/Announcements/intercept.ogg #/Audio/_DV/Announcements/attention.ogg -- Omu, Swapped to other traitor line for consistency
     duration: null
     occursDuringRoundEnd: false
   - type: AlertLevelInterceptionRule

--- a/Resources/Prototypes/_DV/GameRules/events.yml
+++ b/Resources/Prototypes/_DV/GameRules/events.yml
@@ -89,7 +89,7 @@
     maxOccurrences: 1
     startAnnouncement: station-event-communication-interception
     startAudio:
-      path: /Audio/Announcements/intercept.ogg #/Audio/_DV/Announcements/attention.ogg -- Omu, Swapped to other traitor line for consistency
+      path: /Audio/Announcements/intercept.ogg # Omu, Swapped to different traitor line for consistency
     duration: null
     occursDuringRoundEnd: false
   - type: AlertLevelInterceptionRule


### PR DESCRIPTION
## About the PR
Changed one sound to the enemy communication sound

## Why / Balance
Preventing people meta-gaming, and makes more sense for IAA lore for NT to sweep any potential IAA under the rug as an enemy agent

## Technical details
changed one line of spooky yaml

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: IAA spawn now uses the sleeper agent SFX for its announcement