### PR TITLE
[Fix] Crash while attempting to anchor held items

### DIFF
--- a/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
+++ b/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
@@ -260,7 +260,6 @@ public sealed partial class AnchorableSystem : EntitySystem
         }
 
         if (transform.ParentUid != uid)
-
         _tool.UseTool(usingUid, userUid, uid, anchorable.Delay, usingTool.Qualities, new TryAnchorCompletedEvent());
     }
 

--- a/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
+++ b/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
@@ -17,6 +17,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics.Components;
 using Content.Shared.Tag;
+using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
@@ -34,6 +35,7 @@ public sealed partial class AnchorableSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
     [Dependency] private   readonly TagSystem _tagSystem = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
 
     private EntityQuery<PhysicsComponent> _physicsQuery;
 
@@ -148,6 +150,14 @@ public sealed partial class AnchorableSystem : EntitySystem
             return;
         }
 
+        // Omu start -- make sure that the item is not in a container or hand
+        if (_containerSystem.IsEntityInContainer(uid) || xform.GridUid == null)
+        {
+            _popup.PopupClient(Loc.GetString("anchorable-inventory"), uid, args.User);
+            return;
+        }
+        //Omu end -- Screams
+
         // Snap rotation to cardinal (multiple of 90)
         var rot = xform.LocalRotation;
         xform.LocalRotation = Math.Round(rot / (Math.PI / 2)) * (Math.PI / 2);
@@ -248,6 +258,8 @@ public sealed partial class AnchorableSystem : EntitySystem
             _popup.PopupClient(Loc.GetString("construction-step-condition-no-unstackable-in-tile"), uid, userUid);
             return;
         }
+
+        if (transform.ParentUid != uid)
 
         _tool.UseTool(usingUid, userUid, uid, anchorable.Delay, usingTool.Qualities, new TryAnchorCompletedEvent());
     }

--- a/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
+++ b/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
@@ -259,7 +259,6 @@ public sealed partial class AnchorableSystem : EntitySystem
             return;
         }
 
-        if (transform.ParentUid != uid)
 
         _tool.UseTool(usingUid, userUid, uid, anchorable.Delay, usingTool.Qualities, new TryAnchorCompletedEvent());
     }

--- a/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
+++ b/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
@@ -259,7 +259,6 @@ public sealed partial class AnchorableSystem : EntitySystem
             return;
         }
 
-
         _tool.UseTool(usingUid, userUid, uid, anchorable.Delay, usingTool.Qualities, new TryAnchorCompletedEvent());
     }
 

--- a/Resources/Locale/en-US/_Omu/anchorable/anchorable-component.ftl
+++ b/Resources/Locale/en-US/_Omu/anchorable/anchorable-component.ftl
@@ -1,0 +1,1 @@
+anchorable-inventory = Cannot anchor item in inventory


### PR DESCRIPTION
## About the PR
Added check to anchoring items to ensure they are not contained within an inventory

## Why / Balance
caused a crash
resolves https://github.com/ProjectOmu/OmuStation/issues/1457

## Technical details
added check to see if item was contained before finishing anchoring

## Media
<img width="431" height="430" alt="image" src="https://github.com/user-attachments/assets/242501ba-1627-4520-a3ef-292844e49b0d" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed crash caused by anchoring held items