### PR TITLE
Fixed the Xelthia backspikes marking to actually show up

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Customization/xelthia.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Customization/xelthia.yml
@@ -116,14 +116,15 @@
 
 - type: marking
   id: XelthiaBackspikes
-  bodyPart: Chest, RArm, LArm, Head
+  bodyPart: Chest # Omu
   markingCategory: Overlay
   speciesRestriction: [Xelthia]
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#FFFFFF"
+        !type:SkinColoring # Omu
+       # !type:SimpleColoring # Omu
+         # color: "#FFFFFF" # Omu
   sprites:
   - sprite: _EinsteinEngines/Mobs/Customization/xelthia_parts.rsi
     state: backspikes

--- a/Resources/Prototypes/_EinsteinEngines/Species/xelthia.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Species/xelthia.yml
@@ -106,8 +106,8 @@
       required: false
     Overlay:
       points: 1
-      required: true
-      defaultMarkings: [ XelthiaBackspikes ]
+      required: false # Omu
+      # defaultMarkings: [ XelthiaBackspikes ] # Omu
 - type: humanoidBaseSprite
   id: MobXelthiaHead
   baseSprite:


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
Fixed for #568 the Xelthia backsprite marking to show up and made it optional.

## Why / Balance
It was configured wrongly so it never rendered.

## Technical details
Yamlslop. `bodyPart` isn't a comma separated list but a single part.

## Media
<img width="212" height="260" alt="image" src="https://github.com/user-attachments/assets/f26e2ab7-52a6-41fc-9336-a5062480805c" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Quill
- fix: Made the Xelthia Backspikes marking actually visible.

