### PR TITLE
[Mason Mald PR] Warden loudspeaker on headset

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Ears/headsets_alt.yml
@@ -37,7 +37,7 @@
   - type: Unremoveable
 
 - type: entity
-  parent: [ClothingHeadsetAlt, BaseSecurityContraband]
+  parent: [ClothingHeadsetAltLoudspeaker, BaseSecurityContraband]
   id: ClothingHeadsetAltWarden
   name: warden's over-ear headset
   description: An updated, modular intercom, allowing for rapid communication with command personnel.

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Ears/headsets_alt.yml
@@ -37,7 +37,7 @@
   - type: Unremoveable
 
 - type: entity
-  parent: [ClothingHeadsetAltLoudspeaker, BaseSecurityContraband]
+  parent: [ClothingHeadsetAltLoudspeaker, BaseSecurityContraband] #Omu edit; gave warden loudspeaker
   id: ClothingHeadsetAltWarden
   name: warden's over-ear headset
   description: An updated, modular intercom, allowing for rapid communication with command personnel.


### PR DESCRIPTION
## About the PR
Added loudspeaker to wardens headset

## Why / Balance
Request

## Technical details
changed from parenting off of `ClothingHeadsetAlt` to `ClothingHeadsetAltLoudspeaker`

## Media
<img width="295" height="212" alt="image" src="https://github.com/user-attachments/assets/2f820e39-fd20-4ba3-86e5-700b31f15bb3" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Warden's headset now has a loudspeaker.