### PR TITLE
Dead drop alterations and additions

### DIFF
--- a/Content.Server/StationEvents/Events/RandomSpawnRule.cs
+++ b/Content.Server/StationEvents/Events/RandomSpawnRule.cs
@@ -39,7 +39,7 @@ public sealed class RandomSpawnRule : StationEventSystem<RandomSpawnRuleComponen
                             code += rand.ToString();
                         }
                         digilock.Code = code;
-                        message += Loc.GetString("dead-drop-code-announcement", ("code", code));        //Omu append code to message
+                        message += $" {Loc.GetString("dead-drop-code-announcement", ("code", code))}";        //Omu append code to message
                     }
                 }
                 _radio.SendRadioMessage(ent, message, radioMessage.Channel, ent);

--- a/Resources/Locale/en-US/_Starlight/station-events/random-spawn-event.ftl
+++ b/Resources/Locale/en-US/_Starlight/station-events/random-spawn-event.ftl
@@ -3,7 +3,7 @@ random-spawn-default-announcement = This entity has been placed near {$location}
 
 # Syndicate dead drop
 syndicate-dead-drop-announcement = A dead drop has been redspaced near {$location}. Collect these tools at your convenience.
-station-syndicate-dead-drop-announcement = Attention. Redspace signatures detected, illegal teleportation of material likely. Please cooperate with your local security department while they secure the unauthorized decive.
+station-syndicate-dead-drop-announcement = Attention. Redspace signatures detected, illegal teleportation of material likely. Please cooperate with your local security department while they secure the unauthorized device.
 
 # omu get code
 dead-drop-code-announcement = The dead drop code is {$code}.

--- a/Resources/Prototypes/_Starlight/Catalog/Fills/Items/briefcases.yml
+++ b/Resources/Prototypes/_Starlight/Catalog/Fills/Items/briefcases.yml
@@ -56,3 +56,12 @@
         - id: BalloonOperative
         - id: LubeGrenade
         - id: GatfruitSeeds
+        # Omu additions
+        - id: Telecrystal10
+        - id: NutrimentImplanter
+        - id: ReinforcementRadioSyndicateSyndiRoach
+        - id: ThrowingknivesKit
+        - id: EmpImplanter
+        - id: ChemicalSynthesisKit
+        - id: HypopenBox
+        - id: SyndicateLollypopBundle

--- a/Resources/Prototypes/_Starlight/Catalog/Fills/Items/briefcases.yml
+++ b/Resources/Prototypes/_Starlight/Catalog/Fills/Items/briefcases.yml
@@ -60,7 +60,7 @@
         - id: Telecrystal10
         - id: NutrimentImplanter
         - id: ReinforcementRadioSyndicateSyndiRoach
-        - id: ThrowingknivesKit
+        - id: ThrowingKnivesKit
         - id: EmpImplanter
         - id: ChemicalSynthesisKit
         - id: HypopenBox

--- a/Resources/Prototypes/_Starlight/GameRules/events.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/events.yml
@@ -6,11 +6,11 @@
   - type: GameRule  #Omu addition to get it to work
     chaosScore: 300
   - type: StationEvent
-    startAnnouncement: station-syndicate-dead-drop-announcement
-    startAudio:
-      path: /Audio/Announcements/attention.ogg
+    endAnnouncement: station-syndicate-dead-drop-announcement # Omu changed to end announcement to allow for 5 minute timer
+    duration: 300 # Omu five minutes
+    #startAudio:      Omu commented so we don't get the syndicate shuttle metagame again - audio plays with no announcment
+    #  path: /Audio/Announcements/attention.ogg
     earliestStart: 15
-    duration: 1
     minimumPlayers: 10
     maxOccurrences: 3 #Omu just having an alternative to antags
     weight: 10


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Changes dead drop station announcement to only play after 5 minutes

Adds additional gamerloot to the table
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
More interesting contra that isn't lighters and pai's

Give agents a better chance at getting some loot
## Technical details
<!-- Summary of code changes for easier review. -->
Yaml additions to the dead drop loot table and changes to the station event comp on the gamerule - no announcement audio and increased duration. Changes the start announcement to the end announcement

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="480" height="222" alt="image" src="https://github.com/user-attachments/assets/5b9adb5e-a3b0-421b-aa1d-6cbcdc765bf6" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Changed dead drops to only announce to crew after 5 minutes
- tweak: added more items to the dead drop loot table
