### PR TITLE
Lobby message background fix

### DIFF
--- a/Content.Client/Lobby/UI/LobbyGui.xaml
+++ b/Content.Client/Lobby/UI/LobbyGui.xaml
@@ -62,7 +62,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                     <Control VerticalExpand="True" />
                     <!-- Left Bot Panel -->
                     <PanelContainer VerticalAlignment="Bottom" HorizontalAlignment="Left"
-                                    Margin="0 75" StyleClasses="AngleRect">
+                                    Margin="0 75" StyleClasses="BackgroundPanel"> <!-- omu change to correct style -->
                         <RichTextLabel Name="LobbyMessageLabel" Access="Public" Margin="5" />
                     </PanelContainer>
                     <BoxContainer Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Bottom" SeparationOverride="4"> <!-- Goobstation - Lobby Background Credits -->


### PR DESCRIPTION
## About the PR
fixes background on lobby message to proper style

## Why / Balance
its a bug

## Technical details
changed style from outdated `AngleRect` to the newer `BackgroundPanel`

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: lobby message background properly shows after upstream