### PR TITLE
fix cap double shoes for upstream

### DIFF
--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -10,7 +10,6 @@
   - CaptainBackpack
   - CaptainOuterClothing
   - CaptainShoes # Goobstation
-  # - CivilianFormalShoes # Omu moved items to CaptainShoes
   - CaptainPDA # Omu
   - Survival
   - Trinkets

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -10,7 +10,7 @@
   - CaptainBackpack
   - CaptainOuterClothing
   - CaptainShoes # Goobstation
-  - CivilianFormalShoes # Omu
+  # - CivilianFormalShoes # Omu moved items to CaptainShoes
   - CaptainPDA # Omu
   - Survival
   - Trinkets

--- a/Resources/Prototypes/_Goobstation/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Goobstation/Loadouts/loadout_groups.yml
@@ -1284,6 +1284,8 @@
   - LaceupShoes
   - CaptainLeatherShoes
   - CaptainHeels
+  - WhiteShoes #omu
+  - WinterBoots #omu
 
 - type: loadoutGroup
   id: CaptainMask


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
moves the items from formal shoes into the captains shoes tab in the load out and removes the formal shoes option from cap

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
cap was spawning with 2 shoes 

## Technical details
<!-- Summary of code changes for easier review. -->
just some yaml

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="783" height="510" alt="image" src="https://github.com/user-attachments/assets/d03e53be-8489-4458-987a-10a3360e1bc1" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- todo Omustation / License CLA here-->


**Changelog**
:cl:
- fix: fixed cap spawning with 2 pairs of shoes 
