### PR TITLE
[Fix] Pre-filled Chem Jug upstream

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/chemical-containers.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/chemical-containers.yml
@@ -10,7 +10,7 @@
     currentLabel: reagent-name-salicylic-acid
   - type: SolutionContainerManager
     solutions:
-      beaker:
+      drink: #Omu -- Beaker --> drink
         reagents:
         - ReagentId: SalicylicAcid
           Quantity: 200
@@ -25,7 +25,7 @@
     currentLabel: reagent-name-oxandrolone
   - type: SolutionContainerManager
     solutions:
-      beaker:
+      drink: #Omu -- Beaker --> drink
         reagents:
         - ReagentId: Oxandrolone
           Quantity: 200
@@ -40,7 +40,7 @@
     currentLabel: reagent-name-holywater
   - type: SolutionContainerManager
     solutions:
-      beaker:
+      drink: #Omu -- Beaker --> drink
         reagents:
         - ReagentId: Holywater
           Quantity: 200


### PR DESCRIPTION
## About the PR
fixes chem jugs using wrong solution container

## Why / Balance
its a bug

## Technical details
changed parent from beaker to drink

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Salic/Oxan/Holy water Pre-filled chemical containers will now spawn properly