### PR TITLE
Fix deaddrop causing test fail

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Misc/briefcases.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Misc/briefcases.yml
@@ -64,6 +64,9 @@
   name: syndicate briefcase
   suffix: empty
   components:
+    - type: Storage # Omu, give it larger storage to prevent deaddrop causing test fails.
+      grid:
+      - 0,0,7,5
     - type: Sprite
       sprite: _Starlight/Objects/Storage/Briefcases/syndicate_briefcase.rsi
       state: icon


### PR DESCRIPTION
## About the PR
Gave the BriefcaseSyndicateRedspace more storage to prevent dead drops causing test fails.

## Why / Balance
Test fails bad

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- tweak: Increased the storage size of dead drop briefcases to prevent test fails.