### PR TITLE
Agent ID's now spawn with their preset access again

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -626,7 +626,7 @@
     tags: [] # ignore "WhitelistChameleon" tag
 
 - type: entity
-  parent: [PassengerIDCard, BaseChameleon]
+  parent: [IDCardStandard, BaseChameleon] # Omu - goob overwrote idcard standard with passenger and caused presets like nukie/wizard ids to not work
   id: AgentIDCard
   suffix: Agent
   components:


### PR DESCRIPTION
## About the PR
fixes preset agent id's (nukies/wizard) spawning with thier accesses

## Why / Balance
its a bug

## Technical details
changed parent from passenger id to idcard standard so it doesnt overwrite

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: agent id's spawn with their preset accesses (Wizard/Nukie) again