### PR TITLE
Enabled barks in the dev env

### DIFF
--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -66,3 +66,6 @@ ascension_requires_objectives = false
 random_characters = false
 random_species_weights = ""
 ssd_sleep_time = 3600
+
+[voice]
+barks_enabled = true # Omu


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
Enabled barks in the dev env

## Why / Balance
It's confusing why the voice dropdown doesn't show up in it

## Technical details
development.toml file change

## Media
<img width="649" height="94" alt="image" src="https://github.com/user-attachments/assets/1a534f41-5505-4f6b-ae09-2ad90e698422" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- todo Omustation / License CLA here-->

**Changelog**
No Changelog because it doesn't affect players.

<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
