### PR TITLE
Laika is no longer locked behind playing less than 5 hours of security.

### DIFF
--- a/Resources/Prototypes/_Omu/Roles/Ghostroles/Generic/generic.yml
+++ b/Resources/Prototypes/_Omu/Roles/Ghostroles/Generic/generic.yml
@@ -53,7 +53,7 @@
   - type: JobRole # Uh oh this is probably a bad idea
   - type: MindRole
     roleType: NanoTrasen
-    jobPrototype: SecurityCadet
+    jobPrototype: SecurityOfficer # Omu -- changed to officer so people wouldnt be locked out of it
     sortWeight: 30
 
 - type: entity


### PR DESCRIPTION
## About the PR
Laika was using sec cadet as a job prototype; changed to sec off so people were not locked out of it

## Why / Balance
its a bug

## Technical details
changed job prototype from sec cadet to sec officer

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Laika is no longer locked behind playing less than 5 hours of security.