### PR TITLE
Make loneops not always override species

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -905,9 +905,11 @@
         - Syndicate
       mindRoles:
       - MindRoleNukeops
-  - type: AntagLoadProfileRule # Goobstation
+  - type: AntagLoadProfileRule # Omu start
     speciesOverride: Human
-    alwaysUseSpeciesOverride: true
+    speciesOverrideBlacklist:
+    - Abductor
+    - Plasmaman # Omu end
 
 - type: entity
   parent: BaseTraitorRule


### PR DESCRIPTION
## About the PR
Loneops now only overrides species in cases where you either shouldn't (abductor) be it, or would die instantly (plasmamen) 

## Why / Balance
Species override makes it kinda weird as it loads their character but carries over most of the markings making some weird abominations. nukies don't override species (in most cases), nor does ninja (in most cases). So loneop shouldn't either,

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Loneop no longer overrides your species (in most cases)
