### PR TITLE
Made sure that glowy bits get copied over when changing a marking id

### DIFF
--- a/Content.Server/Humanoid/Systems/HumanoidAppearanceSystem.cs
+++ b/Content.Server/Humanoid/Systems/HumanoidAppearanceSystem.cs
@@ -87,6 +87,8 @@ public sealed partial class HumanoidAppearanceSystem : SharedHumanoidAppearanceS
             marking.SetColor(i, markings[index].MarkingColors[i]);
         }
 
+        marking.GlowyBits = markings[index].GlowyBits; // Omu
+
         humanoid.MarkingSet.Replace(category, index, marking);
         Dirty(uid, humanoid);
     }

--- a/Content.Shared/Humanoid/Markings/Marking.cs
+++ b/Content.Shared/Humanoid/Markings/Marking.cs
@@ -47,6 +47,7 @@ namespace Content.Shared.Humanoid.Markings
             _markingColors = new(other.MarkingColors);
             Visible = other.Visible;
             Forced = other.Forced;
+            GlowyBits = other.GlowyBits; // Omu - Glowy markings
         }
 
         /// <summary>
@@ -111,7 +112,8 @@ namespace Content.Shared.Humanoid.Markings
             return MarkingId.Equals(other.MarkingId)
                 && _markingColors.SequenceEqual(other._markingColors)
                 && Visible.Equals(other.Visible)
-                && Forced.Equals(other.Forced);
+                && Forced.Equals(other.Forced)
+                && GlowyBits.Equals(other.GlowyBits); // Omu - Glowy markings
         }
 
         // VERY BIG TODO: TURN THIS INTO JSONSERIALIZER IMPLEMENTATION
@@ -133,7 +135,7 @@ namespace Content.Shared.Humanoid.Markings
             foreach (Color color in _markingColors)
                 colorStringList.Add(color.ToHex());
 
-            return $"{sanitizedName}@{String.Join(',', colorStringList)}";
+            return $"{sanitizedName}@{string.Join(',', colorStringList)}@{GlowyBits}"; // Omu
         }
 
         public static Marking? ParseFromDbString(string input)
@@ -148,7 +150,7 @@ namespace Content.Shared.Humanoid.Markings
                 foreach (string color in split[1].Split(','))
                     colorList.Add(Color.FromHex(color));
 
-                return new Marking(split[0], colorList, 0); // Omu
+                return new Marking(split[0], colorList, 0); // Omu - Glowy markings
             }
 
             if (split.Length == 3)
@@ -168,7 +170,7 @@ namespace Content.Shared.Humanoid.Markings
         /// A bitwise index of which markingColors are glowing.
         /// </summary>
         [DataField]
-        public uint GlowyBits { get; private set; }
+        public uint GlowyBits { get; set; }
         // Omu end
 
         // Omu begin


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
The tails of species with a wagging tail option would stop glowing when they start the tail wag.

This also fixes some glowing things being broken due to upstream merge.

## Why / Balance
Bugfix

## Technical details
Tail wagging uses `HumanoidAppearance.SetMarkingId()` which didn't copy over the glowing bits from the original marking.

## Media
Old, New

[Screencast_20260818_144651.webm](https://github.com/user-attachments/assets/33224ed8-9113-4678-8910-7103fe554a8a)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Quill
- fix: Tails now keep glowing when they start to wag.

