### PR TITLE
Port Goob Woundmed Fixes

### DIFF
--- a/Content.Client/_Shitmed/Medical/Surgery/SurgeryBui.cs
+++ b/Content.Client/_Shitmed/Medical/Surgery/SurgeryBui.cs
@@ -152,17 +152,26 @@ public sealed class SurgeryBui : BoundUserInterface
 
             _window.Parts.AddChild(partButton);
 
-            foreach (var surgeryId in surgeries)
-            {
-                if (_system.GetSingleton(surgeryId) is not { } surgery ||
-                    !_entities.TryGetComponent(surgery, out SurgeryComponent? surgeryComp))
-                    continue;
+            if (oldPart != entity)
+                continue;
 
-                if (oldPart == entity && oldSurgery?.Proto == surgeryId)
+            var restored = false;
+            if (oldSurgery != null)
+            {
+                foreach (var surgeryId in surgeries)
+                {
+                    if (oldSurgery.Value.Proto != surgeryId
+                        || _system.GetSingleton(surgeryId) is not { } surgery
+                        || !_entities.TryGetComponent(surgery, out SurgeryComponent? surgeryComp))
+                        continue;
+
                     OnSurgeryPressed((surgery, surgeryComp), netEntity, surgeryId);
+                    restored = true;
+                    break;
+                }
             }
 
-            if (oldPart == entity && oldSurgery == null)
+            if (!restored)
                 OnPartPressed(netEntity, surgeries);
         }
 

--- a/Content.Goobstation.Common/SecondSkin/SecondSkinEvents.cs
+++ b/Content.Goobstation.Common/SecondSkin/SecondSkinEvents.cs
@@ -1,7 +1,7 @@
 namespace Content.Goobstation.Common.SecondSkin;
 
 [ByRefEvent]
-public record struct GetSecondSkinDeductionEvent(int Coverage, int TraumaType, float Deduction = 0f);
+public record struct GetSecondSkinDeductionEvent(int Coverage, string TraumaType, float Deduction = 0f);
 
 [ByRefEvent]
 public record struct ModifyDisgustEvent(float Delta);

--- a/Content.Goobstation.Shared/SecondSkin/SharedSecondSkinSystem.cs
+++ b/Content.Goobstation.Shared/SecondSkin/SharedSecondSkinSystem.cs
@@ -100,7 +100,6 @@ public abstract class SharedSecondSkinSystem : EntitySystem
     private void OnGetDeduction(Entity<SecondSkinUserComponent> ent, ref GetSecondSkinDeductionEvent args)
     {
         var coverage = (BodyPartType) args.Coverage;
-        var type = (TraumaType) args.TraumaType;
 
         if (!Exists(ent.Comp.SecondSkin) || !TryComp(ent.Comp.SecondSkin, out ArmorComponent? comp))
             return;
@@ -108,7 +107,7 @@ public abstract class SharedSecondSkinSystem : EntitySystem
         if (!comp.ArmorCoverage.Contains(coverage))
             return;
 
-        args.Deduction += comp.TraumaDeductions[type].Float();
+        args.Deduction += comp.TraumaDeductions.GetValueOrDefault(args.TraumaType).Float();
     }
 
     private void OnModifyDamage(Entity<SecondSkinUserComponent> ent, ref DamageModifyEvent args)

--- a/Content.Server/Medical/HealthAnalyzerSystem.cs
+++ b/Content.Server/Medical/HealthAnalyzerSystem.cs
@@ -418,7 +418,7 @@ public sealed class HealthAnalyzerSystem : EntitySystem
         {
             foreach (var trauma in traumasFound)
             {
-                if (trauma.Comp.TraumaType == TraumaType.BoneDamage
+                if (trauma.Comp.TraumaType == TraumaSystem.BoneDamage
                     && trauma.Comp.TraumaTarget is { } boneWoundable
                     && TryComp(boneWoundable, out BoneComponent? boneComp))
                 {

--- a/Content.Server/_Shitmed/Body/Systems/EyesSystem.cs
+++ b/Content.Server/_Shitmed/Body/Systems/EyesSystem.cs
@@ -52,10 +52,12 @@ namespace Content.Server._Shitmed.Body.Systems
                 || !TryComp(uid, out OrganComponent? organ)
                 || !organ.Body.HasValue
                 || !TryComp(organ.Body.Value, out BlindableComponent? blindable)
-                || organ.OrganIntegrity <= 0)
+                || organ.OrganIntegrity <= 0
+                || organ.IntegrityCap <= 0)
                 return;
 
-            _blindableSystem.SetEyeDamage((organ.Body.Value, blindable), (int) organ.IntegrityCap - (int) organ.OrganIntegrity); // Omu
+            var lost = 1f - (float) (organ.OrganIntegrity / organ.IntegrityCap);
+            _blindableSystem.SetEyeDamage((organ.Body.Value, blindable), (int) (blindable.MaxDamage * lost));
         }
 
         private void OnOrganEnabled(EntityUid uid, EyesComponent component, OrganEnabledEvent args)
@@ -65,10 +67,10 @@ namespace Content.Server._Shitmed.Body.Systems
             || !TryComp(body, out BlindableComponent? blindable))
                 return;
 
-            // We add the current eye damage since in any context, the organ being enabled means that it was
-            // either removed or disabled, so the BlindableComponent must have some prior damage already.
-            var adjustment = (int)(args.Organ.Comp.IntegrityCap - args.Organ.Comp.OrganIntegrity);
-            _blindableSystem.SetEyeDamage((body, blindable), adjustment);
+            var lost = args.Organ.Comp.IntegrityCap > 0
+                ? 1f - (float) (args.Organ.Comp.OrganIntegrity / args.Organ.Comp.IntegrityCap)
+                : 1f;
+            _blindableSystem.SetEyeDamage((body, blindable), (int) (blindable.MaxDamage * lost));
         }
 
         private void OnOrganDisabled(EntityUid uid, EyesComponent component, OrganDisabledEvent args)

--- a/Content.Server/_Shitmed/Medical/Surgery/SurgerySystem.cs
+++ b/Content.Server/_Shitmed/Medical/Surgery/SurgerySystem.cs
@@ -7,7 +7,6 @@ using Content.Shared.Body.Part;
 using Content.Server.Popups;
 using Content.Shared.Bed.Sleep;
 using Content.Shared.Damage;
-using Content.Shared.Damage.Prototypes;
 using Content.Shared._Shitmed.Targeting;
 using Content.Shared._Shitmed.Damage;
 using Content.Shared._Shitmed.Medical.Surgery;
@@ -17,9 +16,6 @@ using Content.Shared._Shitmed.Medical.Surgery.Effects.Step;
 using Content.Shared._Shitmed.Medical.Surgery.Tools;
 using Robust.Server.GameObjects;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Utility;
-using Content.Shared.Weapons.Melee.Events;
-using System.Linq;
 
 namespace Content.Server._Shitmed.Medical.Surgery;
 
@@ -28,12 +24,9 @@ public sealed class SurgerySystem : SharedSurgerySystem
     [Dependency] private readonly BodySystem _body = default!;
     [Dependency] private readonly ChatSystem _chat = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
-    [Dependency] private readonly IPrototypeManager _prototypes = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly WoundSystem _wounds = default!;
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
-
-    private readonly Dictionary<NetEntity, List<EntProtoId>> _surgeries = new();
 
     public override void Initialize()
     {
@@ -49,7 +42,10 @@ public sealed class SurgerySystem : SharedSurgerySystem
 
     protected override void RefreshUI(EntityUid body)
     {
-        _surgeries.Clear();
+        if (!_ui.IsUiOpen(body, SurgeryUIKey.Key))
+            return;
+
+        var surgeries = new Dictionary<NetEntity, List<EntProtoId>>();
         foreach (var part in _body.GetBodyChildren(body))
         {
             var valid = new List<EntProtoId>();
@@ -66,20 +62,15 @@ public sealed class SurgerySystem : SharedSurgerySystem
 
                 valid.Add(surgery);
             }
-            _surgeries[GetNetEntity(part.Id)] = valid;
+            surgeries[GetNetEntity(part.Id)] = valid;
         }
-        _ui.SetUiState(body, SurgeryUIKey.Key, new SurgeryBuiState(_surgeries));
+        _ui.SetUiState(body, SurgeryUIKey.Key, new SurgeryBuiState(surgeries));
         /*
             Reason we do this is because when applying a BUI State, it rolls back the state on the entity temporarily,
             which just so happens to occur right as we're checking for step completion, so we end up with the UI
             not updating at all until you change tools or reopen the window. I love shitcode.
         */
         _ui.ServerSendUiMessage(body, SurgeryUIKey.Key, new SurgeryBuiRefreshMessage());
-    }
-
-    private DamageGroupPrototype? GetDamageGroupByType(string id)
-    {
-        return (from @group in _prototypes.EnumeratePrototypes<DamageGroupPrototype>() where @group.DamageTypes.Contains(id) select @group).FirstOrDefault();
     }
 
     private void SetDamage(EntityUid body,

--- a/Content.Server/_Shitmed/Medical/Trauma/AddTraumaCommand.cs
+++ b/Content.Server/_Shitmed/Medical/Trauma/AddTraumaCommand.cs
@@ -1,0 +1,95 @@
+using System.Linq;
+using Content.Goobstation.Maths.FixedPoint;
+using Content.Shared.Administration;
+using Content.Shared._Shitmed.Medical.Surgery.Traumas;
+using Content.Shared._Shitmed.Medical.Surgery.Traumas.Systems;
+using Content.Shared._Shitmed.Medical.Surgery.Wounds.Components;
+using Content.Shared.Body.Part;
+using Content.Shared.Body.Systems;
+using Robust.Shared.Console;
+using Robust.Shared.Prototypes;
+using Content.Server.Administration;
+
+namespace Content.Server._Shitmed.Medical.Trauma;
+
+[AdminCommand(AdminFlags.Debug)]
+public sealed class AddTraumaCommand : IConsoleCommand
+{
+    [Dependency] private readonly IEntityManager _entManager = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+
+    public string Command => "addtrauma";
+    public string Description => "Inflicts a trauma on a body, on a specific part type if given.";
+    public string Help => "Usage: addtrauma <target> <traumaType> [partType] [severity]";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length is < 2 or > 4)
+        {
+            shell.WriteError(Loc.GetString("shell-wrong-arguments-number"));
+            return;
+        }
+
+        if (!NetEntity.TryParse(args[0], out var targetNet) || !_entManager.TryGetEntity(targetNet, out var target))
+        {
+            shell.WriteError(Loc.GetString("shell-entity-uid-must-be-number"));
+            return;
+        }
+
+        if (!_proto.HasIndex<TraumaTypePrototype>(args[1]))
+        {
+            shell.WriteError($"No trauma type prototype '{args[1]}'. Known: {string.Join(", ", _proto.EnumeratePrototypes<TraumaTypePrototype>().Select(p => p.ID))}.");
+            return;
+        }
+        var traumaType = new ProtoId<TraumaTypePrototype>(args[1]);
+
+        BodyPartType? partFilter = null;
+        if (args.Length >= 3)
+        {
+            if (!Enum.TryParse<BodyPartType>(args[2], true, out var pt))
+            {
+                shell.WriteError($"Unknown body part type '{args[2]}'. Valid: {string.Join(", ", Enum.GetNames<BodyPartType>())}.");
+                return;
+            }
+            partFilter = pt;
+        }
+
+        var severity = FixedPoint2.New(12);
+        if (args.Length >= 4)
+        {
+            if (!float.TryParse(args[3], out var sev))
+            {
+                shell.WriteError($"Severity '{args[3]}' is not a number.");
+                return;
+            }
+            severity = FixedPoint2.New(sev);
+        }
+
+        var body = _entManager.System<SharedBodySystem>();
+        var trauma = _entManager.System<TraumaSystem>();
+
+        Entity<WoundableComponent>? chosen = null;
+        foreach (var (partId, partComp) in body.GetBodyChildren(target.Value))
+        {
+            if (!_entManager.TryGetComponent<WoundableComponent>(partId, out var woundable)
+                || (partFilter != null && partComp.PartType != partFilter))
+                continue;
+
+            chosen = (partId, woundable);
+            break;
+        }
+
+        if (chosen == null)
+        {
+            shell.WriteError(partFilter != null
+                ? $"No woundable {partFilter} part found on {_entManager.ToPrettyString(target.Value)}."
+                : $"No woundable parts found on {_entManager.ToPrettyString(target.Value)}.");
+            return;
+        }
+
+        if (trauma.TryInflictTrauma(chosen.Value, traumaType, severity))
+            shell.WriteLine($"Inflicted {traumaType} on {_entManager.ToPrettyString(chosen.Value.Owner)}.");
+        else
+            shell.WriteError($"Failed to inflict {traumaType}. The part must be attached to a living body.");
+    }
+}

--- a/Content.Server/_Shitmed/Medical/Trauma/BraindeathSystem.cs
+++ b/Content.Server/_Shitmed/Medical/Trauma/BraindeathSystem.cs
@@ -1,0 +1,41 @@
+using Content.Shared._Shitmed.Body.Organ;
+using Content.Shared._Shitmed.Medical.Surgery.Traumas;
+using Content.Shared._Shitmed.Medical.Surgery.Traumas.Components;
+using Content.Shared.Body.Part;
+
+namespace Content.Server._Shitmed.Medical.Trauma;
+
+public sealed class BraindeathSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<BraindeathComponent, TraumaInducedEvent>(OnInduced);
+        SubscribeLocalEvent<BraindeathComponent, TraumaBeingRemovedEvent>(OnRemoved);
+    }
+
+    private void OnInduced(Entity<BraindeathComponent> ent, ref TraumaInducedEvent args)
+    {
+        if (TryGetBody(args.Trauma.Comp.HoldingWoundable, out var body))
+            EnsureComp<DebrainedComponent>(body);
+    }
+
+    private void OnRemoved(Entity<BraindeathComponent> ent, ref TraumaBeingRemovedEvent args)
+    {
+        if (TryGetBody(args.Trauma.Comp.HoldingWoundable, out var body))
+            RemComp<DebrainedComponent>(body);
+    }
+
+    private bool TryGetBody(EntityUid? woundable, out EntityUid body)
+    {
+        body = default;
+        if (woundable == null
+            || !TryComp<BodyPartComponent>(woundable, out var part)
+            || part.Body == null)
+            return false;
+
+        body = part.Body.Value;
+        return true;
+    }
+}

--- a/Content.Server/_Shitmed/Medical/Trauma/ConstantBleedComponent.cs
+++ b/Content.Server/_Shitmed/Medical/Trauma/ConstantBleedComponent.cs
@@ -1,0 +1,11 @@
+namespace Content.Server._Shitmed.Medical.Trauma;
+
+[RegisterComponent]
+public sealed partial class ConstantBleedComponent : Component
+{
+    /// <summary>
+    /// Total constant bleed floor from all bloodloss traumas currently on this body.
+    /// </summary>
+    [DataField]
+    public float Amount;
+}

--- a/Content.Server/_Shitmed/Medical/Trauma/TraumaBloodlossSystem.cs
+++ b/Content.Server/_Shitmed/Medical/Trauma/TraumaBloodlossSystem.cs
@@ -1,0 +1,75 @@
+using Content.Server.Body.Systems;
+using Content.Shared._Shitmed.Medical.Surgery.Traumas;
+using Content.Shared._Shitmed.Medical.Surgery.Traumas.Components;
+using Content.Shared.Body.Components;
+using Content.Shared.Body.Part;
+using Robust.Shared.Timing;
+
+namespace Content.Server._Shitmed.Medical.Trauma;
+
+public sealed class TraumaBloodlossSystem : EntitySystem
+{
+    [Dependency] private readonly BloodstreamSystem _blood = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    private static readonly TimeSpan UpdateInterval = TimeSpan.FromSeconds(1);
+    private TimeSpan _nextUpdate;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<TraumaBloodlossComponent, TraumaInducedEvent>(OnInduced);
+        SubscribeLocalEvent<TraumaBloodlossComponent, TraumaBeingRemovedEvent>(OnRemoved);
+    }
+
+    private void OnInduced(Entity<TraumaBloodlossComponent> ent, ref TraumaInducedEvent args)
+    {
+        if (!TryGetBody(args.Trauma.Comp.HoldingWoundable, out var body))
+            return;
+
+        var bleed = EnsureComp<ConstantBleedComponent>(body);
+        bleed.Amount += ent.Comp.Amount;
+    }
+
+    private void OnRemoved(Entity<TraumaBloodlossComponent> ent, ref TraumaBeingRemovedEvent args)
+    {
+        if (!TryGetBody(args.Trauma.Comp.HoldingWoundable, out var body)
+            || !TryComp<ConstantBleedComponent>(body, out var bleed))
+            return;
+
+        bleed.Amount -= ent.Comp.Amount;
+        if (bleed.Amount <= 0)
+            RemComp<ConstantBleedComponent>(body);
+    }
+
+    private bool TryGetBody(EntityUid? woundable, out EntityUid body)
+    {
+        body = default;
+        if (woundable == null
+            || !TryComp<BodyPartComponent>(woundable, out var part)
+            || part.Body == null)
+            return false;
+
+        body = part.Body.Value;
+        return true;
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (_timing.CurTime < _nextUpdate)
+            return;
+
+        _nextUpdate = _timing.CurTime + UpdateInterval;
+
+        var query = EntityQueryEnumerator<ConstantBleedComponent, BloodstreamComponent>();
+        while (query.MoveNext(out var uid, out var bleed, out var bloodstream))
+        {
+            var deficit = bleed.Amount - bloodstream.BleedAmountNotFromWounds;
+            if (deficit > 0)
+                _blood.TryModifyBleedAmount((uid, bloodstream), deficit);
+        }
+    }
+}

--- a/Content.Server/_Shitmed/Medical/Trauma/TraumaCauseSystem.cs
+++ b/Content.Server/_Shitmed/Medical/Trauma/TraumaCauseSystem.cs
@@ -1,0 +1,115 @@
+using Content.Goobstation.Maths.FixedPoint;
+using Content.Shared._Shitmed.Medical.Surgery.Traumas;
+using Content.Shared._Shitmed.Medical.Surgery.Traumas.Systems;
+using Content.Shared._Shitmed.Medical.Surgery.Wounds.Components;
+using Content.Shared.Body.Components;
+using Content.Shared.Body.Systems;
+using Content.Shared.Explosion;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+
+namespace Content.Server._Shitmed.Medical.Trauma;
+
+public sealed class TraumaCauseSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly TraumaSystem _trauma = default!;
+    [Dependency] private readonly SharedBodySystem _body = default!;
+
+    private static readonly FixedPoint2 CausedTraumaSeverity = 12;
+
+    private readonly Dictionary<Type, List<(TraumaTypePrototype Proto, TraumaCause Cause)>> _causesByType = new();
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<BodyComponent, BeforeExplodeEvent>(OnBeforeExplode);
+
+        BuildIndex();
+        _prototype.PrototypesReloaded += OnPrototypesReloaded;
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+        _prototype.PrototypesReloaded -= OnPrototypesReloaded;
+    }
+
+    private void OnPrototypesReloaded(PrototypesReloadedEventArgs args)
+    {
+        if (args.WasModified<TraumaTypePrototype>())
+            BuildIndex();
+    }
+
+    private void BuildIndex()
+    {
+        _causesByType.Clear();
+        foreach (var proto in _prototype.EnumeratePrototypes<TraumaTypePrototype>())
+        {
+            if (proto.Causes == null)
+                continue;
+
+            foreach (var cause in proto.Causes)
+            {
+                if (!_causesByType.TryGetValue(cause.GetType(), out var list))
+                {
+                    list = new List<(TraumaTypePrototype, TraumaCause)>();
+                    _causesByType[cause.GetType()] = list;
+                }
+
+                list.Add((proto, cause));
+            }
+        }
+    }
+
+    private void OnBeforeExplode(Entity<BodyComponent> ent, ref BeforeExplodeEvent args)
+    {
+        if (!_causesByType.TryGetValue(typeof(ExplosionCause), out var causes))
+            return;
+
+        var total = args.Damage.GetTotal();
+
+        foreach (var (proto, causeBase) in causes)
+        {
+            var cause = (ExplosionCause) causeBase;
+            if (total < cause.MinDamage)
+                continue;
+
+            var chance = cause.Chance;
+            if (cause.ScaleWithDamage && cause.MinDamage > 0)
+                chance *= (float) (total / cause.MinDamage);
+
+            if (!_random.Prob(Math.Clamp(chance, 0f, 1f)))
+                continue;
+
+            if (TryPickPart(ent, cause, out var part))
+                _trauma.TryInflictTrauma(part, proto.ID, CausedTraumaSeverity);
+        }
+    }
+
+    /// <summary>
+    /// Picks a random attached, non-severed woundable part the cause is allowed to hit.
+    /// </summary>
+    private bool TryPickPart(EntityUid body, TraumaCause cause, out Entity<WoundableComponent> part)
+    {
+        part = default;
+        var candidates = new List<Entity<WoundableComponent>>();
+
+        foreach (var (id, partComp) in _body.GetBodyChildren(body))
+        {
+            if (!TryComp<WoundableComponent>(id, out var woundable)
+                || !cause.PartAllowed(partComp.PartType))
+                continue;
+
+            candidates.Add((id, woundable));
+        }
+
+        if (candidates.Count == 0)
+            return false;
+
+        part = _random.Pick(candidates);
+        return true;
+    }
+}

--- a/Content.Shared/Armor/ArmorComponent.cs
+++ b/Content.Shared/Armor/ArmorComponent.cs
@@ -2,6 +2,7 @@
 
 using Content.Shared.Inventory;
 using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 
@@ -62,13 +63,13 @@ public sealed partial class ArmorComponent : Component
     /// Shitmed Change: The amount of dismemberment chance deduction.
     /// </summary>
     [DataField, Access(Other = AccessPermissions.ReadExecute)] // Goob edit
-    public Dictionary<TraumaType, FixedPoint2> TraumaDeductions = new()
+    public Dictionary<ProtoId<TraumaTypePrototype>, FixedPoint2> TraumaDeductions = new()
     {
-        { TraumaType.Dismemberment, 0 },
-        { TraumaType.BoneDamage, 0 },
-        { TraumaType.OrganDamage, 0 },
-        { TraumaType.VeinsDamage, 0 },
-        { TraumaType.NerveDamage, 0 },
+        { "Dismemberment", 0 },
+        { "BoneDamage", 0 },
+        { "OrganDamage", 0 },
+        { "VeinsDamage", 0 },
+        { "NerveDamage", 0 },
     };
 }
 

--- a/Content.Shared/Body/Organ/OrganComponent.cs
+++ b/Content.Shared/Body/Organ/OrganComponent.cs
@@ -75,6 +75,11 @@ public sealed partial class OrganComponent : Component, ISurgeryToolComponent //
     };
 
     /// <summary>
+    ///     Pre-sorted version of <see cref="IntegrityThresholds"/> in ascending order by value.
+    /// </summary>
+    public KeyValuePair<OrganSeverity, FixedPoint2>[]? SortedIntegrityThresholds;
+
+    /// <summary>
     ///     Shitmed Change: Shitcodey solution to not being able to know what name corresponds to each organ's slot ID
     ///     without referencing the prototype or hardcoding.
     /// </summary>

--- a/Content.Shared/Body/Organ/OrganComponent.cs
+++ b/Content.Shared/Body/Organ/OrganComponent.cs
@@ -35,16 +35,21 @@ public sealed partial class OrganComponent : Component, ISurgeryToolComponent //
     public HashSet<string> AddedKeys = [];
 
     /// <summary>
-    ///     Maximum organ integrity, do keep in mind that Organs are supposed to be VERY and VERY damage sensitive
+    ///     Maximum organ integrity.
     /// </summary>
     [DataField("intCap"), AutoNetworkedField]
-    public FixedPoint2 IntegrityCap = 15;
+    public FixedPoint2 IntegrityCap = 120;
 
     /// <summary>
     ///     Current organ HP, or integrity, whatever you prefer to say
     /// </summary>
     [DataField("integrity"), AutoNetworkedField]
-    public FixedPoint2 OrganIntegrity = 15;
+    public FixedPoint2 OrganIntegrity = 120;
+
+    /// <summary>
+    ///     If true, this organ is never removed/deleted when it reaches Destroyed severity.
+    [DataField, AutoNetworkedField]
+    public bool Indestructible;
 
     /// <summary>
     ///     Current Organ severity, dynamically updated based on organ integrity
@@ -69,8 +74,8 @@ public sealed partial class OrganComponent : Component, ISurgeryToolComponent //
     [DataField] //TEMPORARY: MAKE REQUIRED WHEN EVERY YML HAS THESE.
     public Dictionary<OrganSeverity, FixedPoint2> IntegrityThresholds = new()
     {
-        { OrganSeverity.Normal, 15 },
-        { OrganSeverity.Damaged, 10 },
+        { OrganSeverity.Normal, 120 },
+        { OrganSeverity.Damaged, 60 },
         { OrganSeverity.Destroyed, 0 },
     };
 
@@ -78,6 +83,14 @@ public sealed partial class OrganComponent : Component, ISurgeryToolComponent //
     ///     Pre-sorted version of <see cref="IntegrityThresholds"/> in ascending order by value.
     /// </summary>
     public KeyValuePair<OrganSeverity, FixedPoint2>[]? SortedIntegrityThresholds;
+
+    [DataField]
+    public Dictionary<OrganSeverity, FixedPoint2> HealSeverityFloor = new()
+    {
+        { OrganSeverity.Normal, 0 },
+        { OrganSeverity.Damaged, 10 },
+        { OrganSeverity.Destroyed, 30 },
+    };
 
     /// <summary>
     ///     Shitmed Change: Shitcodey solution to not being able to know what name corresponds to each organ's slot ID

--- a/Content.Shared/Body/Systems/SharedBloodstreamSystem.cs
+++ b/Content.Shared/Body/Systems/SharedBloodstreamSystem.cs
@@ -106,23 +106,20 @@ public abstract partial class SharedBloodstreamSystem : EntitySystem
                     // bloodloss damage is based on the base value, and modified by how low your blood level is.
                     var amt = bloodstream.BloodlossDamage / (0.1f + bloodPercentage);
 
-                    _damageableSystem.TryChangeDamage(uid, amt, ignoreResistances: false, interruptsDoAfters: false);
-                // Goobstation start
-                var multiplierEv = new GetBloodlossDamageMultiplierEvent();
-                RaiseLocalEvent(uid, multiplierEv);
-                amt *= multiplierEv.Multiplier;
+                    // Goobstation start
+                    var multiplierEv = new GetBloodlossDamageMultiplierEvent();
+                    RaiseLocalEvent(uid, multiplierEv);
+                    amt *= multiplierEv.Multiplier;
 
+                    _damageableSystem.TryChangeDamage(uid, amt,
+                        ignoreResistances: false, interruptsDoAfters: false,
+                        splitDamage: SplitDamageBehavior.SplitEnsureAll, targetPart: TargetBodyPart.All);
+                    // Goobstation end
 
-                _damageableSystem.TryChangeDamage(uid, amt,
-                    ignoreResistances: false, interruptsDoAfters: false,
-                    splitDamage: SplitDamageBehavior.SplitEnsureAll, targetPart: TargetBodyPart.All);
-
-                // Goobstation end
-
-                // Apply dizziness as a symptom of bloodloss.
-                // The effect is applied in a way that it will never be cleared without being healthy.
-                // Multiplying by 2 is arbitrary but works for this case, it just prevents the time from running out
-                _status.TrySetStatusEffectDuration(uid, Bloodloss);
+                    // Apply dizziness as a symptom of bloodloss.
+                    // The effect is applied in a way that it will never be cleared without being healthy.
+                    // Multiplying by 2 is arbitrary but works for this case, it just prevents the time from running out
+                    _status.TrySetStatusEffectDuration(uid, Bloodloss);
                 }
                 else if (!_mobStateSystem.IsDead(uid))
                 {
@@ -158,9 +155,11 @@ public abstract partial class SharedBloodstreamSystem : EntitySystem
                     totalPartBleeds += bleeds.BleedingAmount; // Goobstation
                 }
 
-                if (TryComp<WoundableComponent>(bodyPart, out var woundable)) // Goobstation
+                if (TryComp<WoundableComponent>(bodyPart, out var woundable)
+                    && woundable.Bleeds != totalPartBleeds) // Goobstation
                 {
                     woundable.Bleeds = totalPartBleeds; // Goobstation
+                    Dirty(bodyPart, woundable); // Goobstation
                 }
             }
 

--- a/Content.Shared/EntityEffects/Effects/EvenHealthChangeEntityEffectSystem.cs
+++ b/Content.Shared/EntityEffects/Effects/EvenHealthChangeEntityEffectSystem.cs
@@ -2,6 +2,7 @@
 using Content.Shared.Damage.Prototypes;
 using Content.Goobstation.Maths.FixedPoint;
 using Content.Shared._Shitmed.EntityEffects.Effects;
+using Content.Shared._Shitmed.Damage;
 using Content.Shared.Localizations;
 using Content.Shared.Temperature.Components;
 using Robust.Shared.Prototypes;
@@ -37,7 +38,13 @@ public sealed partial class EvenHealthChangeEntityEffectSystem : EntityEffectSys
             {
                 spec.DamageDict[type] = healing / groupProto.DamageTypes.Count;
             }
-            _damageable.TryChangeDamage(entity, spec, ignoreResistances: args.Effect.IgnoreResistances);
+
+            _damageable.TryChangeDamage(
+                    entity,
+                    spec,
+                    ignoreResistances: args.Effect.IgnoreResistances,
+                    interruptsDoAfters: false,
+                    splitDamage: args.Effect.SplitDamage); // Goob
             // </Goob>
         }
     }
@@ -57,6 +64,9 @@ public sealed partial class EvenHealthChange : EntityEffectBase<EvenHealthChange
     /// </summary>
     [DataField]
     public bool IgnoreResistances = true;
+
+    [DataField]
+    public SplitDamageBehavior SplitDamage = SplitDamageBehavior.SplitEnsureAllOrganic; // Goob , need for shitmed
 
     /// <summary>
     /// Shitmed - How to scale the effect based on the temperature of the target entity.

--- a/Content.Shared/EntityEffects/Effects/HealthChangeEntityEffectSystem.cs
+++ b/Content.Shared/EntityEffects/Effects/HealthChangeEntityEffectSystem.cs
@@ -2,6 +2,8 @@
 using Content.Shared.Damage.Prototypes;
 using Content.Goobstation.Maths.FixedPoint;
 using Content.Shared._Shitmed.EntityEffects.Effects;
+using Content.Shared._Shitmed.Targeting;
+using Content.Shared._Shitmed.Damage;
 using Content.Shared.Localizations;
 using Content.Shared.Temperature.Components;
 using Robust.Shared.Prototypes;
@@ -31,13 +33,16 @@ public sealed partial class HealthChangeEntityEffectSystem : EntityEffectSystem<
 
             damageSpec *= scaleTemp.GetEfficiencyMultiplier(temp.CurrentTemperature, args.Scale, false);
         }
-        // Goobstation End
 
         _damageable.TryChangeDamage(
                 entity,
                 damageSpec,
                 args.Effect.IgnoreResistances,
-                interruptsDoAfters: false);
+                interruptsDoAfters: false,
+                targetPart: args.Effect.UseTargeting ? args.Effect.TargetPart : null,
+                ignoreBlockers: args.Effect.IgnoreBlockers,
+                splitDamage: args.Effect.SplitDamage);
+        // Goobstation End
     }
 }
 
@@ -52,6 +57,22 @@ public sealed partial class HealthChange : EntityEffectBase<HealthChange>
 
     [DataField]
     public bool IgnoreResistances = true;
+
+    // Goobstation-start
+    [DataField]
+    public SplitDamageBehavior SplitDamage = SplitDamageBehavior.SplitEnsureAllOrganic;
+
+    [DataField]
+    public bool UseTargeting = true;
+
+    [DataField]
+    public TargetBodyPart TargetPart = TargetBodyPart.All;
+
+    // Respect wound heal-blockers/floors by default so a broken-bone limb can't be fully healed by chems
+    // Set true on a specific reagent to bypass.
+    [DataField]
+    public bool IgnoreBlockers;
+    // Goobstation-end
 
     [DataField]
     public TemperatureScaling? ScaleByTemperature;

--- a/Content.Shared/Eye/Blinding/Systems/BlindableSystem.cs
+++ b/Content.Shared/Eye/Blinding/Systems/BlindableSystem.cs
@@ -97,7 +97,10 @@ public sealed class BlindableSystem : EntitySystem
 
         // for now
         foreach (var eye in eyes)
-            _trauma.TryMakeOrganDamageModifier(eye.Owner, amount, blindable.Owner, "BlindableDamage", eye.Comp2); // Omu
+        {
+            if (!_trauma.TryChangeOrganDamageModifier(eye.Owner, amount, blindable.Owner, "BlindableDamage", eye.Comp2))
+                _trauma.TryCreateOrganDamageModifier(eye.Owner, amount, blindable.Owner, "BlindableDamage", eye.Comp2);
+        }
     }
 
     // Alternative version of the method intended to be used with Eye Organs, so that you can just pass in

--- a/Content.Shared/Medical/Healing/HealingSystem.cs
+++ b/Content.Shared/Medical/Healing/HealingSystem.cs
@@ -386,16 +386,8 @@ public sealed class HealingSystem : EntitySystem
                 targetedWoundable = woundablesQueue.Dequeue();
                 if (!TryComp<WoundableComponent>(targetedWoundable, out var woundableComp2))
                     continue;
-                if (TraumaSystem.TraumasBlockingHealing.Any(traumaType => _trauma.HasWoundableTrauma(targetedWoundable, traumaType, woundableComp2, false)))
-                {
-                    canHeal = false;
-
-                    if (!healedBleedLevel)
-                    {
-                        leftoverHealAndTrauma = true;
-                        continue;
-                    }
-                }
+                if (_trauma.HasHealingBlockingTrauma(targetedWoundable, woundableComp2) && !healedBleedLevel)
+                    leftoverHealAndTrauma = true;
 
                 if (canHeal)
                 {
@@ -405,7 +397,7 @@ public sealed class HealingSystem : EntitySystem
                         continue;
                     }
 
-                    var damageChanged = _damageable.TryChangeDamage(targetedWoundable, healingLeft, true, origin: args.User, ignoreBlockers: healedBleed || healing.BloodlossModifier == 0); // GOOBEDIT
+                    var damageChanged = _damageable.TryChangeDamage(targetedWoundable, healingLeft, true, origin: args.User, ignoreBlockers: false);
 
                     if (damageChanged is not null)
                     {

--- a/Content.Shared/_Shitcode/Heretic/Systems/Abilities/SharedHereticAbilitySystem.cs
+++ b/Content.Shared/_Shitcode/Heretic/Systems/Abilities/SharedHereticAbilitySystem.cs
@@ -8,6 +8,7 @@ using Content.Shared._Shitmed.Damage;
 using Content.Shared._Shitmed.Medical.Surgery.Consciousness;
 using Content.Shared._Shitmed.Medical.Surgery.Consciousness.Components;
 using Content.Shared._Shitmed.Medical.Surgery.Consciousness.Systems;
+using Content.Shared._Shitmed.Medical.Surgery.Pain.Components;
 using Content.Shared._Shitmed.Medical.Surgery.Pain.Systems;
 using Content.Shared._Shitmed.Medical.Surgery.Traumas.Components;
 using Content.Shared._Shitmed.Medical.Surgery.Traumas.Systems;
@@ -367,15 +368,18 @@ public abstract partial class SharedHereticAbilitySystem : EntitySystem
                         uid.Comp3.NerveSystem.Comp);
                 }
 
-                foreach (var nerve in uid.Comp3.NerveSystem.Comp.Nerves)
+                foreach (var nerveEnt in uid.Comp3.NerveSystem.Comp.Nerves)
                 {
-                    foreach (var painFeelsModifier in nerve.Value.PainFeelingModifiers)
+                    if (!TryComp<NerveComponent>(nerveEnt, out var nerve))
+                        continue;
+
+                    foreach (var painFeelsModifier in nerve.PainFeelingModifiers)
                     {
                         // Idk what it does, just remove it
                         _pain.TryRemovePainFeelsModifier(painFeelsModifier.Key.Item1,
                             painFeelsModifier.Key.Item2,
-                            nerve.Key,
-                            nerve.Value);
+                            nerveEnt,
+                            nerve);
                     }
                 }
             }

--- a/Content.Shared/_Shitcode/Wizard/SanguineStrike/SharedSanguineStrikeSystem.cs
+++ b/Content.Shared/_Shitcode/Wizard/SanguineStrike/SharedSanguineStrikeSystem.cs
@@ -101,34 +101,7 @@ public abstract class SharedSanguineStrikeSystem : EntitySystem
         if (Resolve(uid, ref consciousness, false))
         {
             if (consciousness.NerveSystem != default)
-            {
-                foreach (var painModifier in consciousness.NerveSystem.Comp.Modifiers)
-                {
-                    _pain.TryRemovePainModifier(consciousness.NerveSystem.Owner,
-                        painModifier.Key.Item1,
-                        painModifier.Key.Item2,
-                        consciousness.NerveSystem.Comp);
-                }
-
-                foreach (var painMultiplier in consciousness.NerveSystem.Comp.Multipliers)
-                {
-                    _pain.TryRemovePainMultiplier(consciousness.NerveSystem.Owner,
-                        painMultiplier.Key,
-                        consciousness.NerveSystem.Comp);
-                }
-
-
-                foreach (var nerve in consciousness.NerveSystem.Comp.Nerves)
-                {
-                    foreach (var painFeelsModifier in nerve.Value.PainFeelingModifiers)
-                    {
-                        _pain.TryRemovePainFeelsModifier(painFeelsModifier.Key.Item1,
-                            painFeelsModifier.Key.Item2,
-                            nerve.Key,
-                            nerve.Value);
-                    }
-                }
-            }
+                _pain.RemoveAllPainEffects(consciousness.NerveSystem);
 
             foreach (var multiplier in
                      consciousness.Multipliers.Where(multiplier => multiplier.Value.Type == ConsciousnessModType.Pain))

--- a/Content.Shared/_Shitmed/Surgery/Conditions/SurgeryTraumaPresentConditionComponent.cs
+++ b/Content.Shared/_Shitmed/Surgery/Conditions/SurgeryTraumaPresentConditionComponent.cs
@@ -1,5 +1,6 @@
 using Content.Shared._Shitmed.Medical.Surgery.Traumas;
 using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared._Shitmed.Medical.Surgery.Conditions;
 
@@ -7,7 +8,7 @@ namespace Content.Shared._Shitmed.Medical.Surgery.Conditions;
 public sealed partial class SurgeryTraumaPresentConditionComponent : Component
 {
     [DataField("trauma")]
-    public TraumaType TraumaType = TraumaType.BoneDamage;
+    public ProtoId<TraumaTypePrototype> TraumaType = "BoneDamage";
 
     [DataField]
     public bool Inverted = false;

--- a/Content.Shared/_Shitmed/Surgery/Conditions/SurgeryTraumaTreatableConditionComponent.cs
+++ b/Content.Shared/_Shitmed/Surgery/Conditions/SurgeryTraumaTreatableConditionComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Shitmed.Medical.Surgery.Conditions;
+
+/// <summary>
+/// Surgery is valid while the part carries any surgically-treatable trauma.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class SurgeryTraumaTreatableConditionComponent : Component
+{
+    [DataField]
+    public bool Inverted;
+}

--- a/Content.Shared/_Shitmed/Surgery/Consciousness/Systems/ConsciousnessSystem.Helpers.cs
+++ b/Content.Shared/_Shitmed/Surgery/Consciousness/Systems/ConsciousnessSystem.Helpers.cs
@@ -38,6 +38,9 @@ public partial class ConsciousnessSystem
         if (!TryComp<ConsciousnessComponent>(body, out var consciousness))
             return false;
 
+        if (consciousness.NerveSystem.Comp is null || TerminatingOrDeleted(consciousness.NerveSystem.Owner))
+            return false;
+
         nerveSys = consciousness.NerveSystem;
         return true;
     }
@@ -113,9 +116,9 @@ public partial class ConsciousnessSystem
         if (!Resolve(uid, ref consciousness))
             return;
 
-        var totalDamage
-            = consciousness.Modifiers.Aggregate(FixedPoint2.Zero,
-                (current, modifier) => current + modifier.Value.Change * consciousness.Multiplier);
+        var totalDamage = FixedPoint2.Zero;
+        foreach (var modifier in consciousness.Modifiers)
+            totalDamage += modifier.Value.Change;
 
         consciousness.RawConsciousness = consciousness.Cap + totalDamage;
 

--- a/Content.Shared/_Shitmed/Surgery/Consciousness/Systems/ConsciousnessSystem.Process.cs
+++ b/Content.Shared/_Shitmed/Surgery/Consciousness/Systems/ConsciousnessSystem.Process.cs
@@ -36,11 +36,17 @@ public partial class ConsciousnessSystem
 
             consciousness.NextConsciousnessUpdate = _timing.CurTime + consciousness.ConsciousnessUpdateTime;
 
-            foreach (var modifier in consciousness.Modifiers.Where(modifier => modifier.Value.Time < _timing.CurTime))
-                RemoveConsciousnessModifier(ent, modifier.Key.Item1, modifier.Key.Item2, consciousness);
+            foreach (var (key, modifier) in consciousness.Modifiers)
+            {
+                if (modifier.Time < _timing.CurTime)
+                    RemoveConsciousnessModifier(ent, key.Item1, key.Item2, consciousness);
+            }
 
-            foreach (var multiplier in consciousness.Multipliers.Where(multiplier => multiplier.Value.Time < _timing.CurTime))
-                RemoveConsciousnessMultiplier(ent, multiplier.Key.Item1, multiplier.Key.Item2, consciousness);
+            foreach (var (key, multiplier) in consciousness.Multipliers)
+            {
+                if (multiplier.Time < _timing.CurTime)
+                    RemoveConsciousnessMultiplier(ent, key.Item1, key.Item2, consciousness);
+            }
 
             if (consciousness.PassedOutTime < _timing.CurTime && consciousness.PassedOut)
             {
@@ -76,22 +82,7 @@ public partial class ConsciousnessSystem
     private void OnRejuvenate(EntityUid uid, ConsciousnessComponent component, RejuvenateEvent args)
     {
         if (component.NerveSystem != default)
-        {
-            foreach (var painModifier in component.NerveSystem.Comp.Modifiers)
-                _pain.TryRemovePainModifier(component.NerveSystem.Owner,
-                    painModifier.Key.Item1,
-                    painModifier.Key.Item2,
-                    component.NerveSystem.Comp);
-
-            foreach (var painMultiplier in component.NerveSystem.Comp.Multipliers)
-                _pain.TryRemovePainMultiplier(component.NerveSystem.Owner,
-                    painMultiplier.Key,
-                    component.NerveSystem.Comp);
-
-            foreach (var nerve in component.NerveSystem.Comp.Nerves)
-                foreach (var painFeelsModifier in nerve.Value.PainFeelingModifiers)
-                    _pain.TryRemovePainFeelsModifier(painFeelsModifier.Key.Item1, painFeelsModifier.Key.Item2, nerve.Key, nerve.Value);
-        }
+            _pain.RemoveAllPainEffects(component.NerveSystem);
 
         foreach (var multiplier in
                  component.Multipliers.Where(multiplier => multiplier.Value.Type == ConsciousnessModType.Pain))

--- a/Content.Shared/_Shitmed/Surgery/Consciousness/Systems/ConsciousnessSystem.cs
+++ b/Content.Shared/_Shitmed/Surgery/Consciousness/Systems/ConsciousnessSystem.cs
@@ -5,7 +5,6 @@ using Robust.Shared.Timing;
 
 namespace Content.Shared._Shitmed.Medical.Surgery.Consciousness.Systems;
 
-[Virtual]
 public sealed partial class ConsciousnessSystem : EntitySystem
 {
     [Dependency] private readonly INetManager _net = default!;

--- a/Content.Shared/_Shitmed/Surgery/Pain/Components/NerveSystemComponent.cs
+++ b/Content.Shared/_Shitmed/Surgery/Pain/Components/NerveSystemComponent.cs
@@ -31,7 +31,7 @@ public sealed partial class NerveSystemComponent : Component
 
     // Don't change, OR I will break your knees, filled up upon initialization.
     [ViewVariables(VVAccess.ReadOnly)]
-    public Dictionary<EntityUid, NerveComponent> Nerves = new();
+    public HashSet<EntityUid> Nerves = new();
 
     // Don't add manually!! Use built-in functions.
     [ViewVariables(VVAccess.ReadOnly)]
@@ -66,6 +66,9 @@ public sealed partial class NerveSystemComponent : Component
     public TimeSpan UpdateTime;
     public TimeSpan ReactionUpdateTime;
     public TimeSpan NextCritScream;
+
+    [ViewVariables(VVAccess.ReadOnly)]
+    public TimeSpan NextUpdate;
 
     [DataField("painShockStun")]
     public TimeSpan PainShockStunTime = TimeSpan.FromSeconds(2f);
@@ -249,4 +252,9 @@ public sealed partial class NerveSystemComponent : Component
         // :troll:
         { PainThresholdTypes.PainShockAndAgony, 85 },
     };
+
+    /// <summary>
+    /// Pre-sorted version of <see cref="PainThresholds"/> in descending order by value.
+    /// </summary>
+    public KeyValuePair<PainThresholdTypes, FixedPoint2>[]? SortedPainThresholds;
 }

--- a/Content.Shared/_Shitmed/Surgery/Pain/Systems/PainSystem.Damage.cs
+++ b/Content.Shared/_Shitmed/Surgery/Pain/Systems/PainSystem.Damage.cs
@@ -23,6 +23,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Content.Shared._Shitmed.Medical.Surgery.Traumas.Systems;
 
 namespace Content.Shared._Shitmed.Medical.Surgery.Pain.Systems;
 
@@ -660,7 +661,7 @@ public partial class PainSystem
                     sex = humanoid.Sex;
 
                 CleanupSounds(nerveSys);
-                if (_trauma.HasBodyTrauma(body, TraumaType.OrganDamage) && _random.Prob(0.22f))
+                if (_trauma.HasBodyTrauma(body, TraumaSystem.OrganDamage) && _random.Prob(0.22f))
                 {
                     // If the person suffers organ damage, do funny gaggling sound :3
                     PlayPainSound(body,

--- a/Content.Shared/_Shitmed/Surgery/Pain/Systems/PainSystem.Damage.cs
+++ b/Content.Shared/_Shitmed/Surgery/Pain/Systems/PainSystem.Damage.cs
@@ -122,25 +122,14 @@ public partial class PainSystem
         if (!Resolve(uid, ref nerveSys, false))
             return false;
 
-        // Create a modifier for WoundPain
-        var woundModifier = new PainModifier(
+        var modifier = new PainModifier(
             change,
-            MetaData(nerveUid).EntityPrototype!.ID,
-            PainDamageTypes.WoundPain,
+            MetaData(nerveUid).EntityPrototype?.ID ?? string.Empty,
+            painType,
             _timing.CurTime + time
         );
 
-        // Create a modifier for TraumaticPain
-        var traumaModifier = new PainModifier(
-            change,
-            MetaData(nerveUid).EntityPrototype!.ID,
-            PainDamageTypes.TraumaticPain,
-            _timing.CurTime + time
-        );
-
-        // Add both modifiers
-        nerveSys.Modifiers[(nerveUid, $"{identifier}_wound")] = woundModifier;
-        nerveSys.Modifiers[(nerveUid, $"{identifier}_trauma")] = traumaModifier;
+        nerveSys.Modifiers[(nerveUid, identifier)] = modifier;
 
         var ev = new PainModifierAddedEvent(uid, nerveUid, change);
         RaiseLocalEvent(uid, ref ev);
@@ -232,7 +221,7 @@ public partial class PainSystem
 
         var modifierToSet =
             modifier with { Change = change };
-        nerve.PainFeelingModifiers[(nerveUid, identifier)] = modifierToSet;
+        nerve.PainFeelingModifiers[(effectOwner, identifier)] = modifierToSet;
 
         UpdatePainFeels(nerveUid);
 
@@ -266,7 +255,7 @@ public partial class PainSystem
 
         var modifierToSet =
             modifier with { Change = change, Time = _timing.CurTime + time ?? modifier.Time };
-        nerve.PainFeelingModifiers[(nerveUid, identifier)] = modifierToSet;
+        nerve.PainFeelingModifiers[(effectOwner, identifier)] = modifierToSet;
 
         UpdatePainFeels(nerveUid);
 
@@ -300,7 +289,7 @@ public partial class PainSystem
 
         var modifierToSet =
             modifier with { Change = change ?? modifier.Change, Time = _timing.CurTime + time };
-        nerve.PainFeelingModifiers[(nerveUid, identifier)] = modifierToSet;
+        nerve.PainFeelingModifiers[(effectOwner, identifier)] = modifierToSet;
 
         UpdatePainFeels(nerveUid);
 
@@ -588,7 +577,7 @@ public partial class PainSystem
         if (screamString != null)
             _popup.PopupPredicted(screamString, body, null, PopupType.MediumCaution);
 
-        nerveSys.PainSoundsToPlay.Add(body, (specifier, audioParams, _timing.CurTime + delay));
+        nerveSys.PainSoundsToPlay[body] = (specifier, audioParams, _timing.CurTime + delay);
     }
 
     #endregion
@@ -713,11 +702,15 @@ public partial class PainSystem
             if (_timing.CurTime > value.Time)
                 shouldUpdate |= TryRemovePainMultiplier(nerveSysEnt, key, nerveSys);
 
-        // I hate myself.
-        foreach (var (ent, nerve) in nerveSys.Nerves)
-            foreach (var (key, value) in nerve.PainFeelingModifiers.ToList())
+        foreach (var ent in nerveSys.Nerves)
+        {
+            if (!TryComp<NerveComponent>(ent, out var nerve))
+                continue;
+
+            foreach (var (key, value) in nerve.PainFeelingModifiers)
                 if (_timing.CurTime > value.Time)
                     shouldUpdate |= TryRemovePainFeelsModifier(key.Item1, key.Item2, ent, nerve);
+        }
 
         if (shouldUpdate
             && _net.IsServer)
@@ -751,34 +744,50 @@ public partial class PainSystem
             nerveSys.ReactionUpdateTime = _timing.CurTime + nerveSys.PainReactionTime;
         nerveSys.Pain = newPain;
 
-        if (!_consciousness.SetConsciousnessModifier(
-                organ.Body.Value,
-                uid,
-                -nerveSys.Pain,
-                identifier: PainModifierIdentifier,
-                type: ConsciousnessModType.Pain))
+        UpdatePainConsciousness(uid, nerveSys);
+    }
+
+    private void UpdatePainConsciousness(EntityUid uid, NerveSystemComponent nerveSys)
+    {
+        if (!TryComp<OrganComponent>(uid, out var organ) || organ.Body == null)
+            return;
+
+        _consciousness.SetConsciousnessModifier(
+            organ.Body.Value,
+            uid,
+            -nerveSys.Pain,
+            identifier: PainModifierIdentifier,
+            type: ConsciousnessModType.Pain);
+    }
+
+    public void RemoveAllPainEffects(Entity<NerveSystemComponent> nerveSys)
+    {
+        foreach (var key in new List<(EntityUid, string)>(nerveSys.Comp.Modifiers.Keys))
+            TryRemovePainModifier(nerveSys, key.Item1, key.Item2, nerveSys.Comp);
+
+        foreach (var key in new List<string>(nerveSys.Comp.Multipliers.Keys))
+            TryRemovePainMultiplier(nerveSys, key, nerveSys.Comp);
+
+        foreach (var nerveEnt in nerveSys.Comp.Nerves)
         {
-            _consciousness.AddConsciousnessModifier(
-                organ.Body.Value,
-                uid,
-                -nerveSys.Pain,
-                identifier: PainModifierIdentifier,
-                type: ConsciousnessModType.Pain);
+            if (!TryComp<NerveComponent>(nerveEnt, out var nerve))
+                continue;
+
+            foreach (var key in new List<(EntityUid, string)>(nerve.PainFeelingModifiers.Keys))
+                TryRemovePainFeelsModifier(key.Item1, key.Item2, nerveEnt, nerve);
         }
     }
 
     private void CleanupSounds(NerveSystemComponent nerveSys)
     {
-        foreach (var (id, _) in nerveSys.PlayedPainSounds.Where(sound => !TerminatingOrDeleted(sound.Key)))
+        foreach (var (id, _) in nerveSys.PlayedPainSounds)
         {
-            _IHaveNoMouthAndIMustScream.Stop(id);
-            nerveSys.PlayedPainSounds.Remove(id);
+            if (!TerminatingOrDeleted(id))
+                _IHaveNoMouthAndIMustScream.Stop(id);
         }
 
-        foreach (var (id, _) in nerveSys.PainSoundsToPlay.Where(sound => !TerminatingOrDeleted(sound.Key)))
-        {
-            nerveSys.PainSoundsToPlay.Remove(id);
-        }
+        nerveSys.PlayedPainSounds.Clear();
+        nerveSys.PainSoundsToPlay.Clear();
     }
 
     private void ApplyPainReflexesEffects(EntityUid body, Entity<NerveSystemComponent> nerveSys, PainThresholdTypes reaction)
@@ -861,7 +870,8 @@ public partial class PainSystem
         var painInput = nerveSys.Pain - nerveSys.LastPainThreshold;
 
         var nearestReflex = PainThresholdTypes.None;
-        foreach (var (reflex, threshold) in nerveSys.PainThresholds.OrderByDescending(kv => kv.Value))
+        nerveSys.SortedPainThresholds ??= nerveSys.PainThresholds.OrderByDescending(kv => kv.Value).ToArray();
+        foreach (var (reflex, threshold) in nerveSys.SortedPainThresholds)
         {
             if (painInput < threshold)
                 continue;
@@ -905,15 +915,22 @@ public partial class PainSystem
             return pain;
 
         var modifiedPain = pain * nerve.PainMultiplier;
-        if (nerveSys.Multipliers.Count == 0)
+
+        var toMultiply = FixedPoint2.Zero;
+        var matching = 0;
+        foreach (var multiplier in nerveSys.Multipliers.Values)
+        {
+            if (multiplier.PainDamageType != painType)
+                continue;
+
+            toMultiply += multiplier.Change;
+            matching++;
+        }
+
+        if (matching == 0)
             return modifiedPain;
 
-        var toMultiply =
-            nerveSys.Multipliers
-                .Where(markiplier => markiplier.Value.PainDamageType == painType)
-                .Aggregate(FixedPoint2.Zero, (current, markiplier) => current + markiplier.Value.Change);
-
-        return modifiedPain * toMultiply / nerveSys.Multipliers.Count; // o(*^＠^*)o
+        return modifiedPain * toMultiply / matching;
     }
 
     #endregion

--- a/Content.Shared/_Shitmed/Surgery/Pain/Systems/PainSystem.cs
+++ b/Content.Shared/_Shitmed/Surgery/Pain/Systems/PainSystem.cs
@@ -21,12 +21,10 @@ using Robust.Shared.GameStates;
 using Robust.Shared.Network;
 using Robust.Shared.Timing;
 using Robust.Shared.Random;
-using System.Linq;
 using Content.Goobstation.Maths.FixedPoint;
 
 namespace Content.Shared._Shitmed.Medical.Surgery.Pain.Systems;
 
-[Virtual]
 public sealed partial class PainSystem : EntitySystem
 {
     [Dependency] private readonly INetManager _net = default!;
@@ -50,6 +48,9 @@ public sealed partial class PainSystem : EntitySystem
 
     private bool _screamsEnabled = false;
     private float _screamChance = 0.20f;
+
+    private static readonly TimeSpan PainUpdateInterval = TimeSpan.FromSeconds(0.2);
+
     public override void Initialize()
     {
         base.Initialize();
@@ -71,10 +72,11 @@ public sealed partial class PainSystem : EntitySystem
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
-        _painJobQueue.Process();
 
         if (!_timing.IsFirstTimePredicted)
             return;
+
+        _painJobQueue.Process();
 
         // Process pain decay for all entities with active decay
         var decayQuery = EntityQueryEnumerator<PainDecayComponent, NerveSystemComponent>();
@@ -90,9 +92,10 @@ public sealed partial class PainSystem : EntitySystem
         using var query = EntityQueryEnumerator<NerveSystemComponent>();
         while (query.MoveNext(out var ent, out var nerveSystem))
         {
-            if (TerminatingOrDeleted(ent))
+            if (TerminatingOrDeleted(ent) || _timing.CurTime < nerveSystem.NextUpdate)
                 continue;
 
+            nerveSystem.NextUpdate = _timing.CurTime + PainUpdateInterval;
             _painJobQueue.EnqueueJob(new PainTimerJob(this, (ent, nerveSystem), PainJobTime));
         }
     }
@@ -153,9 +156,20 @@ public sealed partial class PainSystem : EntitySystem
         if (!_consciousness.TryGetNerveSystem(bodyPart.Body.Value, out var brainUid) || TerminatingOrDeleted(brainUid.Value))
             return;
 
-        foreach (var modifier in brainUid.Value.Comp.Modifiers
-                     .Where(modifier => modifier.Key.Item1 == uid))
-            brainUid.Value.Comp.Modifiers.Remove((modifier.Key.Item1, modifier.Key.Item2));
+        var removedAny = false;
+        foreach (var key in new List<(EntityUid, string)>(brainUid.Value.Comp.Modifiers.Keys))
+        {
+            if (key.Item1 != uid)
+                continue;
+
+            removedAny |= brainUid.Value.Comp.Modifiers.Remove(key);
+        }
+
+        if (removedAny)
+        {
+            UpdateNerveSystemPain(brainUid.Value, brainUid.Value.Comp);
+            Dirty(brainUid.Value.Owner, brainUid.Value.Comp);
+        }
 
         UpdateNerveSystemNerves(brainUid.Value, bodyPart.Body.Value, Comp<NerveSystemComponent>(brainUid.Value));
     }
@@ -187,12 +201,13 @@ public sealed partial class PainSystem : EntitySystem
             if (!TryComp<NerveComponent>(bodyPart.Id, out var nerve))
                 continue;
 
-            component.Nerves.Add(bodyPart.Id, nerve);
-            Dirty(uid, component);
+            component.Nerves.Add(bodyPart.Id);
 
             nerve.ParentedNerveSystem = uid;
             Dirty(bodyPart.Id, nerve); // ヾ(≧▽≦*)o
         }
+
+        Dirty(uid, component);
     }
 
     #region Pain Decay
@@ -243,6 +258,7 @@ public sealed partial class PainSystem : EntitySystem
             nerveSystem.Pain = FixedPoint2.Zero;
             Dirty(uid, nerveSystem);
             RemComp<PainDecayComponent>(uid);
+            UpdatePainConsciousness(uid, nerveSystem);
             return;
         }
 
@@ -255,6 +271,7 @@ public sealed partial class PainSystem : EntitySystem
         {
             nerveSystem.Pain = currentPain;
             Dirty(uid, nerveSystem);
+            UpdatePainConsciousness(uid, nerveSystem);
         }
     }
 

--- a/Content.Shared/_Shitmed/Surgery/SharedBloodstreamSystem.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedBloodstreamSystem.cs
@@ -28,42 +28,50 @@ public abstract partial class SharedBloodstreamSystem
 
     private void InitializeWounds()
     {
-        base.Initialize();
-
         SubscribeLocalEvent<BleedInflicterComponent, WoundSeverityPointChangedEvent>(OnBleedInflicterSeverityUpdate);
         SubscribeLocalEvent<BleedRemoverComponent, WoundSeverityPointChangedEvent>(OnBleedRemoverSeverityUpdate);
         SubscribeLocalEvent<BleedInflicterComponent, WoundHealAttemptEvent>(OnWoundHealAttempt);
         SubscribeLocalEvent<BleedInflicterComponent, WoundAddedEvent>(OnWoundAdded);
     }
 
+    private static readonly TimeSpan WoundBleedUpdateInterval = TimeSpan.FromSeconds(1);
+    private TimeSpan _nextWoundBleedUpdate;
+
     private void UpdateWounds(float frameTime)
     {
-        base.Update(frameTime);
+        if (_timing.CurTime < _nextWoundBleedUpdate)
+            return;
+
+        _nextWoundBleedUpdate = _timing.CurTime + WoundBleedUpdateInterval;
 
         var bleedsQuery = EntityQueryEnumerator<BleedInflicterComponent>();
         while (bleedsQuery.MoveNext(out var ent, out var bleeds))
         {
             var canBleed = CanWoundBleed(ent, bleeds) && bleeds.BleedingAmount > 0;
             if (canBleed != bleeds.IsBleeding)
+            {
+                bleeds.IsBleeding = canBleed;
                 Dirty(ent, bleeds);
+            }
 
-            bleeds.IsBleeding = canBleed;
-
-            if (!bleeds.IsBleeding)
+            if (!bleeds.IsBleeding || bleeds.Scaling >= bleeds.ScalingLimit)
                 continue;
 
-            var totalTime = bleeds.ScalingFinishesAt - bleeds.ScalingStartsAt;
-            var currentTime = bleeds.ScalingFinishesAt - _timing.CurTime;
-
-            if (totalTime <= currentTime || bleeds.ScalingLimit >= bleeds.Scaling)
+            var start = bleeds.ScalingStartsAt;
+            var end = bleeds.ScalingFinishesAt;
+            if (end <= start)
                 continue;
 
-            var newBleeds = FixedPoint2.Clamp(
-                (totalTime / currentTime) / (bleeds.ScalingLimit - bleeds.Scaling),
-                0,
-                bleeds.ScalingLimit);
+            var progress = (_timing.CurTime - start).TotalSeconds / (end - start).TotalSeconds;
+            if (progress <= 0)
+                continue;
 
-            bleeds.Scaling = newBleeds;
+            var target = FixedPoint2.New(1) + (bleeds.ScalingLimit - 1) * FixedPoint2.New(Math.Min(progress, 1.0));
+            var newScaling = FixedPoint2.Clamp(target, bleeds.Scaling, bleeds.ScalingLimit);
+            if (newScaling == bleeds.Scaling)
+                continue;
+
+            bleeds.Scaling = newScaling;
             Dirty(ent, bleeds);
         }
     }
@@ -281,8 +289,6 @@ public abstract partial class SharedBloodstreamSystem
         component.IsBleeding = true;
 
         Dirty(uid, component);
-
-        TryModifyBleedAmount(uid, component.BleedingAmountRaw.Float());
     }
 
     private void OnWoundHealAttempt(EntityUid uid, BleedInflicterComponent component, ref WoundHealAttemptEvent args)
@@ -305,11 +311,7 @@ public abstract partial class SharedBloodstreamSystem
             || args.NewSeverity < args.OldSeverity)
             return;
 
-        var oldBleedsAmount = args.OldSeverity * _cfg.GetCVar(SurgeryCVars.BleedingSeverityTrade);
         component.BleedingAmountRaw = args.NewSeverity * _cfg.GetCVar(SurgeryCVars.BleedingSeverityTrade);
-
-        var severityPenalty = component.BleedingAmountRaw - oldBleedsAmount / _cfg.GetCVar(SurgeryCVars.BleedsScalingTime);
-        component.SeverityPenalty += severityPenalty;
 
         var formula = (float) (args.NewSeverity / _cfg.GetCVar(SurgeryCVars.BleedsScalingTime) * component.ScalingSpeed);
         component.ScalingFinishesAt = _timing.CurTime + TimeSpan.FromSeconds(formula);

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
@@ -30,6 +30,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 using System.Linq;
 using Content.Shared._Shitmed.Surgery;
+using Content.Shared._Shitmed.Medical.Surgery.Traumas.Systems;
 using Content.Shared._Mono.CorticalBorer; // mono
 
 namespace Content.Shared._Shitmed.Medical.Surgery;
@@ -72,6 +73,7 @@ public abstract partial class SharedSurgerySystem
         SubSurgery<SurgeryRemoveMarkingStepComponent>(OnRemoveMarkingStep, OnRemoveMarkingCheck);
         SubSurgery<SurgeryAddOrganSlotStepComponent>(OnAddOrganSlotStep, OnAddOrganSlotCheck);
         SubSurgery<SurgeryTraumaTreatmentStepComponent>(OnTraumaTreatmentStep, OnTraumaTreatmentCheck);
+        SubSurgery<SurgeryTraumaExtractStepComponent>(OnExtractTraumaStep, OnExtractTraumaCheck);
         SubSurgery<SurgeryBleedsTreatmentStepComponent>(OnBleedsTreatmentStep, OnBleedsTreatmentCheck);
         SubSurgery<SurgeryStepPainInflicterComponent>(OnPainInflicterStep, OnPainInflicterCheck);
         Subs.BuiEvents<SurgeryTargetComponent>(SurgeryUIKey.Key, subs =>
@@ -530,61 +532,85 @@ public abstract partial class SharedSurgerySystem
     private void OnTraumaTreatmentStep(Entity<SurgeryTraumaTreatmentStepComponent> ent, ref SurgeryStepEvent args)
     {
         var healAmount = ent.Comp.Amount;
-        switch (ent.Comp.TraumaType)
+        var traumaType = ent.Comp.TraumaType;
+
+        if (traumaType == TraumaSystem.OrganDamage)
         {
-            case TraumaType.OrganDamage:
-                foreach (var organ in _body.GetBodyOrgans(args.Body))
+            foreach (var organ in _body.GetBodyOrgans(args.Body))
+            {
+                foreach (var modifier in organ.Component.IntegrityModifiers)
                 {
-                    foreach (var modifier in organ.Component.IntegrityModifiers)
+                    var delta = healAmount - modifier.Value;
+                    if (delta > 0)
                     {
-                        var delta = healAmount - modifier.Value;
-                        if (delta > 0)
-                        {
-                            healAmount -= modifier.Value;
-                            _trauma.TryRemoveOrganDamageModifier(
-                                organ.Id,
-                                modifier.Key.Item2,
-                                modifier.Key.Item1,
-                                organ.Component);
-                        }
-                        else
-                        {
-                            _trauma.TryChangeOrganDamageModifier(
-                                organ.Id,
-                                -healAmount,
-                                modifier.Key.Item2,
-                                modifier.Key.Item1,
-                                organ.Component);
-                            break;
-                        }
+                        healAmount -= modifier.Value;
+                        _trauma.TryRemoveOrganDamageModifier(
+                            organ.Id,
+                            modifier.Key.Item2,
+                            modifier.Key.Item1,
+                            organ.Component);
+                    }
+                    else
+                    {
+                        _trauma.TryChangeOrganDamageModifier(
+                            organ.Id,
+                            -healAmount,
+                            modifier.Key.Item2,
+                            modifier.Key.Item1,
+                            organ.Component);
+                        break;
                     }
                 }
+            }
+        }
+        else if (traumaType == TraumaSystem.BoneDamage)
+        {
+            if (!TryComp<WoundableComponent>(args.Part, out var woundable))
+                return;
 
-                break;
+            var bone = woundable.Bone.ContainedEntities.FirstOrNull();
+            if (bone == null || !TryComp<BoneComponent>(bone, out var boneComp))
+                return;
 
-            case TraumaType.BoneDamage:
-                if (!TryComp<WoundableComponent>(args.Part, out var woundable))
-                    return;
+            _trauma.ApplyDamageToBone(bone.Value, -healAmount, boneComp);
+        }
+        else if (traumaType == TraumaSystem.Dismemberment)
+        {
+            if (_trauma.TryGetWoundableTrauma(args.Part, out var traumas, TraumaSystem.Dismemberment))
+                foreach (var trauma in traumas)
+                    _trauma.RemoveTrauma(trauma);
+        }
+        else if (traumaType == TraumaSystem.Braindeath)
+        {
+            if (_trauma.TryGetWoundableTrauma(args.Part, out var traumas, TraumaSystem.Braindeath))
+            {
+                foreach (var trauma in traumas)
+                {
+                    if (trauma.Comp.TraumaTarget is { } organ)
+                        _trauma.RestoreOrganIntegrity(organ);
 
-                var bone = woundable.Bone.ContainedEntities.FirstOrNull();
-                if (bone == null || !TryComp<BoneComponent>(bone, out var boneComp))
-                    return;
-
-                _trauma.ApplyDamageToBone(bone.Value, -healAmount, boneComp);
-                break;
-
-            case TraumaType.Dismemberment:
-                if (_trauma.TryGetWoundableTrauma(args.Part, out var traumas, TraumaType.Dismemberment))
-                    foreach (var trauma in traumas)
-                        _trauma.RemoveTrauma(trauma);
-
-                break;
+                    _trauma.RemoveTrauma(trauma);
+                }
+            }
         }
     }
 
     private void OnTraumaTreatmentCheck(Entity<SurgeryTraumaTreatmentStepComponent> ent, ref SurgeryStepCompleteCheckEvent args)
     {
         if (_trauma.HasWoundableTrauma(args.Part, ent.Comp.TraumaType))
+            args.Cancelled = true;
+    }
+
+    private void OnExtractTraumaStep(Entity<SurgeryTraumaExtractStepComponent> ent, ref SurgeryStepEvent args)
+    {
+        if (_trauma.TryGetSurgicallyTreatableTraumas(args.Part, out var traumas))
+            foreach (var trauma in traumas)
+                _trauma.RemoveTrauma(trauma);
+    }
+
+    private void OnExtractTraumaCheck(Entity<SurgeryTraumaExtractStepComponent> ent, ref SurgeryStepCompleteCheckEvent args)
+    {
+        if (_trauma.TryGetSurgicallyTreatableTraumas(args.Part, out _))
             args.Cancelled = true;
     }
 

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Goobstation.Maths.FixedPoint;
 using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Markings;
 using Content.Shared.Bed.Sleep;
@@ -166,7 +167,7 @@ public abstract partial class SharedSurgerySystem
             args.Invalid = StepInvalidReason.MissingTool;
 
             if (reg.Component is ISurgeryToolComponent required)
-                args.Popup = $"You need {required.ToolName} to perform this step!";
+                args.Popup = Loc.GetString("surgery-ui-window-steps-error-missing-tool", ("tool", required.ToolName));
             else
                 Log.Error($"Surgery step {ToPrettyString(ent)} wants bad component {reg.Component} which isn't a ISurgeryTool");
 
@@ -187,11 +188,6 @@ public abstract partial class SharedSurgerySystem
         }
     }
 
-    private string GetDamageGroupByType(string id)
-    {
-        return (from @group in _prototypes.EnumeratePrototypes<DamageGroupPrototype>() where @group.DamageTypes.Contains(id) select @group.ID).FirstOrDefault()!;
-    }
-
     private void OnTendWoundsStep(Entity<SurgeryTendWoundsEffectComponent> ent, ref SurgeryStepEvent args)
     {
         if (_wounds.GetWoundableSeverityPoint(
@@ -210,7 +206,10 @@ public abstract partial class SharedSurgerySystem
 
         var group = _prototypes.Index<DamageGroupPrototype>(ent.Comp.MainGroup);
         foreach (var type in group.DamageTypes)
-            adjustedDamage.DamageDict[type] -= bonus;
+        {
+            if (adjustedDamage.DamageDict.TryGetValue(type, out var current))
+                adjustedDamage.DamageDict[type] = current - bonus;
+        }
 
         var ev = new SurgeryStepDamageEvent(args.User, args.Body, args.Part, args.Surgery, adjustedDamage, 0.5f);
         RaiseLocalEvent(args.Body, ref ev);
@@ -235,9 +234,9 @@ public abstract partial class SharedSurgerySystem
             && TryComp(activeHandEntity, out ItemComponent? itemComp)
             && (itemComp.Size.Id == "Tiny"
             || itemComp.Size.Id == "Small"))
-            _itemSlotsSystem.TryInsert(ent, partComp.ItemInsertionSlot, activeHandEntity, args.User);
+            _itemSlotsSystem.TryInsert(args.Part, partComp.ItemInsertionSlot, activeHandEntity, args.User);
         else if (ent.Comp.Action == "Remove")
-            _itemSlotsSystem.TryEjectToHands(ent, partComp.ItemInsertionSlot, args.User);
+            _itemSlotsSystem.TryEjectToHands(args.Part, partComp.ItemInsertionSlot, args.User);
     }
 
     private void OnCavityCheck(Entity<SurgeryStepCavityEffectComponent> ent, ref SurgeryStepCompleteCheckEvent args)
@@ -245,11 +244,11 @@ public abstract partial class SharedSurgerySystem
         // Normally this check would simply be partComp.ItemInsertionSlot.HasItem, but as mentioned before,
         // For whatever reason it's not instantiating the field on the clientside after the wizmerge.
         if (!_partQuery.TryComp(args.Part, out var partComp)
-            || !TryComp(args.Part, out ItemSlotsComponent? itemComp)
+            || !_itemSlotsSystem.TryGetSlot(args.Part, partComp.ContainerName, out var slot)
             || ent.Comp.Action == "Insert"
-            && !itemComp.Slots[partComp.ContainerName].HasItem
+            && !slot.HasItem
             || ent.Comp.Action == "Remove"
-            && itemComp.Slots[partComp.ContainerName].HasItem)
+            && slot.HasItem)
             args.Cancelled = true;
     }
 
@@ -594,21 +593,24 @@ public abstract partial class SharedSurgerySystem
         var healAmount = ent.Comp.Amount;
         foreach (var woundEnt in _wounds.GetWoundableWounds(args.Part))
         {
-            if (!TryComp<BleedInflicterComponent>(woundEnt, out var bleeds))
+            if (healAmount <= 0)
+                break;
+
+            if (!TryComp<BleedInflicterComponent>(woundEnt, out var bleeds) || !bleeds.IsBleeding)
                 continue;
 
             if (bleeds.Scaling > healAmount)
             {
                 bleeds.Scaling -= healAmount;
+                bleeds.ScalingLimit = FixedPoint2.Min(bleeds.ScalingLimit, bleeds.Scaling);
+                healAmount = FixedPoint2.Zero;
             }
             else
             {
+                healAmount -= bleeds.Scaling;
                 bleeds.BleedingAmountRaw = 0;
                 bleeds.Scaling = 0;
-
                 bleeds.IsBleeding = false; // Won't bleed as long as it's not reopened
-
-                healAmount -= bleeds.Scaling;
             }
 
             Dirty(woundEnt, bleeds);
@@ -663,7 +665,7 @@ public abstract partial class SharedSurgerySystem
 
     private void OnPainInflicterCheck(Entity<SurgeryStepPainInflicterComponent> ent, ref SurgeryStepCompleteCheckEvent args)
     {
-        if (!_consciousness.TryGetNerveSystem(args.Part, out var nerveSys))
+        if (!_consciousness.TryGetNerveSystem(args.Body, out var nerveSys))
             return;
 
         if (!_pain.TryGetPainModifier(nerveSys.Value.Owner, args.Part, "SurgeryPain", out _, nerveSys))
@@ -885,9 +887,6 @@ public abstract partial class SharedSurgerySystem
         var toolUsed = data?.Used ?? false; // if no tool is being used you can't consume it
         var ev = new SurgeryDoAfterEvent(surgeryId, stepId, toolUsed);
         var duration = GetSurgeryDuration(step, user, body, speed);
-
-        if (TryComp(user, out SurgerySpeedModifierComponent? surgerySpeedMod))
-            duration = duration / surgerySpeedMod.SpeedModifier;
 
         var doAfter = new DoAfterArgs(EntityManager, user, TimeSpan.FromSeconds(duration), ev, body, part)
         {

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.cs
@@ -9,6 +9,7 @@ using Content.Shared._Shitmed.Medical.Surgery.Steps;
 using Content.Shared._Shitmed.Medical.Surgery.Steps.Parts;
 using Content.Shared._Shitmed.Medical.Surgery.Wounds.Systems;
 using Content.Shared._Shitmed.Medical.Surgery.Wounds.Components;
+using Content.Shared._Shitmed.Medical.Surgery.Traumas.Components;
 using Content.Shared._Shitmed.Medical.Surgery.Traumas.Systems;
 using Content.Shared._Shitmed.Surgery;
 using Content.Shared.Buckle.Components;
@@ -105,6 +106,7 @@ public abstract partial class SharedSurgerySystem : EntitySystem
         SubscribeLocalEvent<SurgeryOrganSlotConditionComponent, SurgeryValidEvent>(OnOrganSlotConditionValid);
         SubscribeLocalEvent<SurgeryPartPresentConditionComponent, SurgeryValidEvent>(OnPartPresentConditionValid);
         SubscribeLocalEvent<SurgeryTraumaPresentConditionComponent, SurgeryValidEvent>(OnTraumaPresentConditionValid);
+        SubscribeLocalEvent<SurgeryTraumaTreatableConditionComponent, SurgeryValidEvent>(OnTraumaTreatableConditionValid);
         SubscribeLocalEvent<SurgeryBleedsPresentConditionComponent, SurgeryValidEvent>(OnBleedsPresentConditionValid);
         SubscribeLocalEvent<SurgeryMarkingConditionComponent, SurgeryValidEvent>(OnMarkingPresentValid);
         SubscribeLocalEvent<SurgeryBodyComponentConditionComponent, SurgeryValidEvent>(OnBodyComponentConditionValid);
@@ -210,12 +212,14 @@ public abstract partial class SharedSurgerySystem : EntitySystem
 
     private void OnWoundedValid(Entity<SurgeryWoundedConditionComponent> ent, ref SurgeryValidEvent args)
     {
-        if (!TryComp(args.Part, out WoundableComponent? partWoundable)
-            || _wounds.GetWoundableSeverityPoint(
-                args.Part,
-                partWoundable,
-                ent.Comp.DamageGroup,
-                healable: true) <= 0)
+        if (!TryComp(args.Part, out WoundableComponent? partWoundable))
+        {
+            args.Cancelled = true;
+            return;
+        }
+
+        if (_wounds.GetWoundableSeverityPoint(args.Part, partWoundable, ent.Comp.DamageGroup, healable: true) <= 0
+            && !HasComp<IncisionOpenComponent>(args.Part))
             args.Cancelled = true;
     }
 
@@ -384,6 +388,15 @@ public abstract partial class SharedSurgerySystem : EntitySystem
             args.Cancelled = true;
     }
 
+    private void OnTraumaTreatableConditionValid(Entity<SurgeryTraumaTreatableConditionComponent> ent, ref SurgeryValidEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        if (_trauma.TryGetSurgicallyTreatableTraumas(args.Part, out _) == ent.Comp.Inverted)
+            args.Cancelled = true;
+    }
+
     private void OnBleedsPresentConditionValid(Entity<SurgeryBleedsPresentConditionComponent> ent, ref SurgeryValidEvent args)
     {
         if (!TryComp<WoundableComponent>(args.Part, out var woundable))
@@ -392,9 +405,26 @@ public abstract partial class SharedSurgerySystem : EntitySystem
             return;
         }
 
-        if (ent.Comp.Inverted == woundable.Bleeds > 0
-            && !HasComp<BleedersClampedComponent>(args.Part))
-            args.Cancelled = true;
+        var bleeding = false;
+        foreach (var woundEnt in _wounds.GetWoundableWounds(args.Part, woundable))
+        {
+            if (TryComp<BleedInflicterComponent>(woundEnt, out var bleeds) && bleeds.IsBleeding)
+            {
+                bleeding = true;
+                break;
+            }
+        }
+
+        if (ent.Comp.Inverted)
+        {
+            if (bleeding && !HasComp<BleedersClampedComponent>(args.Part))
+                args.Cancelled = true;
+        }
+        else
+        {
+            if (!bleeding)
+                args.Cancelled = true;
+        }
     }
 
     private void OnMarkingPresentValid(Entity<SurgeryMarkingConditionComponent> ent, ref SurgeryValidEvent args)

--- a/Content.Shared/_Shitmed/Surgery/Steps/SurgeryTraumaExtractStepComponent.cs
+++ b/Content.Shared/_Shitmed/Surgery/Steps/SurgeryTraumaExtractStepComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Shitmed.Medical.Surgery.Steps;
+
+/// <summary>
+/// A surgery step that removes every surgically-treatable trauma on the target part.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class SurgeryTraumaExtractStepComponent : Component;

--- a/Content.Shared/_Shitmed/Surgery/Steps/SurgeryTraumaTreatmentStepComponent.cs
+++ b/Content.Shared/_Shitmed/Surgery/Steps/SurgeryTraumaTreatmentStepComponent.cs
@@ -1,6 +1,7 @@
 using Content.Shared._Shitmed.Medical.Surgery.Traumas;
 using Content.Goobstation.Maths.FixedPoint;
 using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared._Shitmed.Medical.Surgery.Steps;
 
@@ -8,7 +9,7 @@ namespace Content.Shared._Shitmed.Medical.Surgery.Steps;
 public sealed partial class SurgeryTraumaTreatmentStepComponent : Component
 {
     [DataField]
-    public TraumaType TraumaType = TraumaType.BoneDamage;
+    public ProtoId<TraumaTypePrototype> TraumaType = "BoneDamage";
 
     [DataField]
     public FixedPoint2 Amount = 5;

--- a/Content.Shared/_Shitmed/Surgery/Traumas/Components/BleedInflicterComponent.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/Components/BleedInflicterComponent.cs
@@ -38,9 +38,6 @@ public sealed partial class BleedInflicterComponent : Component
     public FixedPoint2 ScalingSpeed = FixedPoint2.New(1);
 
     [ViewVariables(VVAccess.ReadOnly), AutoNetworkedField]
-    public FixedPoint2 SeverityPenalty = FixedPoint2.New(1);
-
-    [ViewVariables(VVAccess.ReadOnly), AutoNetworkedField]
     public FixedPoint2 Scaling = FixedPoint2.New(1);
 
     [DataField, ViewVariables(VVAccess.ReadOnly), AutoNetworkedField]

--- a/Content.Shared/_Shitmed/Surgery/Traumas/Components/BoneComponent.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/Components/BoneComponent.cs
@@ -20,5 +20,14 @@ public sealed partial class BoneComponent : Component
     public BoneSeverity BoneSeverity = BoneSeverity.Normal;
 
     [DataField]
+    public Dictionary<BoneSeverity, FixedPoint2> HealSeverityFloor = new()
+    {
+        { BoneSeverity.Normal, 0 },
+        { BoneSeverity.Damaged, 5 },
+        { BoneSeverity.Cracked, 10 },
+        { BoneSeverity.Broken, 30 },
+    };
+
+    [DataField]
     public SoundSpecifier BoneBreakSound = new SoundCollectionSpecifier("BoneGone");
 }

--- a/Content.Shared/_Shitmed/Surgery/Traumas/Components/BonelessComponent.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/Components/BonelessComponent.cs
@@ -10,7 +10,7 @@ public sealed partial class BonelessComponent : Component
     /// The higher it is, the lower the chance to delimb.
     /// A perfectly healed bone is equivalent to 1.
     /// A destroyed bone is 0.
-    /// See TraumaSystem.Process.cs RandomDismembermentTraumaChance method
+    /// See the DismembermentChance provider in TraumaChance.cs
     /// </summary>
     [ViewVariables, DataField]
     public FixedPoint2 BonePenalty = 1;

--- a/Content.Shared/_Shitmed/Surgery/Traumas/Components/BraindeathComponent.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/Components/BraindeathComponent.cs
@@ -1,0 +1,6 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Shitmed.Medical.Surgery.Traumas.Components;
+
+[RegisterComponent]
+public sealed partial class BraindeathComponent : Component;

--- a/Content.Shared/_Shitmed/Surgery/Traumas/Components/OrganDeathTraumaComponent.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/Components/OrganDeathTraumaComponent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._Shitmed.Medical.Surgery.Traumas.Components;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class OrganDeathTraumaComponent : Component
+{
+    [DataField(required: true)]
+    public ProtoId<TraumaTypePrototype> Trauma;
+}

--- a/Content.Shared/_Shitmed/Surgery/Traumas/Components/TraumaBloodlossComponent.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/Components/TraumaBloodlossComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Shitmed.Medical.Surgery.Traumas.Components;
+
+[RegisterComponent]
+public sealed partial class TraumaBloodlossComponent : Component
+{
+    /// <summary>
+    /// Constant bleed floor this trauma maintains on the body while embedded.
+    /// </summary>
+    [DataField]
+    public float Amount = 0.6f;
+}

--- a/Content.Shared/_Shitmed/Surgery/Traumas/Components/TraumaComponent.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/Components/TraumaComponent.cs
@@ -1,5 +1,6 @@
 using Content.Goobstation.Maths.FixedPoint;
 using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Content.Shared.Body.Part;
 
@@ -43,7 +44,7 @@ public sealed partial class TraumaComponent : Component
     /// Self-explanatory
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadOnly)]
-    public TraumaType TraumaType;
+    public ProtoId<TraumaTypePrototype> TraumaType;
 }
 
 // The networking on consciousness is rather silly.
@@ -54,5 +55,5 @@ public sealed class TraumaComponentState : ComponentState
     public NetEntity? TraumaTarget;
     public (BodyPartType, BodyPartSymmetry)? TargetType;
     public FixedPoint2 TraumaSeverity;
-    public TraumaType TraumaType;
+    public ProtoId<TraumaTypePrototype> TraumaType;
 }

--- a/Content.Shared/_Shitmed/Surgery/Traumas/Components/TraumaInflicterComponent.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/Components/TraumaInflicterComponent.cs
@@ -21,46 +21,27 @@ public sealed partial class TraumaInflicterComponent : Component
     public Container TraumaContainer = new();
 
     /// <summary>
-    /// I like optimisation. So, instead of putting a '-1' in TraumasChance, just remove it from allowed traumas
-    /// </summary>
-    [DataField(required: true), AutoNetworkedField]
-    public List<TraumaType> AllowedTraumas = new();
-
-    /// <summary>
     /// If present in the list, when trauma of the said type is applied, the armour will be counted in to the deduction
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadOnly)]
-    public List<TraumaType> AllowArmourDeduction = new();
+    public List<ProtoId<TraumaTypePrototype>> AllowArmourDeduction = new();
 
     /// <summary>
-    /// If you feel like customizing this for different species, go on.
+    /// Optional per-inflicter override of the entity spawned for a trauma type.
+    /// When a type is not present here, <see cref="TraumaTypePrototype.TraumaEntity"/> is used.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadOnly)]
-    public Dictionary<TraumaType, EntProtoId> TraumaPrototypes = new()
-    {
-        { TraumaType.Dismemberment, "Dismemberment" },
-        { TraumaType.OrganDamage, "OrganDamage" },
-        { TraumaType.BoneDamage, "BoneDamage" },
-        { TraumaType.NerveDamage, "NerveDamage" },
-        { TraumaType.VeinsDamage, "VeinsDamage" },
-    };
+    public Dictionary<ProtoId<TraumaTypePrototype>, EntProtoId> TraumaPrototypes = new();
 
     /// <summary>
     /// Additional chance (-1, 0, 1) that is added in chance calculation
     /// </summary>
     [DataField, AutoNetworkedField]
-    public Dictionary<TraumaType, FixedPoint2> TraumasChances = new()
-    {
-        { TraumaType.Dismemberment, 0 },
-        { TraumaType.OrganDamage, 0 },
-        { TraumaType.BoneDamage, 0 },
-        { TraumaType.NerveDamage, 0 },
-        { TraumaType.VeinsDamage, 0 },
-    };
+    public Dictionary<ProtoId<TraumaTypePrototype>, FixedPoint2> TraumasChances = new();
 
     /// <summary>
     /// When a wound is mangled, any receiving damage will be multiplied by these values and applied to the respective body elements.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public Dictionary<TraumaType, FixedPoint2>? MangledMultipliers;
+    public Dictionary<ProtoId<TraumaTypePrototype>, FixedPoint2>? MangledMultipliers;
 }

--- a/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Bones.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Bones.cs
@@ -8,12 +8,13 @@ using Content.Shared._Shitmed.Weapons.Ranged.Events;
 using Content.Shared.Body.Components;
 using Content.Shared.Body.Part;
 using Content.Goobstation.Maths.FixedPoint;
+using Content.Shared.Bed.Sleep;
 using Content.Shared.Movement.Components;
 using Content.Shared.Popups;
 using Content.Shared.Standing;
+using Content.Shared.Stunnable;
 using Robust.Shared.Audio;
 using Robust.Shared.Utility;
-using Robust.Shared.Random;
 using System.Linq;
 
 namespace Content.Shared._Shitmed.Medical.Surgery.Traumas.Systems;
@@ -94,9 +95,9 @@ public partial class TraumaSystem
     {
         args.Multiplier *= bone.Comp.BoneSeverity switch
         {
-            BoneSeverity.Damaged => 0.92f,
-            BoneSeverity.Cracked => 0.84f,
-            BoneSeverity.Broken => 0.75f,
+            BoneSeverity.Damaged => 1.09f,
+            BoneSeverity.Cracked => 1.19f,
+            BoneSeverity.Broken => 1.33f,
             _ => 1f,
         };
     }
@@ -117,7 +118,7 @@ public partial class TraumaSystem
             || bodyPart.Body is not { } body)
             return;
 
-        if (TryFumble("arm-fumble", new SoundPathSpecifier("/Audio/Effects/slip.ogg"), body, odds))
+        if (_wound.TryFumble("arm-fumble", new SoundPathSpecifier("/Audio/Effects/slip.ogg"), body, odds))
         {
             args.Handled = true;
             args.Cancel();
@@ -140,7 +141,7 @@ public partial class TraumaSystem
             || bodyPart.Body is not { } body)
             return;
 
-        if (TryFumble("arm-fumble", new SoundPathSpecifier("/Audio/Effects/slip.ogg"), body, odds))
+        if (_wound.TryFumble("arm-fumble", new SoundPathSpecifier("/Audio/Effects/slip.ogg"), body, odds))
             args.Handled = true;
     }
 
@@ -255,7 +256,7 @@ public partial class TraumaSystem
     {
         var nearestSeverity = boneComp.BoneSeverity;
 
-        foreach (var (severity, value) in _boneThresholds.OrderByDescending(kv => kv.Value))
+        foreach (var (severity, value) in BoneThresholds)
         {
             if (boneComp.BoneIntegrity < value)
                 continue;
@@ -282,7 +283,7 @@ public partial class TraumaSystem
 
     private void ProcessLegsState(EntityUid body, BodyComponent? bodyComp = null)
     {
-        if (!Resolve(body, ref bodyComp))
+        if (!Resolve(body, ref bodyComp) || bodyComp.RequiredLegs <= 0)
             return;
 
         var rawWalkSpeed = 0f; // just used to compare to actual speed values
@@ -299,10 +300,8 @@ public partial class TraumaSystem
             var partSprintSpeed = movement.SprintSpeed;
             var partAcceleration = movement.Acceleration;
 
-            if (!TryComp<WoundableComponent>(legEntity, out var legWoundable))
-                continue;
-
-            if (!TryComp<BoneComponent>(legWoundable.Bone.ContainedEntities.First(), out var boneComp))
+            if (!TryComp<WoundableComponent>(legEntity, out var legWoundable)
+                || !TryComp<BoneComponent>(legWoundable.Bone.ContainedEntities.FirstOrNull(), out var boneComp))
                 continue;
 
             // Get the foot penalty
@@ -315,7 +314,8 @@ public partial class TraumaSystem
 
             if (footEnt != null)
             {
-                if (TryComp<BoneComponent>(legWoundable.Bone.ContainedEntities.FirstOrNull(), out var footBone))
+                if (TryComp<WoundableComponent>(footEnt.Value.Id, out var footWoundable)
+                    && TryComp<BoneComponent>(footWoundable.Bone.ContainedEntities.FirstOrNull(), out var footBone))
                 {
                     penalty = footBone.BoneSeverity switch
                     {
@@ -368,20 +368,11 @@ public partial class TraumaSystem
 
         if (walkSpeed < rawWalkSpeed / 3.4)
             _standing.Down(body);
-    }
-
-    private bool TryFumble(string message, SoundPathSpecifier sound, EntityUid body, float odds)
-    {
-        var rand = new System.Random((int) _timing.CurTick.Value);
-        if (rand.NextFloat() < odds)
-        {
-            _popup.PopupClient(Loc.GetString(message), body, PopupType.Medium);
-            var ev = new DropHandItemsEvent();
-            RaiseLocalEvent(body, ref ev, false);
-            _audio.PlayPredicted(sound, body, body);
-            return true;
-        }
-        return false;
+        else if (_standing.IsDown(body)
+            && !HasComp<KnockedDownComponent>(body)
+            && !HasComp<SleepingComponent>(body)
+            && !_mobState.IsIncapacitated(body))
+            _standing.Stand(body);
     }
 
     #endregion

--- a/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Bones.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Bones.cs
@@ -76,7 +76,7 @@ public partial class TraumaSystem
             if (bodyComp.PartType == BodyPartType.Hand)
                 _virtual.DeleteInHandsMatching(bodyComp.Body.Value, bone);
 
-            if (TryGetWoundableTrauma(bone.Comp.BoneWoundable.Value, out var traumas, TraumaType.BoneDamage))
+            if (TryGetWoundableTrauma(bone.Comp.BoneWoundable.Value, out var traumas, BoneDamage))
                 foreach (var trauma in traumas.Where(trauma => trauma.Comp.TraumaTarget == bone))
                     RemoveTrauma(trauma);
         }
@@ -180,7 +180,7 @@ public partial class TraumaSystem
             return false;
 
         if (_net.IsServer)
-            AddTrauma(boneEnt, woundable, inflicter, TraumaType.BoneDamage, inflicterSeverity);
+            AddTrauma(boneEnt, woundable, inflicter, BoneDamage, inflicterSeverity);
 
         ApplyDamageToBone(boneEnt, inflicterSeverity, boneComp);
 

--- a/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Data.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Data.cs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-using Content.Shared._Shitmed.Medical.Surgery.Wounds;
 using Content.Goobstation.Maths.FixedPoint;
 
 namespace Content.Shared._Shitmed.Medical.Surgery.Traumas.Systems;
@@ -19,17 +18,6 @@ public partial class TraumaSystem
         new(BoneSeverity.Cracked, 10),
         new(BoneSeverity.Broken, 0),
     ];
-
-    private readonly Dictionary<WoundableSeverity, FixedPoint2> _boneTraumaChanceMultipliers = new()
-    {
-        { WoundableSeverity.Healthy, 0 },
-        { WoundableSeverity.Minor, 0.01 },
-        { WoundableSeverity.Moderate, 0.04 },
-        { WoundableSeverity.Severe, 0.12 },
-        { WoundableSeverity.Critical, 0.21 },
-        { WoundableSeverity.Mangled, 0.21 },
-        { WoundableSeverity.Severed, 0 },
-    };
 
     #endregion
 }

--- a/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Data.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Data.cs
@@ -9,21 +9,16 @@ public partial class TraumaSystem
 {
     #region Data
 
-    private readonly Dictionary<BoneSeverity, FixedPoint2> _boneThresholds = new()
-    {
-        { BoneSeverity.Normal, 40 },
-        { BoneSeverity.Damaged, 25 },
-        { BoneSeverity.Cracked, 10 },
-        { BoneSeverity.Broken, 0 },
-    };
-
-    private readonly Dictionary<BoneSeverity, FixedPoint2> _bonePainModifiers = new()
-    {
-        { BoneSeverity.Normal, 0.4 },
-        { BoneSeverity.Damaged, 0.6 },
-        { BoneSeverity.Cracked, 0.8 },
-        { BoneSeverity.Broken, 1 },
-    };
+    /// <summary>
+    /// Sorted in descending order by threshold value.
+    /// </summary>
+    private static readonly KeyValuePair<BoneSeverity, FixedPoint2>[] BoneThresholds =
+    [
+        new(BoneSeverity.Normal, 40),
+        new(BoneSeverity.Damaged, 25),
+        new(BoneSeverity.Cracked, 10),
+        new(BoneSeverity.Broken, 0),
+    ];
 
     private readonly Dictionary<WoundableSeverity, FixedPoint2> _boneTraumaChanceMultipliers = new()
     {
@@ -33,17 +28,6 @@ public partial class TraumaSystem
         { WoundableSeverity.Severe, 0.12 },
         { WoundableSeverity.Critical, 0.21 },
         { WoundableSeverity.Mangled, 0.21 },
-        { WoundableSeverity.Severed, 0 },
-    };
-
-    private readonly Dictionary<WoundableSeverity, FixedPoint2> _boneDamageMultipliers = new()
-    {
-        { WoundableSeverity.Healthy, 0 },
-        { WoundableSeverity.Minor, 0.4 },
-        { WoundableSeverity.Moderate, 0.6 },
-        { WoundableSeverity.Severe, 0.9 },
-        { WoundableSeverity.Critical, 1.25 },
-        { WoundableSeverity.Mangled, 1.6 }, // Fun.
         { WoundableSeverity.Severed, 0 },
     };
 

--- a/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Organs.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Organs.cs
@@ -17,6 +17,8 @@ namespace Content.Shared._Shitmed.Medical.Surgery.Traumas.Systems;
 public partial class TraumaSystem
 {
     private const string OrganDamagePainIdentifier = "OrganDamage";
+
+    private static readonly FixedPoint2 OrganDamagePainBudget = 30;
     public static readonly EntProtoId OrgansDamagedSlowdown = "OrgansDamagedSlowdownEffect";
 
     private void InitOrgans()
@@ -39,19 +41,24 @@ public partial class TraumaSystem
         var organs = _body.GetPartOrgans(args.Organ.Comp.Body.Value).ToList();
         var totalIntegrity = organs.Aggregate(FixedPoint2.Zero, (current, organ) => current + organ.Component.OrganIntegrity);
         var totalIntegrityCap = organs.Aggregate(FixedPoint2.Zero, (current, organ) => current + organ.Component.IntegrityCap);
-        // Getting your organ turned into a blood mush inside you applies a LOT of internal pain, that can get you dead.
+
+        var damageFraction = totalIntegrityCap > 0
+            ? (totalIntegrityCap - totalIntegrity) / totalIntegrityCap
+            : FixedPoint2.Zero;
+        var organPain = damageFraction * OrganDamagePainBudget;
+
         if (!_pain.TryChangePainModifier(
                 nerveSys.Value,
                 bodyPart.Owner,
                 OrganDamagePainIdentifier,
-                (totalIntegrityCap - totalIntegrity) / 2,
+                organPain,
                 nerveSys.Value.Comp))
         {
             _pain.TryAddPainModifier(
                 nerveSys.Value,
                 bodyPart.Owner,
                 OrganDamagePainIdentifier,
-                (totalIntegrityCap - totalIntegrity) / 2,
+                organPain,
                 PainDamageTypes.TraumaticPain,
                 nerveSys.Value.Comp);
         }
@@ -62,7 +69,7 @@ public partial class TraumaSystem
         if (organ.Comp.Body == null)
             return;
 
-        if (args.NewIntegrity < organ.Comp.IntegrityCap || !TryGetBodyTraumas(organ.Comp.Body.Value, out var traumas, TraumaType.OrganDamage))
+        if (args.NewIntegrity < organ.Comp.IntegrityCap || !TryGetBodyTraumas(organ.Comp.Body.Value, out var traumas, OrganDamage))
             return;
 
         foreach (var trauma in traumas.Where(trauma => trauma.Comp.TraumaTarget == organ))
@@ -109,7 +116,7 @@ public partial class TraumaSystem
                  _cfg.GetCVar(SurgeryCVars.OrganTraumaRunSpeedSlowdown));
         }
 
-        if (TryGetWoundableTrauma(bodyPart, out var traumas, TraumaType.OrganDamage, bodyPart))
+        if (TryGetWoundableTrauma(bodyPart, out var traumas, OrganDamage, bodyPart))
         {
             foreach (var trauma in traumas)
             {
@@ -121,10 +128,41 @@ public partial class TraumaSystem
         }
 
         _audio.PlayPvs(args.Organ.Comp.OrganDestroyedSound, body.Value);
+
+        if (TryComp<OrganDeathTraumaComponent>(args.Organ, out var deathTrauma)
+            && !HasOrganTrauma(bodyPart, args.Organ, deathTrauma.Trauma))
+            TryInflictOrganTrauma(bodyPart, args.Organ, deathTrauma.Trauma, args.Organ.Comp.IntegrityCap);
+
+        if (args.Organ.Comp.Indestructible)
+            return;
+
         _body.RemoveOrgan(args.Organ, args.Organ.Comp);
 
         if (_net.IsServer)
             QueueDel(args.Organ);
+    }
+
+    private bool HasOrganTrauma(EntityUid woundable, EntityUid organ, ProtoId<TraumaTypePrototype> traumaType)
+    {
+        if (!TryGetWoundableTrauma(woundable, out var traumas, traumaType))
+            return false;
+
+        foreach (var trauma in traumas)
+        {
+            if (trauma.Comp.TraumaTarget == organ)
+                return true;
+        }
+
+        return false;
+    }
+
+    public void RestoreOrganIntegrity(EntityUid uid, OrganComponent? organ = null)
+    {
+        if (!Resolve(uid, ref organ))
+            return;
+
+        organ.IntegrityModifiers.Clear();
+        UpdateOrganIntegrity(uid, organ);
     }
 
     #endregion

--- a/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Organs.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Organs.cs
@@ -93,11 +93,12 @@ public partial class TraumaSystem
             if (TryComp<HumanoidAppearanceComponent>(body, out var humanoid))
                 sex = humanoid.Sex;
 
-            _pain.PlayPainSoundWithCleanup(
-                body.Value,
-                nerveSys.Value.Comp,
-                nerveSys.Value.Comp.OrganDestructionReflexSounds[sex],
-                AudioParams.Default.WithVolume(6f));
+            if (nerveSys.Value.Comp.OrganDestructionReflexSounds.TryGetValue(sex, out var reflexSound))
+                _pain.PlayPainSoundWithCleanup(
+                    body.Value,
+                    nerveSys.Value.Comp,
+                    reflexSound,
+                    AudioParams.Default.WithVolume(6f));
 
             _stun.TryUpdateParalyzeDuration(body.Value, nerveSys.Value.Comp.OrganDamageStunTime);
             _movementMod.TryUpdateMovementSpeedModDuration(
@@ -243,26 +244,32 @@ public partial class TraumaSystem
     {
         var oldIntegrity = organ.OrganIntegrity;
 
-        if (organ.IntegrityModifiers.Count > 0)
-            organ.OrganIntegrity = organ.IntegrityCap - FixedPoint2.Clamp(organ.IntegrityModifiers // Omu
-                .Aggregate(FixedPoint2.Zero, (current, modifier) => current + modifier.Value),
-                0,
-                organ.IntegrityCap);
+        var totalDamage = FixedPoint2.Zero;
+        foreach (var modifier in organ.IntegrityModifiers)
+            totalDamage += modifier.Value;
+
+        organ.OrganIntegrity = FixedPoint2.Clamp(organ.IntegrityCap - totalDamage, 0, organ.IntegrityCap);
+
+        _container.TryGetContainingContainer((uid, Transform(uid), MetaData(uid)), out var container);
 
         if (oldIntegrity != organ.OrganIntegrity)
         {
             var ev = new OrganIntegrityChangedEvent(oldIntegrity, organ.OrganIntegrity);
             RaiseLocalEvent(uid, ref ev);
 
-            if (_container.TryGetContainingContainer((uid, Transform(uid), MetaData(uid)), out var container))
+            if (container != null)
             {
                 var ev1 = new OrganIntegrityChangedEventOnWoundable((uid, organ), oldIntegrity, organ.OrganIntegrity);
                 RaiseLocalEvent(container.Owner, ref ev1);
             }
         }
 
-        var nearestSeverity = organ.OrganSeverity;
-        foreach (var (severity, value) in organ.IntegrityThresholds.OrderByDescending(kv => kv.Value))
+        organ.SortedIntegrityThresholds ??= organ.IntegrityThresholds.OrderBy(kv => kv.Value).ToArray();
+
+        var nearestSeverity = organ.SortedIntegrityThresholds.Length > 0
+            ? organ.SortedIntegrityThresholds[^1].Key
+            : organ.OrganSeverity;
+        foreach (var (severity, value) in organ.SortedIntegrityThresholds)
         {
             if (organ.OrganIntegrity > value)
                 continue;
@@ -275,7 +282,7 @@ public partial class TraumaSystem
         {
             var ev = new OrganDamageSeverityChanged(organ.OrganSeverity, nearestSeverity);
             RaiseLocalEvent(uid, ref ev);
-            if (_container.TryGetContainingContainer((uid, Transform(uid), MetaData(uid)), out var container))
+            if (container != null)
             {
                 var ev1 = new OrganDamageSeverityChangedOnWoundable((uid, organ), organ.OrganSeverity, nearestSeverity);
                 RaiseLocalEvent(container.Owner, ref ev1);

--- a/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Process.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Process.cs
@@ -8,11 +8,14 @@ using Content.Shared._Shitmed.Medical.Surgery.Pain.Components;
 using Content.Shared._Shitmed.Medical.Surgery.Traumas.Components;
 using Content.Shared.Armor;
 using Content.Shared.Body.Components;
+using Content.Shared.Body.Organ;
 using Content.Shared.Body.Part;
 using Content.Shared.Damage.Components;
+using Content.Shared.Damage.Prototypes;
 using Content.Shared.Inventory;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
 using System.Diagnostics.CodeAnalysis;
@@ -24,7 +27,11 @@ namespace Content.Shared._Shitmed.Medical.Surgery.Traumas.Systems;
 public partial class TraumaSystem
 {
     private const string TraumaContainerId = "Traumas";
-    public static readonly TraumaType[] TraumasBlockingHealing = { TraumaType.BoneDamage, TraumaType.OrganDamage, TraumaType.Dismemberment };
+
+    private readonly Dictionary<ProtoId<DamageTypePrototype>, List<WoundSeverityCauseEntry>> _woundSeverityCauses = new();
+    private readonly List<WoundSeverityCauseEntry> _anyDamageWoundCauses = new();
+
+    private readonly record struct WoundSeverityCauseEntry(ProtoId<TraumaTypePrototype> Id, TraumaTypePrototype Proto, WoundSeverityCause Cause);
 
     private void InitProcess()
     {
@@ -33,6 +40,114 @@ public partial class TraumaSystem
         SubscribeLocalEvent<TraumaComponent, ComponentHandleState>(OnComponentHandleState);
         SubscribeLocalEvent<TraumaInflicterComponent, WoundSeverityPointChangedEvent>(OnWoundSeverityPointChanged);
         SubscribeLocalEvent<TraumaInflicterComponent, WoundHealAttemptEvent>(OnWoundHealAttempt);
+        SubscribeLocalEvent<WoundableComponent, ApplyTraumaEvent>(OnApplyTrauma);
+        SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypesReloaded);
+
+        BuildWoundSeverityCauseIndex();
+    }
+
+    private void OnPrototypesReloaded(PrototypesReloadedEventArgs args)
+    {
+        if (args.WasModified<TraumaTypePrototype>())
+            BuildWoundSeverityCauseIndex();
+    }
+
+    private void BuildWoundSeverityCauseIndex()
+    {
+        _woundSeverityCauses.Clear();
+        _anyDamageWoundCauses.Clear();
+
+        foreach (var proto in _prototype.EnumeratePrototypes<TraumaTypePrototype>())
+        {
+            if (proto.Causes == null)
+                continue;
+
+            foreach (var cause in proto.Causes)
+            {
+                if (cause is not WoundSeverityCause wsc)
+                    continue;
+
+                var entry = new WoundSeverityCauseEntry(proto.ID, proto, wsc);
+                if (wsc.DamageTypes == null || wsc.DamageTypes.Count == 0)
+                {
+                    _anyDamageWoundCauses.Add(entry);
+                    continue;
+                }
+
+                foreach (var dt in wsc.DamageTypes)
+                {
+                    if (!_woundSeverityCauses.TryGetValue(dt, out var list))
+                        _woundSeverityCauses[dt] = list = new List<WoundSeverityCauseEntry>();
+
+                    list.Add(entry);
+                }
+            }
+        }
+    }
+
+    public bool TraumaBlocksHealing(ProtoId<TraumaTypePrototype> traumaType)
+    {
+        return _prototype.TryIndex(traumaType, out var proto) && proto.BlocksHealing;
+    }
+
+    public bool IsTraumaSurgicallyTreatable(ProtoId<TraumaTypePrototype> traumaType)
+    {
+        return _prototype.TryIndex(traumaType, out var proto) && proto.Treatment is SurgicalTreatment;
+    }
+
+    /// <summary>
+    /// Collects every surgically-treatable trauma currently on a woundable.
+    /// </summary>
+    public bool TryGetSurgicallyTreatableTraumas(EntityUid woundable, out List<Entity<TraumaComponent>> traumas, WoundableComponent? woundableComp = null)
+    {
+        traumas = new List<Entity<TraumaComponent>>();
+        if (!Resolve(woundable, ref woundableComp, false))
+            return false;
+
+        foreach (var woundEnt in _wound.GetWoundableWounds(woundable, woundableComp))
+        {
+            if (!TryComp<TraumaInflicterComponent>(woundEnt, out var inflicter))
+                continue;
+
+            foreach (var trauma in GetAllWoundTraumas(woundEnt, inflicter))
+            {
+                if (IsTraumaSurgicallyTreatable(trauma.Comp.TraumaType))
+                    traumas.Add(trauma);
+            }
+        }
+
+        return traumas.Count > 0;
+    }
+
+    /// <summary>
+    /// Whether a woundable currently carries any trauma that blocks healing.
+    /// </summary>
+    public bool HasHealingBlockingTrauma(EntityUid woundable, WoundableComponent? woundableComp = null)
+    {
+        if (!Resolve(woundable, ref woundableComp, false))
+            return false;
+
+        foreach (var woundEnt in _wound.GetWoundableWounds(woundable, woundableComp))
+        {
+            if (!TryComp<TraumaInflicterComponent>(woundEnt, out var inflicter))
+                continue;
+
+            foreach (var trauma in GetAllWoundTraumas(woundEnt, inflicter))
+            {
+                if (!TraumaBlocksHealing(trauma.Comp.TraumaType))
+                    continue;
+
+                if (trauma.Comp.TraumaType == BoneDamage
+                    && (woundableComp.Bone.ContainedEntities.FirstOrNull() is not { } bone
+                        || !TryComp(bone, out BoneComponent? boneComp)
+                        || boneComp.BoneSeverity != BoneSeverity.Broken))
+                    continue;
+
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private void OnTraumaInflicterInit(
@@ -99,17 +214,34 @@ public partial class TraumaSystem
 
         foreach (var trauma in GetAllWoundTraumas(inflicter, inflicter))
         {
-            if (TraumasBlockingHealing.Contains(trauma.Comp.TraumaType))
-            {
-                if (trauma.Comp.TraumaType == TraumaType.BoneDamage
-                    && args.Woundable.Comp.Bone.ContainedEntities.FirstOrNull() is { } bone
-                    && TryComp(bone, out BoneComponent? boneComp)
-                    && boneComp.BoneSeverity != BoneSeverity.Broken)
-                    continue;
+            if (!TraumaBlocksHealing(trauma.Comp.TraumaType))
+                continue;
 
+
+            var floor = GetTraumaHealFloor(trauma);
+            if (floor == null)
+            {
                 args.Cancelled = true;
+                continue;
             }
+
+            if (floor.Value > args.SeverityFloor)
+                args.SeverityFloor = floor.Value;
         }
+    }
+
+    private FixedPoint2? GetTraumaHealFloor(Entity<TraumaComponent> trauma)
+    {
+        if (trauma.Comp.TraumaTarget is not { } target)
+            return null;
+
+        if (TryComp<BoneComponent>(target, out var bone))
+            return bone.HealSeverityFloor.GetValueOrDefault(bone.BoneSeverity);
+
+        if (TryComp<OrganComponent>(target, out var organ))
+            return organ.HealSeverityFloor.GetValueOrDefault(organ.OrganSeverity);
+
+        return null;
     }
 
     #region Public API
@@ -131,7 +263,7 @@ public partial class TraumaSystem
         EntityUid woundable,
         EntityUid woundInflicter,
         WoundableComponent? woundableComp = null,
-        TraumaType? traumaType = null,
+        ProtoId<TraumaTypePrototype>? traumaType = null,
         TraumaInflicterComponent? component = null,
         bool showAll = true)
     {
@@ -150,7 +282,7 @@ public partial class TraumaSystem
             if (!showAll)
             {
                 // TODO: Fill this with other blocking traumas.
-                if (trauma.Comp.TraumaType == TraumaType.BoneDamage
+                if (trauma.Comp.TraumaType == BoneDamage
                     && (woundableComp.Bone.ContainedEntities.FirstOrNull() is not { } bone
                     || !TryComp(bone, out BoneComponent? boneComp)
                     || boneComp.BoneSeverity != BoneSeverity.Broken))
@@ -166,7 +298,7 @@ public partial class TraumaSystem
     public bool TryGetAssociatedTrauma(
         EntityUid woundInflicter,
         [NotNullWhen(true)] out List<Entity<TraumaComponent>>? traumas,
-        TraumaType? traumaType = null,
+        ProtoId<TraumaTypePrototype>? traumaType = null,
         TraumaInflicterComponent? component = null)
     {
         traumas = null;
@@ -190,7 +322,7 @@ public partial class TraumaSystem
 
     public bool HasWoundableTrauma(
         EntityUid woundable,
-        TraumaType? traumaType = null,
+        ProtoId<TraumaTypePrototype>? traumaType = null,
         WoundableComponent? woundableComp = null,
         bool showAll = true) // Used to skip certain non-lethal traumas like minor bone fractures.
     {
@@ -212,7 +344,7 @@ public partial class TraumaSystem
     public bool TryGetWoundableTrauma(
         EntityUid woundable,
         [NotNullWhen(true)] out List<Entity<TraumaComponent>>? traumas,
-        TraumaType? traumaType = null,
+        ProtoId<TraumaTypePrototype>? traumaType = null,
         WoundableComponent? woundableComp = null)
     {
         traumas = null;
@@ -234,7 +366,7 @@ public partial class TraumaSystem
 
     public bool HasBodyTrauma(
         EntityUid body,
-        TraumaType? traumaType = null,
+        ProtoId<TraumaTypePrototype>? traumaType = null,
         BodyComponent? bodyComp = null)
     {
         return Resolve(body, ref bodyComp, false) && _body.GetBodyChildren(body, bodyComp).Any(bodyPart => HasWoundableTrauma(bodyPart.Id, traumaType));
@@ -243,7 +375,7 @@ public partial class TraumaSystem
     public bool TryGetBodyTraumas(
         EntityUid body,
         [NotNullWhen(true)] out List<Entity<TraumaComponent>>? traumas,
-        TraumaType? traumaType = null,
+        ProtoId<TraumaTypePrototype>? traumaType = null,
         BodyComponent? bodyComp = null)
     {
         traumas = null;
@@ -260,44 +392,90 @@ public partial class TraumaSystem
         return traumas.Count > 0;
     }
 
-    public List<TraumaType> RandomTraumaChance(
+    public List<ProtoId<TraumaTypePrototype>> RandomTraumaChance(
         EntityUid target,
         Entity<TraumaInflicterComponent> woundInflicter,
         FixedPoint2 severity,
         WoundableComponent? woundable = null)
     {
-        var traumaList = new List<TraumaType>();
-        if (!Resolve(target, ref woundable, false))
+        var traumaList = new List<ProtoId<TraumaTypePrototype>>();
+        if (!Resolve(target, ref woundable, false)
+            || !TryComp<WoundComponent>(woundInflicter, out var wound))
             return traumaList;
 
+        var partType = CompOrNull<BodyPartComponent>(target)?.PartType ?? BodyPartType.Other;
 
-        if (severity >= 5 && woundInflicter.Comp.AllowedTraumas.Contains(TraumaType.NerveDamage) &&
-            RandomNerveDamageChance((target, woundable), woundInflicter))
-            traumaList.Add(TraumaType.NerveDamage);
+        foreach (var entry in _anyDamageWoundCauses)
+            TryRollWoundTrauma(entry, target, woundable, woundInflicter, severity, partType, traumaList);
 
-        if (severity >= 10 && woundInflicter.Comp.AllowedTraumas.Contains(TraumaType.BoneDamage) &&
-            RandomBoneTraumaChance((target, woundable), woundInflicter))
-            traumaList.Add(TraumaType.BoneDamage);
-
-        if (severity >= 10 && woundInflicter.Comp.AllowedTraumas.Contains(TraumaType.Dismemberment) &&
-            RandomDismembermentTraumaChance((target, woundable), woundInflicter))
-            traumaList.Add(TraumaType.Dismemberment);
-
-        if (severity >= 15 && woundInflicter.Comp.AllowedTraumas.Contains(TraumaType.OrganDamage) &&
-            RandomOrganTraumaChance((target, woundable), woundInflicter))
-            traumaList.Add(TraumaType.OrganDamage);
-
-        //if (RandomVeinsTraumaChance(woundable))
-        //    traumaList.Add(TraumaType.VeinsDamage);
+        if (_woundSeverityCauses.TryGetValue(wound.DamageType, out var eligible))
+            foreach (var entry in eligible)
+                TryRollWoundTrauma(entry, target, woundable, woundInflicter, severity, partType, traumaList);
 
         return traumaList;
     }
 
-    public FixedPoint2 GetArmourChanceDeduction(EntityUid body, Entity<TraumaInflicterComponent> inflicter, TraumaType traumaType, BodyPartType coverage)
+    private void TryRollWoundTrauma(
+        WoundSeverityCauseEntry entry,
+        EntityUid target,
+        WoundableComponent woundable,
+        Entity<TraumaInflicterComponent> woundInflicter,
+        FixedPoint2 severity,
+        BodyPartType partType,
+        List<ProtoId<TraumaTypePrototype>> traumaList)
+    {
+        if (severity < entry.Proto.SeverityGate || !entry.Cause.PartAllowed(partType))
+            return;
+
+        var chance = GetWoundTraumaChance(entry, (target, woundable), woundInflicter, severity);
+        if (chance > 0 && _random.Prob((float) FixedPoint2.Clamp(chance, 0, 1)))
+            traumaList.Add(entry.Id);
+    }
+
+    /// <summary>
+    /// Runs the cause's <see cref="TraumaChance"/> provider (or the prototype BaseChance fallback),
+    /// then applies the generic armour/weapon deduction wrapper.
+    /// </summary>
+    private FixedPoint2 GetWoundTraumaChance(
+        WoundSeverityCauseEntry entry,
+        Entity<WoundableComponent> target,
+        Entity<TraumaInflicterComponent> woundInflicter,
+        FixedPoint2 severity)
+    {
+        if (entry.Cause.Chance is not { } provider)
+            return entry.Proto.BaseChance;
+
+        var bodyPart = Comp<BodyPartComponent>(target);
+        if (bodyPart.Body is not { } body)
+            return FixedPoint2.Zero;
+
+        var args = new TraumaChanceArgs(EntityManager, target, woundInflicter, severity, bodyPart, body);
+
+        if (provider.Calculate(in args) is not { } baseChance)
+            return FixedPoint2.Zero;
+
+        var deduction = GetTraumaChanceDeduction(
+            woundInflicter,
+            body,
+            target,
+            Comp<WoundComponent>(woundInflicter).WoundSeverityPoint,
+            entry.Id,
+            bodyPart.PartType);
+
+        if (deduction == 1)
+            return FixedPoint2.Zero;
+
+        return FixedPoint2.Clamp(
+            baseChance - deduction + woundInflicter.Comp.TraumasChances.GetValueOrDefault(entry.Id),
+            0,
+            1);
+    }
+
+    public FixedPoint2 GetArmourChanceDeduction(EntityUid body, Entity<TraumaInflicterComponent> inflicter, ProtoId<TraumaTypePrototype> traumaType, BodyPartType coverage)
     {
         var deduction = FixedPoint2.Zero;
 
-        var ev = new GetSecondSkinDeductionEvent((int) coverage, (int) traumaType);
+        var ev = new GetSecondSkinDeductionEvent((int) coverage, traumaType);
         RaiseLocalEvent(body, ref ev);
         deduction += ev.Deduction;
 
@@ -322,7 +500,7 @@ public partial class TraumaSystem
         EntityUid body,
         Entity<WoundableComponent> traumaTarget,
         FixedPoint2 severity,
-        TraumaType traumaType,
+        ProtoId<TraumaTypePrototype> traumaType,
         BodyPartType coverage)
     {
         var deduction = traumaTarget.Comp.TraumaDeductions.GetValueOrDefault(traumaType, FixedPoint2.Zero);
@@ -347,21 +525,19 @@ public partial class TraumaSystem
             || inflicterComponent.MangledMultipliers == null)
             return;
 
-        var traumasToInduce = new List<TraumaType>();
+        var traumasToInduce = new List<ProtoId<TraumaTypePrototype>>();
         foreach (var traumaType in inflicterComponent.MangledMultipliers.Keys)
         {
-            switch (traumaType)
-            {
-                case TraumaType.BoneDamage:
-                    {
-                        var bone = woundableComp.Bone.ContainedEntities.FirstOrNull();
-                        if (bone == null || !TryComp<BoneComponent>(bone, out var boneComp))
-                            break;
+            if (!_prototype.TryIndex(traumaType, out var proto))
+                continue;
 
-                        traumasToInduce.Add(TraumaType.BoneDamage);
-                        break;
-                    }
-            }
+            // TODO: NUKE OLD CHANCE HANDLERS AND MAKE ALL DAMAGES INTO TRAUMAS
+            if (proto.Target == TraumaTarget.Bone
+                && (woundableComp.Bone.ContainedEntities.FirstOrNull() is not { } bone
+                    || !HasComp<BoneComponent>(bone)))
+                continue;
+
+            traumasToInduce.Add(traumaType);
         }
 
         ApplyTraumas((woundable, woundableComp), (wound, inflicterComponent), traumasToInduce, severity);
@@ -369,193 +545,13 @@ public partial class TraumaSystem
 
     #endregion
 
-    #region Trauma Chance Randoming
-
-    public bool RandomBoneTraumaChance(Entity<WoundableComponent> target, Entity<TraumaInflicterComponent> woundInflicter)
-    {
-        var bodyPart = Comp<BodyPartComponent>(target);
-        if (!bodyPart.Body.HasValue)
-            return false; // Can't sever if already severed
-
-        var bone = target.Comp.Bone.ContainedEntities.FirstOrNull();
-
-        if (bone == null || !TryComp<BoneComponent>(bone, out var boneComp))
-            return false;
-
-        if (boneComp.BoneSeverity == BoneSeverity.Broken)
-            return false;
-
-        var deduction = GetTraumaChanceDeduction(
-            woundInflicter,
-            bodyPart.Body.Value,
-            target,
-            Comp<WoundComponent>(woundInflicter).WoundSeverityPoint,
-            TraumaType.BoneDamage,
-            bodyPart.PartType);
-
-        if (deduction == 1)
-            return false;
-
-        // We do complete random to get the chance for trauma to happen,
-        // We combine multiple parameters and do some math, to get the chance.
-        // Even if we get 0.1 damage there's still a chance for injury to be applied, but with the extremely low chance.
-        // The more damage, the bigger is the chance.
-        var chance = FixedPoint2.Clamp(
-            target.Comp.IntegrityCap / (target.Comp.WoundableIntegrity + boneComp.BoneIntegrity)
-             * _boneTraumaChanceMultipliers[target.Comp.WoundableSeverity]
-             - deduction + woundInflicter.Comp.TraumasChances[TraumaType.BoneDamage],
-            0,
-            1);
-
-        return _random.Prob((float) chance);
-    }
-
-    public bool RandomNerveDamageChance(
-        Entity<WoundableComponent> target,
-        Entity<TraumaInflicterComponent> woundInflicter)
-    {
-        var bodyPart = Comp<BodyPartComponent>(target);
-        if (!bodyPart.Body.HasValue)
-            return false; // No entity to apply pain to
-
-        if (!TryComp<NerveComponent>(target, out var nerve))
-            return false;
-
-        if (nerve.PainFeels < 0.2)
-            return false;
-
-        var deduction = GetTraumaChanceDeduction(
-            woundInflicter,
-            bodyPart.Body.Value,
-            target,
-            Comp<WoundComponent>(woundInflicter).WoundSeverityPoint,
-            TraumaType.NerveDamage,
-            bodyPart.PartType);
-
-        if (deduction == 1)
-            return false;
-        // literally dismemberment chance, but lower by default
-        var chance =
-            FixedPoint2.Clamp(
-                target.Comp.WoundableIntegrity / target.Comp.IntegrityCap / 20
-                - deduction + woundInflicter.Comp.TraumasChances[TraumaType.NerveDamage],
-                0,
-                1);
-
-        return _random.Prob((float) chance);
-    }
-
-    public bool RandomOrganTraumaChance(
-        Entity<WoundableComponent> target,
-        Entity<TraumaInflicterComponent> woundInflicter)
-    {
-        var bodyPart = Comp<BodyPartComponent>(target);
-        if (!bodyPart.Body.HasValue)
-            return false; // No entity to apply pain to
-
-        var totalIntegrity =
-            _body.GetPartOrgans(target, bodyPart)
-                .Aggregate(FixedPoint2.Zero, (current, organ) => current + organ.Component.OrganIntegrity);
-
-        if (totalIntegrity <= 0) // No surviving organs
-            return false;
-
-        var deduction = GetTraumaChanceDeduction(
-            woundInflicter,
-            bodyPart.Body.Value,
-            target,
-            Comp<WoundComponent>(woundInflicter).WoundSeverityPoint,
-            TraumaType.OrganDamage,
-            bodyPart.PartType);
-
-        if (deduction == 1)
-            return false;
-        // organ damage is like, very deadly, but not yet
-        // so like, like, yeah, we don't want a disabler to induce some EVIL ASS organ damage with a 0,000001% chance and ruin your round
-        // Very unlikely to happen if your woundables are in a good condition
-
-        var chance =
-            FixedPoint2.Clamp(
-                target.Comp.WoundableIntegrity / target.Comp.IntegrityCap / totalIntegrity
-                - deduction + woundInflicter.Comp.TraumasChances[TraumaType.OrganDamage],
-                0,
-                1);
-
-        return _random.Prob((float) chance);
-    }
-
-    public bool RandomDismembermentTraumaChance(
-        Entity<WoundableComponent> target,
-        Entity<TraumaInflicterComponent> woundInflicter)
-    {
-        var bodyPart = Comp<BodyPartComponent>(target);
-        if (!bodyPart.Body.HasValue)
-            return false; // Can't sever if already severed
-
-        var parentWoundable = target.Comp.ParentWoundable;
-        if (!parentWoundable.HasValue)
-            return false;
-
-        if (bodyPart.PartType == BodyPartType.Chest
-            || (bodyPart.PartType == BodyPartType.Groin
-            && Comp<WoundableComponent>(parentWoundable.Value).WoundableSeverity != WoundableSeverity.Mangled))
-            return false;
-
-        var deduction = GetTraumaChanceDeduction(
-            woundInflicter,
-            bodyPart.Body.Value,
-            target,
-            Comp<WoundComponent>(woundInflicter).WoundSeverityPoint,
-            TraumaType.Dismemberment,
-            bodyPart.PartType);
-
-        if (deduction == 1)
-            return false;
-
-        var bonePenalty = FixedPoint2.New(1); // higher means less chance to delimb
-        if (TryComp<BonelessComponent>(target.Owner, out var bonelessComp))
-            bonePenalty = bonelessComp.BonePenalty;
-
-        // Healthy bones decrease the chance of your limb getting delimbed
-        var bone = target.Comp.Bone.ContainedEntities.FirstOrNull();
-        var multiplier = 1f;
-        if (bone != null && TryComp<BoneComponent>(bone, out var boneComp))
-        {
-            switch (boneComp.BoneSeverity)
-            {
-                case BoneSeverity.Normal:
-                    multiplier *= 0.3f; // decreases delimb chance by 70%
-                    break;
-                case BoneSeverity.Damaged:
-                    multiplier *= 0.6f; // 40%
-                    break;
-                case BoneSeverity.Cracked:
-                    multiplier *= 1f; // 0%
-                    break;
-                case BoneSeverity.Broken:
-                    multiplier *= 1.2f; // increases by 20%
-                    break;
-                default:
-                    break;
-            }
-        }
-
-        var chance =
-            FixedPoint2.Clamp(
-                (1f - (MathF.Pow(target.Comp.WoundableIntegrity.Float(), 1.3f) / target.Comp.IntegrityCap - 1f) * bonePenalty) * multiplier
-                - deduction + woundInflicter.Comp.TraumasChances[TraumaType.Dismemberment],
-                0,
-                1);
-
-        var result = _random.Prob((float) chance);
-        return result;
-    }
+    #region Trauma Application
 
     public EntityUid AddTrauma(
         EntityUid target,
         Entity<WoundableComponent> holdingWoundable,
         Entity<TraumaInflicterComponent> inflicter,
-        TraumaType traumaType,
+        ProtoId<TraumaTypePrototype> traumaType,
         FixedPoint2 severity,
         (BodyPartType, BodyPartSymmetry)? targetType = null)
     {
@@ -581,7 +577,10 @@ public partial class TraumaSystem
             return trauma;
         }
 
-        var traumaEnt = Spawn(inflicter.Comp.TraumaPrototypes[traumaType]);
+        var entityProto = inflicter.Comp.TraumaPrototypes.TryGetValue(traumaType, out var overrideProto)
+            ? overrideProto
+            : _prototype.Index(traumaType).TraumaEntity;
+        var traumaEnt = Spawn(entityProto);
         var traumaComp = EnsureComp<TraumaComponent>(traumaEnt);
 
         traumaComp.TraumaSeverity = severity;
@@ -594,6 +593,9 @@ public partial class TraumaSystem
         traumaComp.HoldingWoundable = holdingWoundable;
 
         _container.Insert(traumaEnt, inflicter.Comp.TraumaContainer);
+
+        var evTrauma = new TraumaInducedEvent((traumaEnt, traumaComp), target, severity, traumaType);
+        RaiseLocalEvent(traumaEnt, ref evTrauma);
 
         // Raise the event on the woundable
         var ev = new TraumaInducedEvent((traumaEnt, traumaComp), target, severity, traumaType);
@@ -627,6 +629,9 @@ public partial class TraumaSystem
 
         if (trauma.Comp.TraumaTarget != null)
         {
+            var evTrauma = new TraumaBeingRemovedEvent(trauma, trauma.Comp.TraumaTarget.Value, trauma.Comp.TraumaSeverity, trauma.Comp.TraumaType);
+            RaiseLocalEvent(trauma.Owner, ref evTrauma);
+
             var ev = new TraumaBeingRemovedEvent(trauma, trauma.Comp.TraumaTarget.Value, trauma.Comp.TraumaSeverity, trauma.Comp.TraumaType);
             RaiseLocalEvent(inflicterWound, ref ev);
 
@@ -645,133 +650,71 @@ public partial class TraumaSystem
 
     #region Private API
 
-    private void ApplyTraumas(Entity<WoundableComponent> target, Entity<TraumaInflicterComponent> inflicter, List<TraumaType> traumas, FixedPoint2 severity)
+    /// <summary>
+    /// Inflicts a trauma from an external cause (explosion, etc.) that has no existing wound to host it.
+    /// </summary>
+    public bool TryInflictTrauma(Entity<WoundableComponent> woundable, ProtoId<TraumaTypePrototype> traumaType, FixedPoint2 severity)
     {
-        if (_net.IsClient)
+        if (_net.IsClient
+            || Comp<BodyPartComponent>(woundable).Body == null
+            || !_wound.TryInduceWound(woundable, "Blunt", 0f, out var hostWound))
+            return false;
+
+        var inflicter = EnsureComp<TraumaInflicterComponent>(hostWound.Value.Owner);
+        ApplyTrauma(woundable, (hostWound.Value.Owner, inflicter), traumaType, severity);
+        return true;
+    }
+
+    /// <summary>
+    /// Inflicts a trauma that targets a specific organ.
+    /// </summary>
+    public bool TryInflictOrganTrauma(Entity<WoundableComponent> woundable, EntityUid organ, ProtoId<TraumaTypePrototype> traumaType, FixedPoint2 severity)
+    {
+        if (_net.IsClient
+            || Comp<BodyPartComponent>(woundable).Body == null
+            || !_wound.TryInduceWound(woundable, "Blunt", 0f, out var hostWound))
+            return false;
+
+        var inflicter = EnsureComp<TraumaInflicterComponent>(hostWound.Value.Owner);
+        AddTrauma(organ, woundable, (hostWound.Value.Owner, inflicter), traumaType, severity);
+        return true;
+    }
+
+    private void ApplyTraumas(Entity<WoundableComponent> target, Entity<TraumaInflicterComponent> inflicter, List<ProtoId<TraumaTypePrototype>> traumas, FixedPoint2 severity)
+    {
+        if (_net.IsClient
+            || !Comp<BodyPartComponent>(target).Body.HasValue)
             return;
 
-        var bodyPart = Comp<BodyPartComponent>(target);
-        if (!bodyPart.Body.HasValue)
+        foreach (var traumaType in traumas)
+            ApplyTrauma(target, inflicter, traumaType, severity);
+    }
+
+    /// <summary>
+    /// Selects the target sub-entity for a single trauma, runs the before/apply events.
+    /// </summary>
+    private void ApplyTrauma(Entity<WoundableComponent> target, Entity<TraumaInflicterComponent> inflicter, ProtoId<TraumaTypePrototype> traumaType, FixedPoint2 severity)
+    {
+        if (!_prototype.TryIndex(traumaType, out var proto))
             return;
 
-        if (!_consciousness.TryGetNerveSystem(bodyPart.Body.Value, out var nerveSys))
+        var targetChosen = SelectTraumaTarget(target, proto.Target);
+        if (targetChosen == null)
             return;
 
-        foreach (var trauma in traumas)
-        {
-            EntityUid? targetChosen = null;
-            switch (trauma)
-            {
-                case TraumaType.BoneDamage:
-                    targetChosen = target.Comp.Bone.ContainedEntities.FirstOrNull();
-                    break;
+        var beforeTraumaInduced = new BeforeTraumaInducedEvent(severity, targetChosen.Value, traumaType);
+        RaiseLocalEvent(target, ref beforeTraumaInduced);
+        if (beforeTraumaInduced.Cancelled)
+            return;
 
-                case TraumaType.OrganDamage:
-                    var organs = _body.GetPartOrgans(target).ToList();
-                    _random.Shuffle(organs);
+        var apply = new ApplyTraumaEvent(traumaType, target, inflicter, targetChosen.Value, severity);
+        RaiseLocalEvent(target, ref apply);
 
-                    var chosenOrgan = organs.FirstOrNull();
-                    if (chosenOrgan != null)
-                    {
-                        targetChosen = chosenOrgan.Value.Id;
-                    }
-
-                    break;
-                case TraumaType.Dismemberment:
-                    targetChosen = target.Comp.ParentWoundable;
-                    break;
-
-                case TraumaType.NerveDamage:
-                    targetChosen = target;
-                    break;
-            }
-
-            if (targetChosen == null)
-                continue;
-
-            var beforeTraumaInduced = new BeforeTraumaInducedEvent(severity, targetChosen.Value, trauma);
-            RaiseLocalEvent(target, ref beforeTraumaInduced);
-
-            if (beforeTraumaInduced.Cancelled)
-                continue;
-
-            switch (trauma)
-            {
-                case TraumaType.BoneDamage:
-                    if (ApplyBoneTrauma(targetChosen.Value, target, inflicter, severity))
-                    {
-                        _pain.TryAddPainModifier(
-                            nerveSys.Value.Owner,
-                                target.Owner,
-                                "BoneDamage",
-                                severity / 1.4f,
-                                PainDamageTypes.TraumaticPain,
-                                nerveSys.Value.Comp);
-                    }
-
-                    break;
-
-                case TraumaType.OrganDamage:
-                    var traumaEnt = AddTrauma(targetChosen.Value, target, inflicter, TraumaType.OrganDamage, severity);
-
-                    if (traumaEnt != EntityUid.Invalid
-                        && !TryChangeOrganDamageModifier(targetChosen.Value, severity, traumaEnt, "WoundableDamage"))
-                    {
-                        TryCreateOrganDamageModifier(targetChosen.Value, severity, traumaEnt, "WoundableDamage");
-                    }
-
-                    break;
-
-                case TraumaType.NerveDamage:
-                    var time = TimeSpan.FromSeconds((float) severity * 2.4);
-
-                    // Fooling people into thinking they have no pain.
-                    // 10 (raw pain) * 1.4 (multiplier) = 14 (actual pain)
-                    // 1 - 0.28 = 0.72 (the fraction of pain the person feels)
-                    // 14 * 0.72 = 10.08 (the pain the player can actually see) ... Barely noticeable :3
-                    _pain.TryAddPainMultiplier(nerveSys.Value,
-                        "NerveDamage",
-                        1.4f,
-                        time: time);
-
-                    _pain.TryAddPainFeelsModifier(nerveSys.Value,
-                        "NerveDamage",
-                        target,
-                        -0.28f,
-                        time: time);
-                    foreach (var child in _wound.GetAllWoundableChildren(target))
-                    {
-                        // Funner! Very unlucky of you if your torso gets hit. Rest in pieces
-                        _pain.TryAddPainFeelsModifier(nerveSys.Value,
-                            "NerveDamage",
-                            child,
-                            -0.7f,
-                            time: time);
-                    }
-
-                    break;
-
-                case TraumaType.Dismemberment:
-                    if (!_wound.IsWoundableRoot(target)
-                        && _wound.TryInduceWound(targetChosen.Value, "Blunt", 0f, out var woundInduced)) // We need this to add the trauma into.
-                    {
-                        AddTrauma(
-                            targetChosen.Value,
-                            (targetChosen.Value, Comp<WoundableComponent>(targetChosen.Value)),
-                            (woundInduced.Value.Owner, EnsureComp<TraumaInflicterComponent>(woundInduced.Value.Owner)),
-                            TraumaType.Dismemberment,
-                            severity,
-                            (bodyPart.PartType, bodyPart.Symmetry));
-
-                        _wound.AmputateWoundable(targetChosen.Value, target, target);
-                    }
-                    break;
-            }
-
-            //Log.Debug($"A new trauma (Raw Severity: {severity}) was created on target: {ToPrettyString(target)}. Type: {trauma}.");
-        }
+        if (!apply.Handled)
+            AddTrauma(targetChosen.Value, target, inflicter, traumaType, severity);
 
         // TODO: veins, would have been very lovely to integrate this into vascular system
+        // TODO: FUCK YOURSELF
         //if (RandomVeinsTraumaChance(woundable))
         //{
         //    traumaApplied = ApplyDamageToVeins(woundable.Veins!.ContainedEntities[0], severity * _veinsDamageMultipliers[woundable.WoundableSeverity]);
@@ -781,6 +724,109 @@ public partial class TraumaSystem
         //}
     }
 
+    private EntityUid? SelectTraumaTarget(Entity<WoundableComponent> woundable, TraumaTarget target)
+    {
+        return target switch
+        {
+            TraumaTarget.Bone => woundable.Comp.Bone.ContainedEntities.FirstOrNull(),
+            TraumaTarget.Organ => SelectRandomOrgan(woundable),
+            TraumaTarget.ParentWoundable => woundable.Comp.ParentWoundable,
+            TraumaTarget.Woundable => woundable.Owner,
+            _ => null,
+        };
+    }
+
+    private EntityUid? SelectRandomOrgan(Entity<WoundableComponent> woundable)
+    {
+        var organs = _body.GetPartOrgans(woundable).ToList();
+        if (organs.Count == 0)
+            return null;
+
+        _random.Shuffle(organs);
+        return organs[0].Id;
+    }
+
+    /// <summary>
+    /// Applies the old trauma behaviours.
+    /// TODO: NUKE TS AS WELL, FUCK YOU MOCHO
+    /// </summary>
+    private void OnApplyTrauma(Entity<WoundableComponent> ent, ref ApplyTraumaEvent args)
+    {
+        var target = args.Woundable;
+        var inflicter = args.Inflicter;
+        var severity = args.Severity;
+        var targetChosen = args.Target;
+        var bodyPart = Comp<BodyPartComponent>(target);
+
+        if (args.TraumaType == BoneDamage)
+        {
+            if (ApplyBoneTrauma(targetChosen, target, inflicter, severity)
+                && bodyPart.Body is { } bodyBone
+                && _consciousness.TryGetNerveSystem(bodyBone, out var nerveBone))
+            {
+                _pain.TryAddPainModifier(
+                    nerveBone.Value.Owner,
+                    target.Owner,
+                    "BoneDamage",
+                    severity / 1.4f,
+                    PainDamageTypes.TraumaticPain,
+                    nerveBone.Value.Comp);
+            }
+
+            args.Handled = true;
+        }
+        else if (args.TraumaType == OrganDamage)
+        {
+            var traumaEnt = AddTrauma(targetChosen, target, inflicter, OrganDamage, severity);
+
+            if (traumaEnt != EntityUid.Invalid
+                && !TryChangeOrganDamageModifier(targetChosen, severity, traumaEnt, "WoundableDamage"))
+                TryCreateOrganDamageModifier(targetChosen, severity, traumaEnt, "WoundableDamage");
+
+            args.Handled = true;
+        }
+        else if (args.TraumaType == NerveDamage)
+        {
+            if (bodyPart.Body is { } bodyNerve
+                && _consciousness.TryGetNerveSystem(bodyNerve, out var nerveNerve))
+            {
+                var time = TimeSpan.FromSeconds((float) severity * 2.4);
+
+                // Fooling people into thinking they have no pain.
+                // 10 (raw pain) * 1.4 (multiplier) = 14 (actual pain)
+                // 1 - 0.28 = 0.72 (the fraction of pain the person feels)
+                // 14 * 0.72 = 10.08 (the pain the player can actually see) ... Barely noticeable :3
+                // KYS
+                _pain.TryAddPainMultiplier(nerveNerve.Value, "NerveDamage", 1.4f, time: time);
+                _pain.TryAddPainFeelsModifier(nerveNerve.Value, "NerveDamage", target, -0.28f, time: time);
+
+                foreach (var child in _wound.GetAllWoundableChildren(target))
+                {
+                    _pain.TryAddPainFeelsModifier(nerveNerve.Value, "NerveDamage", child, -0.7f, time: time);
+                }
+            }
+
+            args.Handled = true;
+        }
+        else if (args.TraumaType == Dismemberment)
+        {
+            if (!_wound.IsWoundableRoot(target)
+                && _wound.TryInduceWound(targetChosen, "Blunt", 0f, out var woundInduced)) // We need this to add the trauma into.
+            {
+                AddTrauma(
+                    targetChosen,
+                    (targetChosen, Comp<WoundableComponent>(targetChosen)),
+                    (woundInduced.Value.Owner, EnsureComp<TraumaInflicterComponent>(woundInduced.Value.Owner)),
+                    Dismemberment,
+                    severity,
+                    (bodyPart.PartType, bodyPart.Symmetry));
+
+                _wound.AmputateWoundable(targetChosen, target, target);
+            }
+
+            args.Handled = true;
+        }
+    }
 
     #endregion
 }

--- a/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Process.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Process.cs
@@ -73,7 +73,7 @@ public partial class TraumaSystem
         Entity<TraumaInflicterComponent> woundEnt,
         ref WoundSeverityPointChangedEvent args)
     {
-        if (!_timing.IsFirstTimePredicted
+        if (_net.IsClient
             || HasComp<GodmodeComponent>(args.Component.HoldingWoundable))
             return;
 
@@ -303,16 +303,15 @@ public partial class TraumaSystem
 
         foreach (var ent in _inventory.GetHandOrInventoryEntities(body, SlotFlags.WITHOUT_POCKET))
         {
-            if (!TryComp<ArmorComponent>(ent, out var armour))
+            if (!TryComp<ArmorComponent>(ent, out var armour)
+                || !armour.TraumaDeductions.TryGetValue(traumaType, out var traumaDeduction))
                 continue;
 
-            if (!inflicter.Comp.AllowArmourDeduction.Contains(traumaType) && armour.TraumaDeductions[traumaType] >= 0)
+            if (!inflicter.Comp.AllowArmourDeduction.Contains(traumaType) && traumaDeduction >= 0)
                 continue;
 
             if (armour.ArmorCoverage.Contains(coverage))
-            {
-                deduction += armour.TraumaDeductions[traumaType];
-            }
+                deduction += traumaDeduction;
         }
 
         return deduction;
@@ -498,8 +497,8 @@ public partial class TraumaSystem
             return false;
 
         if (bodyPart.PartType == BodyPartType.Chest
-            || bodyPart.PartType == BodyPartType.Groin
-            && Comp<WoundableComponent>(parentWoundable.Value).WoundableSeverity != WoundableSeverity.Mangled)
+            || (bodyPart.PartType == BodyPartType.Groin
+            && Comp<WoundableComponent>(parentWoundable.Value).WoundableSeverity != WoundableSeverity.Mangled))
             return false;
 
         var deduction = GetTraumaChanceDeduction(
@@ -578,6 +577,7 @@ public partial class TraumaSystem
                 continue;
 
             containedTraumaComp.TraumaSeverity = severity;
+            Dirty(trauma, containedTraumaComp);
             return trauma;
         }
 
@@ -647,6 +647,9 @@ public partial class TraumaSystem
 
     private void ApplyTraumas(Entity<WoundableComponent> target, Entity<TraumaInflicterComponent> inflicter, List<TraumaType> traumas, FixedPoint2 severity)
     {
+        if (_net.IsClient)
+            return;
+
         var bodyPart = Comp<BodyPartComponent>(target);
         if (!bodyPart.Body.HasValue)
             return;
@@ -749,7 +752,6 @@ public partial class TraumaSystem
                     break;
 
                 case TraumaType.Dismemberment:
-                    Logger.Debug("Attempting to trigger dismemberment");
                     if (!_wound.IsWoundableRoot(target)
                         && _wound.TryInduceWound(targetChosen.Value, "Blunt", 0f, out var woundInduced)) // We need this to add the trauma into.
                     {
@@ -762,7 +764,6 @@ public partial class TraumaSystem
                             (bodyPart.PartType, bodyPart.Symmetry));
 
                         _wound.AmputateWoundable(targetChosen.Value, target, target);
-                        Logger.Debug($"Amputating woundable.");
                     }
                     break;
             }

--- a/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.cs
@@ -14,6 +14,7 @@ using Robust.Shared.Audio.Systems;
 using Robust.Shared.Configuration;
 using Robust.Shared.Containers;
 using Robust.Shared.Network;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
@@ -21,6 +22,14 @@ namespace Content.Shared._Shitmed.Medical.Surgery.Traumas.Systems;
 
 public sealed partial class TraumaSystem : EntitySystem
 {
+    public static readonly ProtoId<TraumaTypePrototype> BoneDamage = "BoneDamage";
+    public static readonly ProtoId<TraumaTypePrototype> OrganDamage = "OrganDamage";
+    public static readonly ProtoId<TraumaTypePrototype> NerveDamage = "NerveDamage";
+    public static readonly ProtoId<TraumaTypePrototype> Dismemberment = "Dismemberment";
+    public static readonly ProtoId<TraumaTypePrototype> VeinsDamage = "VeinsDamage";
+    public static readonly ProtoId<TraumaTypePrototype> Braindeath = "Braindeath";
+
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly INetManager _net = default!;

--- a/Content.Shared/_Shitmed/Surgery/Traumas/TraumaCause.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/TraumaCause.cs
@@ -1,0 +1,73 @@
+using Content.Goobstation.Maths.FixedPoint;
+using Content.Shared.Body.Part;
+using Content.Shared.Damage.Prototypes;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._Shitmed.Medical.Surgery.Traumas;
+
+[ImplicitDataDefinitionForInheritors]
+public abstract partial class TraumaCause
+{
+    /// <summary>
+    /// If set, this cause can only inflict the trauma on these body part types. Null means any part.
+    /// </summary>
+    [DataField]
+    public List<BodyPartType>? AllowedParts;
+
+    /// <summary>
+    /// Whether the chosen target woundable's part type is allowed by this cause.
+    /// </summary>
+    public bool PartAllowed(BodyPartType partType)
+    {
+        return AllowedParts == null || AllowedParts.Contains(partType);
+    }
+}
+
+/// <summary>
+/// Inflicts a trauma when the entity takes explosion damage.
+/// </summary>
+public sealed partial class ExplosionCause : TraumaCause
+{
+    /// <summary>
+    /// Minimum total explosion damage dealt to this entity before a roll happens.
+    /// </summary>
+    [DataField]
+    public FixedPoint2 MinDamage = 40;
+
+    /// <summary>
+    /// Base probability of inflicting the trauma once past <see cref="MinDamage"/>.
+    /// </summary>
+    [DataField]
+    public float Chance = 0.25f;
+
+    /// <summary>
+    /// If true, the chance scales up as damage exceeds <see cref="MinDamage"/>.
+    /// </summary>
+    [DataField]
+    public bool ScaleWithDamage = true;
+}
+
+/// <summary>
+/// Inflicts a trauma when a wound of a matching damage type gains severity.
+public sealed partial class WoundSeverityCause : TraumaCause
+{
+    /// <summary>
+    /// Damage types of wound that can inflict this trauma. Null/empty means any damaging wound.
+    /// </summary>
+    [DataField]
+    public List<ProtoId<DamageTypePrototype>>? DamageTypes;
+
+    /// <summary>
+    /// Formula that computes the base chance for this cause. Null uses the prototype's BaseChance.
+    /// </summary>
+    [DataField]
+    public TraumaChance? Chance;
+
+    /// <summary>
+    /// Whether a wound of the given damage type can inflict this trauma.
+    /// </summary>
+    public bool DamageAllowed(ProtoId<DamageTypePrototype> damageType)
+    {
+        return DamageTypes == null || DamageTypes.Count == 0 || DamageTypes.Contains(damageType);
+    }
+}

--- a/Content.Shared/_Shitmed/Surgery/Traumas/TraumaChance.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/TraumaChance.cs
@@ -1,0 +1,182 @@
+using System.Linq;
+using Content.Goobstation.Maths.FixedPoint;
+using Content.Shared._Shitmed.Medical.Surgery.Pain.Components;
+using Content.Shared._Shitmed.Medical.Surgery.Traumas.Components;
+using Content.Shared._Shitmed.Medical.Surgery.Wounds;
+using Content.Shared._Shitmed.Medical.Surgery.Wounds.Components;
+using Content.Shared.Body.Part;
+using Content.Shared.Body.Systems;
+using Content.Shared.Damage.Prototypes;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Content.Shared._Shitmed.Medical.Surgery.Traumas;
+
+public readonly struct TraumaChanceArgs
+{
+    public readonly IEntityManager EntityManager;
+    public readonly Entity<WoundableComponent> Target;
+    public readonly Entity<TraumaInflicterComponent> Inflicter;
+    public readonly FixedPoint2 Severity;
+    public readonly BodyPartComponent Part;
+    public readonly EntityUid Body;
+
+    public TraumaChanceArgs(
+        IEntityManager entityManager,
+        Entity<WoundableComponent> target,
+        Entity<TraumaInflicterComponent> inflicter,
+        FixedPoint2 severity,
+        BodyPartComponent part,
+        EntityUid body)
+    {
+        EntityManager = entityManager;
+        Target = target;
+        Inflicter = inflicter;
+        Severity = severity;
+        Part = part;
+        Body = body;
+    }
+}
+
+[ImplicitDataDefinitionForInheritors]
+public abstract partial class TraumaChance
+{
+    public abstract FixedPoint2? Calculate(in TraumaChanceArgs args);
+}
+
+public sealed partial class FlatTraumaChance : TraumaChance
+{
+    [DataField]
+    public FixedPoint2 Chance;
+
+    public override FixedPoint2? Calculate(in TraumaChanceArgs args)
+    {
+        return Chance;
+    }
+}
+
+/// <summary>
+/// Bone fracture chance, scales with how damaged the part and its bone already are.
+/// </summary>
+public sealed partial class BoneFractureChance : TraumaChance
+{
+    [DataField]
+    public Dictionary<WoundableSeverity, FixedPoint2> SeverityMultipliers = new()
+    {
+        { WoundableSeverity.Healthy, 0 },
+        { WoundableSeverity.Minor, 0.01 },
+        { WoundableSeverity.Moderate, 0.04 },
+        { WoundableSeverity.Severe, 0.12 },
+        { WoundableSeverity.Critical, 0.21 },
+        { WoundableSeverity.Mangled, 0.21 },
+        { WoundableSeverity.Severed, 0 },
+    };
+
+    public override FixedPoint2? Calculate(in TraumaChanceArgs args)
+    {
+        var target = args.Target;
+        if (target.Comp.Bone.ContainedEntities.FirstOrNull() is not { } bone
+            || !args.EntityManager.TryGetComponent(bone, out BoneComponent? boneComp)
+            || boneComp.BoneSeverity == BoneSeverity.Broken)
+            return null;
+
+        return target.Comp.IntegrityCap / (target.Comp.WoundableIntegrity + boneComp.BoneIntegrity)
+            * SeverityMultipliers.GetValueOrDefault(target.Comp.WoundableSeverity);
+    }
+}
+
+/// <summary>
+/// Nerve damage chance, only on parts that can still feel pain.
+/// </summary>
+public sealed partial class NerveTraumaChance : TraumaChance
+{
+    [DataField]
+    public float MinPainFeels = 0.2f;
+
+    [DataField]
+    public FixedPoint2 Divisor = 20;
+
+    public override FixedPoint2? Calculate(in TraumaChanceArgs args)
+    {
+        if (!args.EntityManager.TryGetComponent(args.Target, out NerveComponent? nerve)
+            || nerve.PainFeels < MinPainFeels)
+            return null;
+
+        return args.Target.Comp.WoundableIntegrity / args.Target.Comp.IntegrityCap / Divisor;
+    }
+}
+
+/// <summary>
+/// Organ damage chance, dealt to a random surviving organ in the part.
+/// </summary>
+public sealed partial class OrganTraumaChance : TraumaChance
+{
+    [DataField]
+    public FixedPoint2 BaseChance = 0.4;
+
+    public override FixedPoint2? Calculate(in TraumaChanceArgs args)
+    {
+        var body = args.EntityManager.System<SharedBodySystem>();
+        var hasOrgan = false;
+        foreach (var organ in body.GetPartOrgans(args.Target, args.Part))
+        {
+            if (organ.Component.OrganIntegrity <= 0)
+                continue;
+
+            hasOrgan = true;
+            break;
+        }
+
+        return hasOrgan ? BaseChance : null;
+    }
+}
+
+/// <summary>
+/// Dismemberment chance, scales with how damaged the part and its bone already are.
+/// </summary>
+public sealed partial class DismembermentChance : TraumaChance
+{
+    [DataField]
+    public float IntegrityExponent = 1.3f;
+
+    [DataField]
+    public Dictionary<BoneSeverity, float> BoneMultipliers = new()
+    {
+        { BoneSeverity.Normal, 0.3f },
+        { BoneSeverity.Damaged, 0.6f },
+        { BoneSeverity.Cracked, 1f },
+        { BoneSeverity.Broken, 1.2f },
+    };
+
+    [DataField]
+    public Dictionary<ProtoId<DamageTypePrototype>, float> DamageTypeMultipliers = new();
+
+    public override FixedPoint2? Calculate(in TraumaChanceArgs args)
+    {
+        var em = args.EntityManager;
+        var target = args.Target;
+
+        if (target.Comp.ParentWoundable is not { } parentWoundable)
+            return null;
+
+        if (args.Part.PartType == BodyPartType.Chest
+            || args.Part.PartType == BodyPartType.Groin
+                && em.GetComponent<WoundableComponent>(parentWoundable).WoundableSeverity != WoundableSeverity.Mangled)
+            return null;
+
+        var bonePenalty = FixedPoint2.New(1);
+        if (em.TryGetComponent(target, out BonelessComponent? bonelessComp))
+            bonePenalty = bonelessComp.BonePenalty;
+
+        var multiplier = 1f;
+        if (target.Comp.Bone.ContainedEntities.FirstOrNull() is { } bone
+            && em.TryGetComponent(bone, out BoneComponent? boneComp))
+            multiplier = BoneMultipliers.GetValueOrDefault(boneComp.BoneSeverity, 1f);
+
+        if (DamageTypeMultipliers.Count > 0
+            && em.TryGetComponent(args.Inflicter, out WoundComponent? inflicterWound))
+            multiplier *= DamageTypeMultipliers.GetValueOrDefault(inflicterWound.DamageType, 1f);
+
+        return (1f - (MathF.Pow(target.Comp.WoundableIntegrity.Float(), IntegrityExponent) / target.Comp.IntegrityCap - 1f) * bonePenalty) * multiplier;
+    }
+}

--- a/Content.Shared/_Shitmed/Surgery/Traumas/TraumaTreatment.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/TraumaTreatment.cs
@@ -1,0 +1,15 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._Shitmed.Medical.Surgery.Traumas;
+
+/// <summary>
+/// Declares how a trauma can be treated / removed.
+/// </summary>
+[ImplicitDataDefinitionForInheritors]
+public abstract partial class TraumaTreatment;
+
+/// <summary>
+/// The trauma is removed by surgery. Presence of this treatment makes the trauma eligible for the generic "extract foreign body" surgery.
+/// Define a new surgery instead when you want something else.
+/// </summary>
+public sealed partial class SurgicalTreatment : TraumaTreatment;

--- a/Content.Shared/_Shitmed/Surgery/Traumas/TraumaTypePrototype.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/TraumaTypePrototype.cs
@@ -1,0 +1,89 @@
+using Content.Goobstation.Maths.FixedPoint;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
+
+namespace Content.Shared._Shitmed.Medical.Surgery.Traumas;
+
+/// <summary>
+/// Defines a kind of trauma.
+/// </summary>
+[Prototype]
+public sealed partial class TraumaTypePrototype : IPrototype
+{
+    [IdDataField]
+    public string ID { get; private set; } = default!;
+
+    /// <summary>
+    /// Localization id base used for popups and the health analyzer.
+    /// </summary>
+    [DataField]
+    public string? Name;
+
+    /// <summary>
+    /// Minimum inflicting-wound severity (delta) before this trauma is eligible to roll.
+    /// </summary>
+    [DataField]
+    public FixedPoint2 SeverityGate = 10;
+
+    /// <summary>
+    /// Whether wounds carrying this trauma refuse to heal while it is present.
+    /// </summary>
+    [DataField]
+    public bool BlocksHealing;
+
+    /// <summary>
+    /// Which entity in the woundable this trauma is applied to / targets.
+    /// </summary>
+    [DataField]
+    public TraumaTarget Target = TraumaTarget.Woundable;
+
+    /// <summary>
+    /// The entity spawned to represent an instance of this trauma.
+    /// </summary>
+    [DataField(required: true)]
+    public EntProtoId TraumaEntity;
+
+    /// <summary>
+    /// Fallback chance (0-1) used when a cause has no <see cref="TraumaChance"/> provider of its own.
+    /// </summary>
+    [DataField]
+    public FixedPoint2 BaseChance;
+
+    /// <summary>
+    /// Causes that can inflict this trauma (explosion, wound severity, etc.)
+    /// </summary>
+    [DataField]
+    public List<TraumaCause>? Causes;
+
+    /// <summary>
+    /// How this trauma can be treated / removed. Null means it is not treatable on its own (e.g. it clears when the underlying bone/organ heals).
+    /// </summary>
+    [DataField]
+    public TraumaTreatment? Treatment;
+
+    /// <summary>
+    /// Optional icon for the health analyzer / part status display.
+    /// </summary>
+    [DataField]
+    public SpriteSpecifier? Icon;
+}
+
+/// <summary>
+/// Which entity inside (or around) the woundable a trauma is applied to.
+/// </summary>
+[Serializable, NetSerializable]
+public enum TraumaTarget : byte
+{
+    /// <summary>The woundable body part itself.</summary>
+    Woundable,
+
+    /// <summary>The woundable's bone entity.</summary>
+    Bone,
+
+    /// <summary>A random organ in the woundable.</summary>
+    Organ,
+
+    /// <summary>The parent woundable (used by dismemberment).</summary>
+    ParentWoundable,
+}

--- a/Content.Shared/_Shitmed/Surgery/Traumas/TraumasSerializable.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/TraumasSerializable.cs
@@ -1,19 +1,24 @@
 ﻿using Content.Shared._Shitmed.Medical.Surgery.Traumas.Components;
+using Content.Shared._Shitmed.Medical.Surgery.Wounds.Components;
 using Content.Shared.Body.Organ;
 using Content.Goobstation.Maths.FixedPoint;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared._Shitmed.Medical.Surgery.Traumas;
 
-[Serializable, NetSerializable]
-public enum TraumaType
-{
-    BoneDamage,
-    OrganDamage,
-    VeinsDamage,
-    NerveDamage, // pain
-    Dismemberment,
-}
+#region Dispatch
+
+[ByRefEvent]
+public record struct ApplyTraumaEvent(
+    ProtoId<TraumaTypePrototype> TraumaType,
+    Entity<WoundableComponent> Woundable,
+    Entity<TraumaInflicterComponent> Inflicter,
+    EntityUid Target,
+    FixedPoint2 Severity,
+    bool Handled = false);
+
+#endregion
 
 #region Organs
 
@@ -37,16 +42,16 @@ public record struct OrganIntegrityChangedEventOnWoundable(Entity<OrganComponent
 [ByRefEvent]
 public record struct OrganDamageSeverityChangedOnWoundable(Entity<OrganComponent> Organ, OrganSeverity OldSeverity, OrganSeverity NewSeverity);
 [ByRefEvent]
-public record struct TraumaChanceDeductionEvent(FixedPoint2 TraumaSeverity, TraumaType TraumaType, FixedPoint2 ChanceDeduction);
+public record struct TraumaChanceDeductionEvent(FixedPoint2 TraumaSeverity, ProtoId<TraumaTypePrototype> TraumaType, FixedPoint2 ChanceDeduction);
 
 [ByRefEvent]
-public record struct BeforeTraumaInducedEvent(FixedPoint2 TraumaSeverity, EntityUid TraumaTarget, TraumaType TraumaType, bool Cancelled = false);
+public record struct BeforeTraumaInducedEvent(FixedPoint2 TraumaSeverity, EntityUid TraumaTarget, ProtoId<TraumaTypePrototype> TraumaType, bool Cancelled = false);
 
 [ByRefEvent]
-public record struct TraumaInducedEvent(Entity<TraumaComponent> Trauma, EntityUid TraumaTarget, FixedPoint2 TraumaSeverity, TraumaType TraumaType);
+public record struct TraumaInducedEvent(Entity<TraumaComponent> Trauma, EntityUid TraumaTarget, FixedPoint2 TraumaSeverity, ProtoId<TraumaTypePrototype> TraumaType);
 
 [ByRefEvent]
-public record struct TraumaBeingRemovedEvent(Entity<TraumaComponent> Trauma, EntityUid TraumaTarget, FixedPoint2 TraumaSeverity, TraumaType TraumaType);
+public record struct TraumaBeingRemovedEvent(Entity<TraumaComponent> Trauma, EntityUid TraumaTarget, FixedPoint2 TraumaSeverity, ProtoId<TraumaTypePrototype> TraumaType);
 
 #endregion
 

--- a/Content.Shared/_Shitmed/Surgery/Wounds/Components/WoundableComponent.cs
+++ b/Content.Shared/_Shitmed/Surgery/Wounds/Components/WoundableComponent.cs
@@ -210,6 +210,4 @@ public sealed class WoundableComponentState : ComponentState
     public Dictionary<NetEntity, WoundableHealingMultiplier> HealingMultipliers = new();
 
     public WoundableSeverity WoundableSeverity;
-
-    public float HealingRateAccumulated;
 }

--- a/Content.Shared/_Shitmed/Surgery/Wounds/Components/WoundableComponent.cs
+++ b/Content.Shared/_Shitmed/Surgery/Wounds/Components/WoundableComponent.cs
@@ -40,6 +40,9 @@ public sealed partial class WoundableComponent : Component
     [DataField]
     public bool AllowWounds = true;
 
+    [DataField]
+    public bool RedirectOverflowDamage;
+
     /// <summary>
     /// The same as DamageableComponent's one
     /// </summary>
@@ -182,9 +185,9 @@ public sealed partial class WoundableComponent : Component
     public DamageSpecifier? DamageOnAmputate;
 
     [DataField]
-    public Dictionary<TraumaType, FixedPoint2> TraumaDeductions = new()
+    public Dictionary<ProtoId<TraumaTypePrototype>, FixedPoint2> TraumaDeductions = new()
     {
-        {TraumaType.Dismemberment, 0.3f},
+        { "Dismemberment", 0.3f },
     };
 }
 

--- a/Content.Shared/_Shitmed/Surgery/Wounds/Systems/WoundSystem.Destruction.cs
+++ b/Content.Shared/_Shitmed/Surgery/Wounds/Systems/WoundSystem.Destruction.cs
@@ -1,15 +1,18 @@
+using Content.Goobstation.Maths.FixedPoint;
 using Content.Shared._Shitmed.Medical.Surgery.Traumas;
 using Content.Shared._Shitmed.Medical.Surgery.Traumas.Components;
 using Content.Shared._Shitmed.Medical.Surgery.Wounds.Components;
 using Content.Shared._Shitmed.Targeting;
 using Content.Shared._Shitmed.Targeting.Events;
 using Content.Shared.Body.Part;
+using Content.Shared.Body.Systems;
 using Content.Shared.Humanoid;
 using Content.Shared.Inventory;
 using Content.Shared.Popups;
 using Content.Shared.Standing;
 using Content.Goobstation.Common.Medical;
 using Robust.Shared.Audio;
+using Robust.Shared.Random;
 
 
 namespace Content.Shared._Shitmed.Medical.Surgery.Wounds.Systems;
@@ -66,7 +69,7 @@ public sealed partial class WoundSystem
                     15f,
                     (bodyPart.PartType, bodyPart.Symmetry));
 
-                ApplyDismembermentBleeding(woundInduced.Value.Owner);
+                ApplyWoundBleeding(woundInduced.Value.Owner);
             }
 
             Dirty(woundableEntity, woundableComp);
@@ -92,8 +95,7 @@ public sealed partial class WoundSystem
 
             DropWoundableOrgans(woundableEntity, woundableComp);
 
-            ApplyDismembermentBleeding(parentWoundableEntity);
-            _body.DetachPart(parentWoundableEntity, bodyPartId.Remove(0, 15), woundableEntity);
+            _body.DetachPart(parentWoundableEntity, bodyPartId.Remove(0, SharedBodySystem.PartSlotContainerIdPrefix.Length), woundableEntity);
             DestroyWoundableChildren(woundableEntity, woundableComp);
 
             PredictedQueueDel(woundableEntity);
@@ -132,21 +134,7 @@ public sealed partial class WoundSystem
 
         AmputateWoundableSafely(parentWoundableEntity, woundableEntity);
 
-        if (TryComp<WoundableComponent>(parentWoundableEntity, out var parentWoundable)
-            && parentWoundable.CanBleed)
-        {
-            foreach (var wound in GetWoundableWounds(parentWoundableEntity))
-            {
-                if (!TryComp<BleedInflicterComponent>(wound, out var bleeds))
-                    continue;
-
-                bleeds.BleedingAmountRaw += 20f;
-                bleeds.Scaling = 1f;
-                bleeds.ScalingLimit = 1f;
-                bleeds.IsBleeding = true;
-            }
-        }
-
+        ApplyDismembermentBleeding(parentWoundableEntity);
 
         if (!_net.IsServer)
             return;
@@ -210,7 +198,7 @@ public sealed partial class WoundSystem
 
         // Still does the funny popping, if the children are critted. for the funny :3
         DestroyWoundableChildren(woundableEntity, woundableComp, amputateChildrenSafely);
-        _body.DetachPart(parentWoundableEntity, bodyPartId.Remove(0, 15), woundableEntity);
+        _body.DetachPart(parentWoundableEntity, bodyPartId.Remove(0, SharedBodySystem.PartSlotContainerIdPrefix.Length), woundableEntity);
     }
 
     private void DestroyWoundableChildren(EntityUid woundableEntity,
@@ -220,7 +208,7 @@ public sealed partial class WoundSystem
         if (!Resolve(woundableEntity, ref woundableComp, false))
             return;
 
-        foreach (var child in woundableComp.ChildWoundables)
+        foreach (var child in new List<EntityUid>(woundableComp.ChildWoundables))
         {
             var childWoundable = Comp<WoundableComponent>(child);
             if (childWoundable.WoundableSeverity is WoundableSeverity.Mangled)
@@ -254,7 +242,7 @@ public sealed partial class WoundSystem
                 _throwing.TryThrow(
                     organ.Id,
                     _random.NextAngle().RotateVec(direction / dropAngle + worldRotation / 50),
-                    0.5f * dropAngle * _random.NextFloat(-0.9f, 1.1f),
+                    0.5f * dropAngle * _random.NextFloat(0.2f, 1.1f),
                     doSpin: false,
                     pushbackRatio: 0
                 );
@@ -264,26 +252,37 @@ public sealed partial class WoundSystem
                 // Destroy it
                 _trauma.TrySetOrganDamageModifier(
                     organ.Id,
-                    organ.Component.OrganIntegrity * 100,
+                    organ.Component.IntegrityCap * 100,
                     woundable,
-                    "LETMETELLYOUHOWMUCHIVECOMETOHATEYOUSINCEIBEGANTOLIVE",
+                    "OrganDestroyed",
                     organ.Component);
             }
         }
     }
 
-    private void ApplyDismembermentBleeding(EntityUid target, float amount = 20f)
+    private void ApplyWoundBleeding(EntityUid wound, float amount = 20f)
     {
-        var bleedInflicter = EnsureComp<BleedInflicterComponent>(target);
+        var bleedInflicter = EnsureComp<BleedInflicterComponent>(wound);
         bleedInflicter.BleedingAmountRaw += amount;
-        bleedInflicter.Scaling = 1f;
-        bleedInflicter.ScalingLimit = 1f;
+        bleedInflicter.Scaling = FixedPoint2.Max(bleedInflicter.Scaling, 1);
+        bleedInflicter.ScalingLimit = FixedPoint2.Max(bleedInflicter.ScalingLimit, 1);
         bleedInflicter.IsBleeding = true;
+        Dirty(wound, bleedInflicter);
     }
 
-    private bool TryFumble(string message, SoundPathSpecifier sound, EntityUid body, float odds)
+    private void ApplyDismembermentBleeding(EntityUid woundable, float amount = 20f)
     {
-        if (_random.NextFloat() < odds)
+        if (TryComp<WoundableComponent>(woundable, out var woundableComp) && !woundableComp.CanBleed)
+            return;
+
+        foreach (var wound in GetWoundableWounds(woundable))
+            ApplyWoundBleeding(wound, amount);
+    }
+
+    public bool TryFumble(string message, SoundPathSpecifier sound, EntityUid body, float odds)
+    {
+        var seed = unchecked((int) _timing.CurTick.Value + GetNetEntity(body).Id * 92821);
+        if (new System.Random(seed).NextFloat() < odds)
         {
             _popup.PopupClient(Loc.GetString(message), body, PopupType.Medium);
             var ev = new DropHandItemsEvent();

--- a/Content.Shared/_Shitmed/Surgery/Wounds/Systems/WoundSystem.Destruction.cs
+++ b/Content.Shared/_Shitmed/Surgery/Wounds/Systems/WoundSystem.Destruction.cs
@@ -13,6 +13,7 @@ using Content.Shared.Standing;
 using Content.Goobstation.Common.Medical;
 using Robust.Shared.Audio;
 using Robust.Shared.Random;
+using Content.Shared._Shitmed.Medical.Surgery.Traumas.Systems;
 
 
 namespace Content.Shared._Shitmed.Medical.Surgery.Wounds.Systems;
@@ -65,7 +66,7 @@ public sealed partial class WoundSystem
                     parentWoundableEntity,
                     (parentWoundableEntity, Comp<WoundableComponent>(parentWoundableEntity)),
                     (woundInduced.Value.Owner, traumaInflicter),
-                    TraumaType.Dismemberment,
+                    TraumaSystem.Dismemberment,
                     15f,
                     (bodyPart.PartType, bodyPart.Symmetry));
 

--- a/Content.Shared/_Shitmed/Surgery/Wounds/Systems/WoundSystem.Healing.cs
+++ b/Content.Shared/_Shitmed/Surgery/Wounds/Systems/WoundSystem.Healing.cs
@@ -7,6 +7,7 @@ using Content.Shared._Shitmed.Medical.Surgery.Wounds.Components;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Goobstation.Maths.FixedPoint;
+using Content.Shared._Shitmed.Medical.Surgery.Consciousness.Systems;
 using Content.Shared._Shitmed.Medical.Surgery.Pain.Components;
 using Content.Shared._Shitmed.Medical.Surgery.Pain.Systems;
 using Content.Shared.Body.Part;
@@ -22,6 +23,7 @@ namespace Content.Shared._Shitmed.Medical.Surgery.Wounds.Systems;
 public sealed partial class WoundSystem
 {
     [Dependency] private readonly PainSystem _pain = default!;
+    [Dependency] private readonly ConsciousnessSystem _consciousness = default!;
 
     // Updates pain state after wounds are healed and starts pain decay
     /// <param name="woundable">The entity on which to update the pain state</param>
@@ -31,22 +33,18 @@ public sealed partial class WoundSystem
         if (!TryComp<BodyPartComponent>(woundable, out var bodyPart) || !bodyPart.Body.HasValue)
             return;
 
-        // Get the body entity.
-        var body = bodyPart.Body.Value;
-
-        // Check if the body has a NerveSystemComponent.
-        if (!TryComp<NerveSystemComponent>(body, out var nerveSystem))
+        if (!_consciousness.TryGetNerveSystem(bodyPart.Body.Value, out var nerveSys))
             return;
 
         // Start pain decay if there's still pain after healing
-        if (nerveSystem.Pain > FixedPoint2.Zero)
+        if (nerveSys.Value.Comp.Pain > FixedPoint2.Zero)
         {
             // Calculate decay duration based on current pain level - 12 seconds per pain point
             // 50 pain * 12 seconds per pain point = 600 seconds = 10 minutes
-            var decayDuration = TimeSpan.FromSeconds(nerveSystem.Pain.Float() * 12);
+            var decayDuration = TimeSpan.FromSeconds(nerveSys.Value.Comp.Pain.Float() * 12);
 
             // Start the pain decay process
-            _pain.StartPainDecay(body, nerveSystem.Pain, decayDuration, nerveSystem);
+            _pain.StartPainDecay(nerveSys.Value, nerveSys.Value.Comp.Pain, decayDuration, nerveSys.Value.Comp);
         }
     }
 
@@ -118,29 +116,22 @@ public sealed partial class WoundSystem
         // Sort woundables by bleeding amount (descending)
         bleedingWoundables.Sort((a, b) => b.BleedAmount.CompareTo(a.BleedAmount));
 
-        float remainingHealAmount = healAmount * bleedingWoundables.Count;
-        bool anyHealed = false;
+        var remaining = FixedPoint2.New(healAmount);
 
         // Apply healing to each woundable in order
         foreach (var (woundable, _) in bleedingWoundables)
         {
-            if (remainingHealAmount <= 0)
+            if (remaining <= 0)
                 break;
 
-            FixedPoint2 modifiedBleed;
-            bool didHeal = TryHealBleedingWounds(woundable, -remainingHealAmount, out modifiedBleed);
-            if (didHeal)
-            {
-                anyHealed = true;
-                healed += -modifiedBleed - remainingHealAmount;
-                remainingHealAmount -= (float) modifiedBleed;
+            if (!TryHealBleedingWounds(woundable, (float) -remaining, out var healedHere))
+                continue;
 
-                if (remainingHealAmount <= 0)
-                    break;
-            }
+            healed += healedHere;
+            remaining -= healedHere;
         }
 
-        return anyHealed;
+        return healed > 0;
     }
 
     public bool TryHealBleedingWounds(EntityUid woundable, float bleedStopAbility, out FixedPoint2 modifiedBleed, WoundableComponent? component = null)
@@ -149,28 +140,39 @@ public sealed partial class WoundSystem
         if (!Resolve(woundable, ref component))
             return false;
 
+        var remaining = FixedPoint2.New(-bleedStopAbility);
+        if (remaining <= 0)
+            return false;
+
         foreach (var wound in GetWoundableWounds(woundable, component))
         {
             if (!TryComp<BleedInflicterComponent>(wound, out var bleeds)
                 || !bleeds.IsBleeding)
                 continue;
 
-            if (-bleedStopAbility > bleeds.BleedingAmount)
+            if (remaining >= bleeds.BleedingAmount)
             {
-                modifiedBleed = bleeds.BleedingAmount;
+                modifiedBleed += bleeds.BleedingAmount;
+                remaining -= bleeds.BleedingAmount;
                 bleeds.BleedingAmountRaw = 0;
                 bleeds.IsBleeding = false;
                 bleeds.Scaling = 0;
             }
             else
             {
-                bleeds.BleedingAmountRaw += bleedStopAbility;
-                modifiedBleed = -bleedStopAbility;
+                var rawReduction = bleeds.Scaling > 0 ? remaining / bleeds.Scaling : remaining;
+                bleeds.BleedingAmountRaw = FixedPoint2.Max(FixedPoint2.Zero, bleeds.BleedingAmountRaw - rawReduction);
+                modifiedBleed += remaining;
+                remaining = FixedPoint2.Zero;
             }
 
             Dirty(wound, bleeds);
+
+            if (remaining <= 0)
+                break;
         }
-        return modifiedBleed <= -bleedStopAbility;
+
+        return modifiedBleed > 0;
     }
 
     public void ForceHealWoundsOnWoundable(EntityUid woundable,

--- a/Content.Shared/_Shitmed/Surgery/Wounds/Systems/WoundSystem.Healing.cs
+++ b/Content.Shared/_Shitmed/Surgery/Wounds/Systems/WoundSystem.Healing.cs
@@ -218,13 +218,13 @@ public sealed partial class WoundSystem
             || component.Wounds == null)
             return false;
 
-        var woundsToHeal = new List<Entity<WoundComponent>>();
+        var woundsToHeal = new List<(Entity<WoundComponent> Wound, FixedPoint2 Floor)>();
         foreach (var wound in component.Wounds.ContainedEntities)
         {
             var woundComp = Comp<WoundComponent>(wound);
-            if (CanHealWound(wound, woundComp, ignoreBlockers)
+            if (CanHealWound(wound, out var floor, woundComp, ignoreBlockers)
                 && (damageGroup == null || damageGroup == woundComp.DamageGroup))
-                woundsToHeal.Add((wound, woundComp));
+                woundsToHeal.Add(((wound, woundComp), floor));
         }
 
         if (woundsToHeal.Count == 0)
@@ -232,11 +232,15 @@ public sealed partial class WoundSystem
 
         var healNumba = healAmount / woundsToHeal.Count;
         var actualHeal = FixedPoint2.Zero;
-        foreach (var wound in woundsToHeal)
+        foreach (var (wound, floor) in woundsToHeal)
         {
             var heal = ignoreMultipliers
                 ? -healNumba
                 : ApplyHealingRateMultipliers(wound, woundable, -healNumba, component);
+
+            heal = ClampHealToFloor(wound.Comp, heal, floor);
+            if (heal >= 0)
+                continue;
 
             actualHeal += -heal;
             ApplyWoundSeverity(wound, heal, wound);
@@ -310,13 +314,13 @@ public sealed partial class WoundSystem
     {
         healed = 0;
 
-        var woundsToHeal = new List<Entity<WoundComponent>>();
+        var woundsToHeal = new List<(Entity<WoundComponent> Wound, FixedPoint2 Floor)>();
         foreach (var wound in component.Wounds.ContainedEntities)
         {
             var woundComp = Comp<WoundComponent>(wound);
-            if (CanHealWound(wound, woundComp, ignoreBlockers)
+            if (CanHealWound(wound, out var floor, woundComp, ignoreBlockers)
                 && damageType == woundComp.DamageType)
-                woundsToHeal.Add((wound, woundComp));
+                woundsToHeal.Add(((wound, woundComp), floor));
         }
 
         if (woundsToHeal.Count == 0)
@@ -324,11 +328,15 @@ public sealed partial class WoundSystem
 
         var healNumba = healAmount / woundsToHeal.Count;
         var actualHeal = FixedPoint2.Zero;
-        foreach (var wound in woundsToHeal)
+        foreach (var (wound, floor) in woundsToHeal)
         {
             var heal = ignoreMultipliers
                 ? -healNumba
                 : ApplyHealingRateMultipliers(wound, woundable, -healNumba, component);
+
+            heal = ClampHealToFloor(wound.Comp, heal, floor);
+            if (heal >= 0)
+                continue;
 
             actualHeal += -heal;
             ApplyWoundSeverity(wound, heal, wound);
@@ -430,7 +438,11 @@ public sealed partial class WoundSystem
     }
 
     public bool CanHealWound(EntityUid wound, WoundComponent? comp = null, bool ignoreBlockers = false)
+        => CanHealWound(wound, out _, comp, ignoreBlockers);
+
+    public bool CanHealWound(EntityUid wound, out FixedPoint2 severityFloor, WoundComponent? comp = null, bool ignoreBlockers = false)
     {
+        severityFloor = FixedPoint2.Zero;
         if (!Resolve(wound, ref comp))
             return false;
 
@@ -448,7 +460,20 @@ public sealed partial class WoundSystem
         var ev1 = new WoundHealAttemptEvent((holdingWoundable, Comp<WoundableComponent>(holdingWoundable)), ignoreBlockers);
         RaiseLocalEvent(wound, ref ev1);
 
+        severityFloor = ev1.SeverityFloor;
         return !ev1.Cancelled;
+    }
+
+    private FixedPoint2 ClampHealToFloor(WoundComponent wound, FixedPoint2 heal, FixedPoint2 floor)
+    {
+        if (floor <= 0 || heal >= 0)
+            return heal;
+
+        var allowedReduction = wound.WoundSeverityPoint - floor;
+        if (allowedReduction <= 0)
+            return FixedPoint2.Zero;
+
+        return -heal > allowedReduction ? -allowedReduction : heal;
     }
 
     /// <summary>

--- a/Content.Shared/_Shitmed/Surgery/Wounds/Systems/WoundSystem.Queries.cs
+++ b/Content.Shared/_Shitmed/Surgery/Wounds/Systems/WoundSystem.Queries.cs
@@ -455,7 +455,7 @@ public sealed partial class WoundSystem
         // We prevent removal if theres at least one wound holding traumas left.
         foreach (var trauma in _trauma.GetAllWoundTraumas(woundEntity))
         {
-            if (Array.IndexOf(Traumas.Systems.TraumaSystem.TraumasBlockingHealing, trauma.Comp.TraumaType) >= 0)
+            if (_trauma.TraumaBlocksHealing(trauma.Comp.TraumaType))
                 return false;
         }
 

--- a/Content.Shared/_Shitmed/Surgery/Wounds/Systems/WoundSystem.Severity.cs
+++ b/Content.Shared/_Shitmed/Surgery/Wounds/Systems/WoundSystem.Severity.cs
@@ -27,6 +27,7 @@ public sealed partial class WoundSystem
             return;
 
         var old = wound.WoundSeverityPoint;
+        var holdingWoundable = wound.HoldingWoundable;
 
         var upperLimit = wound.WoundSeverityPoint + woundable.WoundableIntegrity;
         wound.WoundSeverityPoint =
@@ -37,6 +38,9 @@ public sealed partial class WoundSystem
             var ev = new WoundSeverityPointChangedEvent(wound, old, wound.WoundSeverityPoint);
             RaiseLocalEvent(uid, ref ev);
         }
+
+        if (TerminatingOrDeleted(uid) || wound.HoldingWoundable != holdingWoundable)
+            return;
 
         CheckSeverityThresholds(uid, wound.HoldingWoundable, wound, woundable);
         Dirty(uid, wound);
@@ -61,6 +65,7 @@ public sealed partial class WoundSystem
             return;
 
         var old = wound.WoundSeverityPoint;
+        var holdingWoundable = wound.HoldingWoundable;
         var rawValue = severity > 0
             ? old + ApplySeverityModifiers(wound.HoldingWoundable, severity)
             : old + severity;
@@ -79,6 +84,9 @@ public sealed partial class WoundSystem
             && wound.MangleSeverity != null
             && HasWoundsExceedingMangleSeverity(wound.HoldingWoundable))
             _trauma.ApplyMangledTraumas(wound.HoldingWoundable, uid, severity, woundable);
+
+        if (TerminatingOrDeleted(uid) || wound.HoldingWoundable != holdingWoundable)
+            return;
 
         CheckSeverityThresholds(uid, wound.HoldingWoundable, wound, woundable);
     }

--- a/Content.Shared/_Shitmed/Surgery/Wounds/Systems/WoundSystem.Wounding.cs
+++ b/Content.Shared/_Shitmed/Surgery/Wounds/Systems/WoundSystem.Wounding.cs
@@ -80,7 +80,7 @@ public sealed partial class WoundSystem
         RaiseLocalEvent(comp.HoldingWoundable, ref ev1);
     }
 
-    private void OnWoundRemoved(EntityUid woundableEntity, WoundComponent wound, EntGotRemovedFromContainerMessage args)
+    private void OnWoundRemoved(EntityUid woundEntity, WoundComponent wound, EntGotRemovedFromContainerMessage args)
     {
         if (wound.HoldingWoundable == EntityUid.Invalid)
             return;
@@ -90,12 +90,16 @@ public sealed partial class WoundSystem
             return;
 
         var oldHoldingWoundable = wound.HoldingWoundable;
-        wound.HoldingWoundable = EntityUid.Invalid;
 
         var ev = new WoundRemovedEvent(wound, oldParentWoundable, oldWoundableRoot);
-        RaiseLocalEvent(oldHoldingWoundable, ref ev);
+        RaiseLocalEvent(woundEntity, ref ev);
 
-        PredictedQueueDel(woundableEntity);
+        var ev1 = new WoundRemovedEvent(wound, oldParentWoundable, oldWoundableRoot);
+        RaiseLocalEvent(oldHoldingWoundable, ref ev1);
+
+        wound.HoldingWoundable = EntityUid.Invalid;
+
+        PredictedQueueDel(woundEntity);
     }
 
     private void OnWoundableInserted(EntityUid parentEntity, WoundableComponent parentWoundable, EntInsertedIntoContainerMessage args)
@@ -223,10 +227,14 @@ public sealed partial class WoundSystem
 
     private void OnGetDoAfterDelayMultiplier(EntityUid uid, WoundableComponent component, ref GetDoAfterDelayMultiplierEvent args)
     {
-        if (component.WoundableIntegrity > 50)
+        if (component.IntegrityCap <= 0)
             return;
 
-        args.Multiplier *= (float) (component.WoundableIntegrity / component.IntegrityCap);
+        var integrityFraction = (float) (component.WoundableIntegrity / component.IntegrityCap);
+        if (integrityFraction > 0.5f)
+            return;
+
+        args.Multiplier *= 1f + (0.5f - integrityFraction) * 2f;
     }
 
     private void OnAttemptHandsMelee(EntityUid uid, WoundableComponent component, ref AttemptHandsMeleeEvent args)

--- a/Content.Shared/_Shitmed/Surgery/Wounds/Systems/WoundSystem.Wounding.cs
+++ b/Content.Shared/_Shitmed/Surgery/Wounds/Systems/WoundSystem.Wounding.cs
@@ -175,7 +175,8 @@ public sealed partial class WoundSystem
 
         TryComp<DamageableComponent>(uid, out var damageable);
         BodyPartComponent? bp = null;
-        var needsRedirect = component.WoundableIntegrity <= 0
+        var needsRedirect = component.RedirectOverflowDamage
+            && component.WoundableIntegrity <= 0
             && TryComp(uid, out bp)
             && bp.Body.HasValue;
 

--- a/Content.Shared/_Shitmed/Surgery/Wounds/Systems/WoundSystem.cs
+++ b/Content.Shared/_Shitmed/Surgery/Wounds/Systems/WoundSystem.cs
@@ -125,10 +125,11 @@ public sealed partial class WoundSystem : EntitySystem
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
-        _woundJobQueue.Process();
 
         if (!_timing.IsFirstTimePredicted)
             return;
+
+        _woundJobQueue.Process();
 
         // If this still causes lag, we go with the nuclear option of also checking for ConsciousnessComponent :niceportrait:
         using var query = EntityQueryEnumerator<BodyComponent, DamageableComponent>();
@@ -143,7 +144,7 @@ public sealed partial class WoundSystem : EntitySystem
                 || !_body.TryGetRootPart(ent, out var rootPart, body: body))
                 continue;
 
-            body.HealAt += TimeSpan.FromSeconds(1f / _medicalHealingTickrate);
+            body.HealAt = _timing.CurTime + TimeSpan.FromSeconds(1f / _medicalHealingTickrate);
             foreach (var woundable in GetAllWoundableChildren(rootPart.Value))
                 if (woundable.Comp.CanHealDamage || woundable.Comp.CanHealBleeds)
                     _woundJobQueue.EnqueueJob(new WoundJob(this, woundable, ent, WoundJobTime));
@@ -388,11 +389,10 @@ public sealed partial class WoundSystem : EntitySystem
             RaiseLocalEvent(uid, ref ev);
 
             var bodySeverity = FixedPoint2.Zero;
-            if (TryComp<BodyPartComponent>(uid, out var bodyPart) && bodyPart.Body.HasValue)
+            if (TryComp<BodyPartComponent>(uid, out var bodyPart)
+                && bodyPart.Body.HasValue
+                && TryComp<BodyComponent>(bodyPart.Body.Value, out var bodyComp))
             {
-                if (!TryComp<BodyComponent>(bodyPart.Body.Value, out var bodyComp))
-                    return;
-
                 var rootPart = bodyComp.RootContainer?.ContainedEntity;
                 if (rootPart.HasValue)
                 {

--- a/Content.Shared/_Shitmed/Surgery/Wounds/WoundsSerializable.cs
+++ b/Content.Shared/_Shitmed/Surgery/Wounds/WoundsSerializable.cs
@@ -98,7 +98,7 @@ public record struct WoundableIntegrityChangedOnBodyEvent(Entity<WoundableCompon
 public record struct WoundableSeverityChangedEvent(WoundableSeverity OldSeverity, WoundableSeverity NewSeverity);
 
 [ByRefEvent]
-public record struct WoundHealAttemptEvent(Entity<WoundableComponent> Woundable, bool IgnoreBlockers = false, bool Cancelled = false);
+public record struct WoundHealAttemptEvent(Entity<WoundableComponent> Woundable, bool IgnoreBlockers = false, bool Cancelled = false, FixedPoint2 SeverityFloor = default);
 
 [ByRefEvent]
 public record struct WoundHealAttemptOnWoundableEvent(Entity<WoundComponent> Wound, bool Cancelled = false);

--- a/Resources/Locale/en-US/_Shitmed/medical/components/health-analyzer.ftl
+++ b/Resources/Locale/en-US/_Shitmed/medical/components/health-analyzer.ftl
@@ -6,6 +6,8 @@ condition-body-trauma-OrganDamage = • The {$woundable} has some damage on its 
 condition-body-trauma-VeinsDamage = • The {$woundable} has some damage on its veins.
 condition-body-trauma-NerveDamage = • The {$woundable} has some damage on its nerves.
 condition-body-trauma-Dismemberment = • The {$targetSymmetry}{$targetType} has been removed...
+condition-body-trauma-Shrapnel = • There is shrapnel embedded in the {$woundable}.
+condition-body-trauma-Braindeath = • [color=red]The brain is dead.[/color] It must be surgically repaired before revival is possible.
 condition-body-pain-decreased = • The {$woundable}'s nerves are numbed.
 condition-body-pain-increased = • The {$woundable}'s nerves are abnormally sensitive.
 condition-body-unrevivable = • {$entity} has a particularly weak constitution. They cannot withstand the shock of a defibrillator.

--- a/Resources/Locale/en-US/_Shitmed/surgery/surgery-ui.ftl
+++ b/Resources/Locale/en-US/_Shitmed/surgery/surgery-ui.ftl
@@ -15,6 +15,7 @@ surgery-ui-window-steps-error-skills = You have no surgical skills.
 surgery-ui-window-steps-error-table = You need an operating table for this.
 surgery-ui-window-steps-error-armor = You need to remove their armor!
 surgery-ui-window-steps-error-tools = Missing tools.
+surgery-ui-window-steps-error-missing-tool = You need {$tool} to perform this step!
 surgery-error-laying = They need to be laying down!
 surgery-error-self-surgery = You can't perform surgery on yourself!
 surgery-part-damage-evaded = {$user} narrowly evaded!

--- a/Resources/Prototypes/Body/Organs/Animal/animal.yml
+++ b/Resources/Prototypes/Body/Organs/Animal/animal.yml
@@ -6,11 +6,11 @@
   abstract: true
   components:
   - type: Organ
-    intCap: 13
-    integrity: 13
+    intCap: 65
+    integrity: 65
     integrityThresholds:
-      Normal: 13
-      Damaged: 6
+      Normal: 65
+      Damaged: 30
       Destroyed: 0
   - type: Edible
   - type: Sprite
@@ -54,11 +54,11 @@
     - state: lung-r
   - type: Organ
     slotId: lungs # Shitmed
-    intCap: 17 # animal lungs are less tuff than human's one
-    integrity: 17
+    intCap: 85 # animal lungs are less tuff than human's one
+    integrity: 85
     integrityThresholds:
-      Normal: 17
-      Damaged: 8
+      Normal: 85
+      Damaged: 40
       Destroyed: 0
   - type: Lung
   - type: Metabolizer
@@ -98,11 +98,11 @@
     state: stomach
   - type: Organ
     slotId: stomach # Shitmed
-    intCap: 28
-    integrity: 28
+    intCap: 140
+    integrity: 140
     integrityThresholds:
-      Normal: 28
-      Damaged: 16
+      Normal: 140
+      Damaged: 80
       Destroyed: 0
   - type: SolutionContainerManager
     solutions:
@@ -157,11 +157,11 @@
     state: liver
   - type: Organ
     slotId: liver # Shitmed
-    intCap: 17
-    integrity: 17
+    intCap: 85
+    integrity: 85
     integrityThresholds:
-      Normal: 17
-      Damaged: 8
+      Normal: 85
+      Damaged: 40
       Destroyed: 0
   - type: Metabolizer
     maxPoisonsProcessable: 1
@@ -188,11 +188,11 @@
     state: heart-on
   - type: Organ
     slotId: heart # Shitmed
-    intCap: 14
-    integrity: 14
+    intCap: 70
+    integrity: 70
     integrityThresholds:
-      Normal: 14
-      Damaged: 6
+      Normal: 70
+      Damaged: 30
       Destroyed: 0
   - type: Metabolizer
     maxPoisonsProcessable: 2
@@ -223,11 +223,11 @@
     - state: kidney-r
   - type: Organ
     slotId: kidneys # Shitmed
-    intCap: 17
-    integrity: 17
+    intCap: 85
+    integrity: 85
     integrityThresholds:
-      Normal: 17
-      Damaged: 8
+      Normal: 85
+      Damaged: 40
       Destroyed: 0
   - type: Metabolizer
     maxPoisonsProcessable: 5

--- a/Resources/Prototypes/Body/Organs/Animal/slimes.yml
+++ b/Resources/Prototypes/Body/Organs/Animal/slimes.yml
@@ -10,11 +10,11 @@
       sprite: Mobs/Species/Slime/organs.rsi
       state: brain-slime
     - type: Organ
-      intCap: 60 # to prevent slimes from getting oneshot
-      integrity: 60
+      intCap: 120 # to prevent slimes from getting oneshot
+      integrity: 120
       integrityThresholds:
-        Normal: 60
-        Damaged: 27
+        Normal: 120
+        Damaged: 60
         Destroyed: 0
       slotId: core
     - type: Stomach
@@ -77,11 +77,11 @@
         - state: lung-l-slime
         - state: lung-r-slime
     - type: Organ
-      intCap: 28
-      integrity: 28
+      intCap: 140
+      integrity: 140
       integrityThresholds:
-        Normal: 28
-        Damaged: 16
+        Normal: 140
+        Damaged: 80
         Destroyed: 0
     - type: Lung
       alert: LowNitrogen

--- a/Resources/Prototypes/Body/Organs/arachnid.yml
+++ b/Resources/Prototypes/Body/Organs/arachnid.yml
@@ -8,11 +8,11 @@
   - type: Sprite
     sprite: Mobs/Species/Arachnid/organs.rsi
   - type: Organ
-    intCap: 28
-    integrity: 28
+    intCap: 140
+    integrity: 140
     integrityThresholds:
-      Normal: 28
-      Damaged: 16
+      Normal: 140
+      Damaged: 80
       Destroyed: 0
   - type: Edible
   - type: Extractable
@@ -46,11 +46,11 @@
     sprite: Mobs/Species/Arachnid/organs.rsi
     state: stomach
   - type: Organ # Shitmed
-    intCap: 44
-    integrity: 44
+    intCap: 220
+    integrity: 220
     integrityThresholds:
-      Normal: 44
-      Damaged: 21
+      Normal: 220
+      Damaged: 105
       Destroyed: 0
     slotId: stomach
   - type: Item
@@ -86,11 +86,11 @@
       - state: lung-l
       - state: lung-r
   - type: Organ # Shitmed
-    intCap: 28
-    integrity: 28
+    intCap: 140
+    integrity: 140
     integrityThresholds:
-      Normal: 28
-      Damaged: 16
+      Normal: 140
+      Damaged: 80
       Destroyed: 0
     slotId: lungs
   - type: Lung
@@ -143,11 +143,11 @@
     - id: Poison
     - id: Narcotic
   - type: Organ # Shitmed
-    intCap: 21
-    integrity: 21
+    intCap: 105
+    integrity: 105
     integrityThresholds:
-      Normal: 21
-      Damaged: 12
+      Normal: 105
+      Damaged: 60
       Destroyed: 0
     slotId: heart
   - type: Heart # Shitmed: Lets you transplant spider hearts into other species
@@ -176,11 +176,11 @@
     groups:
     - id: Alcohol
   - type: Organ # Shitmed
-    intCap: 28
-    integrity: 28
+    intCap: 140
+    integrity: 140
     integrityThresholds:
-      Normal: 28
-      Damaged: 16
+      Normal: 140
+      Damaged: 80
       Destroyed: 0
     slotId: liver
   - type: Liver # Shitmed
@@ -198,11 +198,11 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Organ # Shitmed
-    intCap: 21
-    integrity: 21
+    intCap: 105
+    integrity: 105
     integrityThresholds:
-      Normal: 21
-      Damaged: 12
+      Normal: 105
+      Damaged: 60
       Destroyed: 0
     slotId: kidneys
   - type: Sprite
@@ -235,11 +235,11 @@
       - state: eyeball-l
       - state: eyeball-r
   - type: Organ # Shitmed
-    intCap: 17
-    integrity: 17
+    intCap: 85
+    integrity: 85
     integrityThresholds:
-      Normal: 17
-      Damaged: 8
+      Normal: 85
+      Damaged: 40
       Destroyed: 0
     slotId: eyes
   - type: Eyes # Shitmed

--- a/Resources/Prototypes/Body/Organs/diona.yml
+++ b/Resources/Prototypes/Body/Organs/diona.yml
@@ -8,11 +8,11 @@
   - type: Sprite
     sprite: Mobs/Species/Diona/organs.rsi
   - type: Organ
-    intCap: 24
-    integrity: 24
+    intCap: 120
+    integrity: 120
     integrityThresholds:
-      Normal: 24
-      Damaged: 15
+      Normal: 120
+      Damaged: 75
       Destroyed: 0
   - type: Edible
   - type: Extractable
@@ -68,11 +68,11 @@
   - type: Sprite
     state: brain
   - type: Organ # Shitmed
-    intCap: 28
-    integrity: 28
+    intCap: 140
+    integrity: 140
     integrityThresholds:
-      Normal: 28
-      Damaged: 16
+      Normal: 140
+      Damaged: 80
       Destroyed: 0
     slotId: brain
   - type: Brain # Shitmed
@@ -113,11 +113,11 @@
       - state: eyeball-l
       - state: eyeball-r
   - type: Organ # Shitmed
-    intCap: 17 # dionas will have better eyes. :fort:
-    integrity: 17
+    intCap: 85 # dionas will have better eyes. :fort:
+    integrity: 85
     integrityThresholds:
-      Normal: 17
-      Damaged: 8
+      Normal: 85
+      Damaged: 40
       Destroyed: 0
     slotId: eyes
   - type: Tag # goob edit
@@ -144,11 +144,11 @@
         - ReagentId: Cellulose
           Quantity: 5
   - type: Organ # Shitmed
-    intCap: 35
-    integrity: 35
+    intCap: 175
+    integrity: 175
     integrityThresholds:
-      Normal: 35
-      Damaged: 19
+      Normal: 175
+      Damaged: 95
       Destroyed: 0
     slotId: stomach
   - type: Stomach
@@ -181,11 +181,11 @@
   - type: Sprite
     state: lungs
   - type: Organ # Shitmed
-    intCap: 21
-    integrity: 21
+    intCap: 105
+    integrity: 105
     integrityThresholds:
-      Normal: 21
-      Damaged: 12
+      Normal: 105
+      Damaged: 60
       Destroyed: 0
     slotId: lungs
   - type: Item

--- a/Resources/Prototypes/Body/Organs/dwarf.yml
+++ b/Resources/Prototypes/Body/Organs/dwarf.yml
@@ -24,11 +24,11 @@
   - type: Sprite
     state: stomach
   - type: Organ
-    intCap: 38
-    integrity: 38
+    intCap: 190
+    integrity: 190
     integrityThresholds:
-      Normal: 38
-      Damaged: 22
+      Normal: 190
+      Damaged: 110
       Destroyed: 0
   - type: SolutionContainerManager
     solutions:

--- a/Resources/Prototypes/Body/Organs/human.yml
+++ b/Resources/Prototypes/Body/Organs/human.yml
@@ -19,11 +19,11 @@
   - type: Sprite
     sprite: Mobs/Species/Human/organs.rsi
   - type: Organ
-    intCap: 15
-    integrity: 15
+    intCap: 120
+    integrity: 120
     integrityThresholds:
-      Normal: 15
-      Damaged: 6
+      Normal: 120
+      Damaged: 60
       Destroyed: 0
   - type: Edible
   - type: Extractable
@@ -77,6 +77,15 @@
     state: brain
   - type: Organ
     slotId: brain # Shitmed Change
+    intCap: 200
+    integrity: 200
+    integrityThresholds:
+      Normal: 200
+      Damaged: 100
+      Destroyed: 0
+    indestructible: true # A dead brain stays in the skull so it can be surgically repaired.
+  - type: OrganDeathTrauma
+    trauma: Braindeath # Reaching 0 integrity inflicts brain death rather than deleting the organ.
   - type: Input
     context: "ghost"
   - type: Brain
@@ -125,11 +134,11 @@
   description: "I see you!"
   components:
   - type: Organ # Shitmed Change
-    intCap: 12
-    integrity: 12
+    intCap: 60
+    integrity: 60
     integrityThresholds:
-      Normal: 12
-      Damaged: 4
+      Normal: 60
+      Damaged: 30
       Destroyed: 0
     slotId: eyes # Shitmed Change
   - type: Eyes # Shitmed Change
@@ -188,11 +197,11 @@
   description: "Filters oxygen from an atmosphere, which is then sent into the bloodstream to be used as an electron carrier."
   components:
   - type: Organ # Shitmed Change
-    intCap: 17
-    integrity: 17
+    intCap: 120
+    integrity: 120
     integrityThresholds:
-      Normal: 17
-      Damaged: 9
+      Normal: 120
+      Damaged: 60
       Destroyed: 0
     slotId: lungs # Shitmed Change
   - type: Sprite
@@ -239,11 +248,11 @@
   components:
   - type: Heart # Shitmed Change
   - type: Organ # Shitmed Change
-    intCap: 17
-    integrity: 17
+    intCap: 120
+    integrity: 120
     integrityThresholds:
-      Normal: 17
-      Damaged: 9
+      Normal: 120
+      Damaged: 60
       Destroyed: 0
     slotId: heart # Shitmed Change
   - type: Sprite
@@ -274,11 +283,11 @@
   description: "Gross. This is hard to stomach."
   components:
   - type: Organ # Shitmed Change
-    intCap: 44 # consists of a lot of pieces, thus is incredibly hard to easily destroy
-    integrity: 44
+    intCap: 140 # consists of a lot of pieces, thus is incredibly hard to easily destroy
+    integrity: 140
     integrityThresholds:
-      Normal: 44
-      Damaged: 17
+      Normal: 140
+      Damaged: 70
       Destroyed: 0
     slotId: stomach # Shitmed Change
   - type: Sprite
@@ -320,11 +329,11 @@
   components:
   - type: Liver # Shitmed Change
   - type: Organ # Shitmed Change
-    intCap: 21
-    integrity: 21
+    intCap: 120
+    integrity: 120
     integrityThresholds:
-      Normal: 21
-      Damaged: 12
+      Normal: 120
+      Damaged: 60
       Destroyed: 0
     slotId: liver # Shitmed Change
   - type: Sprite
@@ -350,11 +359,11 @@
   description: "Filters toxins from the bloodstream."
   components:
   - type: Organ # Shitmed
-    intCap: 21
-    integrity: 21
+    intCap: 120
+    integrity: 120
     integrityThresholds:
-      Normal: 21
-      Damaged: 12
+      Normal: 120
+      Damaged: 60
       Destroyed: 0
     slotId: kidneys
   - type: Sprite

--- a/Resources/Prototypes/Body/Organs/slime.yml
+++ b/Resources/Prototypes/Body/Organs/slime.yml
@@ -11,11 +11,11 @@
       state: brain-slime
     - type: Stomach
     - type: Organ
-      intCap: 60 # to prevent slimes from getting oneshot
-      integrity: 60
+      intCap: 120 # to prevent slimes from getting oneshot
+      integrity: 120
       integrityThresholds:
-        Normal: 60
-        Damaged: 27
+        Normal: 120
+        Damaged: 60
         Destroyed: 0
       slotId: brain # Omu slime brain changes
     - type: Metabolizer
@@ -64,11 +64,11 @@
       - state: lung-l-slime
       - state: lung-r-slime
   - type: Organ # Shitmed
-    intCap: 21 #
-    integrity: 21
+    intCap: 105 #
+    integrity: 105
     integrityThresholds:
-      Normal: 21
-      Damaged: 14
+      Normal: 105
+      Damaged: 70
       Destroyed: 0
     slotId: lungs
   - type: Lung

--- a/Resources/Prototypes/_DV/Body/Organs/feroxi.yml
+++ b/Resources/Prototypes/_DV/Body/Organs/feroxi.yml
@@ -38,11 +38,11 @@
     - state: lung-l
     - state: lung-r
   - type: Organ
-    intCap: 17 # Omu start
-    integrity: 17
+    intCap: 85 # Goob start
+    integrity: 85
     integrityThresholds:
-      Normal: 17
-      Damaged: 9
+      Normal: 85
+      Damaged: 45
       Destroyed: 0
     slotId: lungs
     removable: False # Omu end, make them actualy unremovable

--- a/Resources/Prototypes/_Goobstation/Heretic/Reagents/reagents.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Reagents/reagents.yml
@@ -52,6 +52,7 @@
           - type: Ghoul
           guidebookComponentName: reagent-comp-condition-heretic-or-ghoul
       - !type:CleanBloodstream
+        excluded: EldritchEssence
         cleanseRate: 3
         conditions:
         - !type:HasComponentCondition

--- a/Resources/Prototypes/_Goobstation/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Goobstation/Reagents/medicine.yml
@@ -280,6 +280,7 @@
           groups:
             Toxin: -6
       - !type:CleanBloodstream
+        excluded: Musiver
         cleanseRate: 6 # POWERFUL cleansing effect
       - !type:HealthChange
         damage:
@@ -579,6 +580,7 @@
       metabolismRate: 1
       effects:
       - !type:CleanBloodstream
+        excluded: Calomel
         cleanseRate: 4.5 # better than charcoal
       - !type:HealthChange
         damage:
@@ -1085,6 +1087,7 @@
       metabolismRate: 0.25
       effects:
       - !type:CleanBloodstream
+        excluded: PentenicAcid # Goobstation
       - !type:HealthChange
         damage:
           types:

--- a/Resources/Prototypes/_Goobstation/SlaughterDemon/Body/Organs/slaughter_demon.yml
+++ b/Resources/Prototypes/_Goobstation/SlaughterDemon/Body/Organs/slaughter_demon.yml
@@ -9,11 +9,11 @@
     sprite: _Goobstation/SlaughterDemon/heart.rsi
     state: demon_heart
   - type: Organ
-    intCap: 21
-    integrity: 21
+    intCap: 105
+    integrity: 105
     integrityThresholds:
-      Normal: 21
-      Damaged: 12
+      Normal: 105
+      Damaged: 60
       Destroyed: 0
     onAdd:
     - type: BloodCrawl

--- a/Resources/Prototypes/_Goobstation/Wizard/reagents.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/reagents.yml
@@ -85,6 +85,7 @@
           - type: Apprentice
           guidebookComponentName: reagent-comp-condition-wizard-or-apprentice
       - !type:CleanBloodstream
+        excluded: Mugwort
         cleanseRate: 6
         conditions:
         - !type:HasComponentCondition

--- a/Resources/Prototypes/_Shitmed/Body/Organs/Animal/animal.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Organs/Animal/animal.yml
@@ -10,11 +10,11 @@
     state: brain
   - type: Organ
     slotId: brain
-    intCap: 28
-    integrity: 28
+    intCap: 140
+    integrity: 140
     integrityThresholds:
-      Normal: 28
-      Damaged: 16
+      Normal: 140
+      Damaged: 80
       Destroyed: 0
   - type: Input
     context: "ghost"
@@ -63,11 +63,11 @@
   # start-backmen: surgery
   - type: Organ
     slotId: eyes
-    intCap: 12
-    integrity: 12
+    intCap: 60
+    integrity: 60
     integrityThresholds:
-      Normal: 12
-      Damaged: 6
+      Normal: 60
+      Damaged: 30
       Destroyed: 0
   - type: Eyes
   # end-backmen: surgery

--- a/Resources/Prototypes/_Shitmed/Body/Organs/Animal/space.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Organs/Animal/space.yml
@@ -6,11 +6,11 @@
   name: space animal lungs
   components:
   - type: Organ
-    intCap: 28
-    integrity: 28
+    intCap: 140
+    integrity: 140
     integrityThresholds:
-      Normal: 28
-      Damaged: 16
+      Normal: 140
+      Damaged: 80
       Destroyed: 0
     onAdd:
     - type: BreathingImmunity
@@ -21,11 +21,11 @@
   name: space animal heart
   components:
   - type: Organ
-    intCap: 21
-    integrity: 21
+    intCap: 105
+    integrity: 105
     integrityThresholds:
-      Normal: 21
-      Damaged: 12
+      Normal: 105
+      Damaged: 60
       Destroyed: 0
     onAdd:
     - type: PressureImmunity

--- a/Resources/Prototypes/_Shitmed/Body/Organs/cybernetic.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Organs/cybernetic.yml
@@ -25,11 +25,11 @@
     sprite: _Shitmed/Mobs/Species/Misc/Cybernetics/organs.rsi
     state: eyes
   - type: Organ
-    intCap: 21
-    integrity: 21
+    intCap: 105
+    integrity: 105
     integrityThresholds:
-      Normal: 21
-      Damaged: 11
+      Normal: 105
+      Damaged: 55
       Destroyed: 0
     slotId: eyes
     onAdd:
@@ -115,11 +115,11 @@
     state: heart-on
   - type: Heart
   - type: Organ
-    intCap: 25
-    integrity: 25
+    intCap: 125
+    integrity: 125
     integrityThresholds:
-      Normal: 25
-      Damaged: 9
+      Normal: 125
+      Damaged: 45
       Destroyed: 0
     slotId: heart
     onAdd:
@@ -152,11 +152,11 @@
   - type: Sprite
     state: heart-u-on
   - type: Organ
-    intCap: 32
-    integrity: 32
+    intCap: 160
+    integrity: 160
     integrityThresholds:
-      Normal: 32
-      Damaged: 9
+      Normal: 160
+      Damaged: 45
       Destroyed: 0
     slotId: heart
     onAdd:
@@ -183,11 +183,11 @@
   components:
   - type: Liver
   - type: Organ
-    intCap: 29
-    integrity: 29
+    intCap: 145
+    integrity: 145
     integrityThresholds:
-      Normal: 29
-      Damaged: 12
+      Normal: 145
+      Damaged: 60
       Destroyed: 0
     slotId: liver
   - type: Sprite
@@ -219,11 +219,11 @@
       - state: lung-l
       - state: lung-r
   - type: Organ
-    intCap: 25
-    integrity: 25
+    intCap: 125
+    integrity: 125
     integrityThresholds:
-      Normal: 25
-      Damaged: 9
+      Normal: 125
+      Damaged: 45
       Destroyed: 0
     slotId: lungs
   - type: Item
@@ -261,11 +261,11 @@
       - state: lung-u-l
       - state: lung-u-r
   - type: Organ
-    intCap: 32
-    integrity: 32
+    intCap: 160
+    integrity: 160
     integrityThresholds:
-      Normal: 32
-      Damaged: 9
+      Normal: 160
+      Damaged: 45
       Destroyed: 0
     slotId: lungs
     onAdd:

--- a/Resources/Prototypes/_Shitmed/Entities/Objects/Augments/base.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Objects/Augments/base.yml
@@ -7,11 +7,11 @@
   - type: SurgeryTool
     ignoreToggle: true # ItemToggle is used for augment logic not surgical tool usability
   - type: Organ
-    intCap: 30
-    integrity: 30
+    intCap: 150
+    integrity: 150
     integrityThresholds:
-      Normal: 30
-      Damaged: 12
+      Normal: 150
+      Damaged: 60
       Destroyed: 0
 
 - type: entity

--- a/Resources/Prototypes/_Shitmed/Entities/Surgery/surgeries.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Surgery/surgeries.yml
@@ -198,6 +198,37 @@
   - type: SurgeryTraumaPresentCondition
     trauma: OrganDamage
 
+- type: entity
+  parent: BasePartSurgery
+  id: SurgeryExtractForeignBody
+  name: Extract Foreign Body
+  components:
+  - type: Surgery
+    requirement: SurgeryOpenIncision
+    steps:
+    - SurgeryStepExtractForeignBody
+  - type: SurgeryBleedsPresentCondition
+    inverted: true
+  - type: SurgeryTraumaTreatableCondition
+
+- type: entity
+  parent: BasePartSurgery
+  id: SurgeryRepairBrainDamage
+  name: Repair Brain Damage
+  components:
+  - type: Surgery
+    requirement: SurgeryOpenIncision
+    steps:
+    - SurgeryStepSawBones
+    - SurgeryStepClampInternalBleeders
+    - SurgeryStepRepairBrain
+  - type: SurgeryPartCondition
+    parts: [ Head ]
+  - type: SurgeryBleedsPresentCondition
+    inverted: true
+  - type: SurgeryTraumaPresentCondition
+    trauma: Braindeath
+
 # I fucking hate hardcoding all of this shit to accomodate for surgery BUI.
 # If anyone can give me pointers on how to make it better I'd be incredibly grateful.
 

--- a/Resources/Prototypes/_Shitmed/Entities/Surgery/surgery_steps.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Surgery/surgery_steps.yml
@@ -180,7 +180,45 @@
   - type: SurgeryRepeatableStep
   - type: SurgeryTraumaTreatmentStep
     traumaType: OrganDamage
-    amount: 17
+    amount: 30
+
+- type: entity
+  parent: SurgeryStepBase
+  id: SurgeryStepExtractForeignBody
+  name: Extract foreign body
+  components:
+  - type: SurgeryStep
+    tool:
+    - type: Hemostat
+    duration: 7
+  - type: Sprite
+    sprite: _Shitmed/Objects/Specific/Medical/Surgery/hemostat.rsi
+    state: hemostat
+  - type: SurgeryStepPainInflicter
+    amount: 20
+    painType: TraumaticPain
+    sleepModifier: 0
+  - type: SurgeryTraumaExtractStep
+
+- type: entity
+  parent: SurgeryStepBase
+  id: SurgeryStepRepairBrain
+  name: Repair the brain
+  components:
+  - type: SurgeryStep
+    tool:
+    - type: Tending
+    duration: 12
+  - type: Sprite
+    sprite: _Shitmed/Objects/Specific/Medical/Surgery/hemostat.rsi
+    state: hemostat
+  - type: SurgeryStepPainInflicter
+    amount: 40
+    painType: TraumaticPain
+    sleepModifier: 0
+  - type: SurgeryTraumaTreatmentStep
+    traumaType: Braindeath
+    amount: 60
 
 - type: entity
   parent: SurgeryStepBase

--- a/Resources/Prototypes/_Shitmed/Entities/Surgery/wounds.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Surgery/wounds.yml
@@ -24,12 +24,6 @@
 
   - type: TraumaInflicter
     severityThreshold: 12
-    allowedTraumas:
-    - Dismemberment
-    - OrganDamage
-    - BoneDamage
-    - VeinsDamage
-    - NerveDamage
     allowArmourDeduction:
     - Dismemberment
     - OrganDamage
@@ -62,12 +56,6 @@
     mangleSeverity: Severe
   - type: TraumaInflicter
     severityThreshold: 9
-    allowedTraumas:
-    - Dismemberment
-    - OrganDamage
-    - BoneDamage
-    - VeinsDamage
-    - NerveDamage
     allowArmourDeduction:
     - Dismemberment
     - OrganDamage
@@ -77,7 +65,7 @@
     traumasChances:
       Dismemberment: 0
       OrganDamage: 0.08
-      BoneDamage: 0.14
+      BoneDamage: -0.1
       VeinsDamage: -0.4 # goes through rather easy.
       NerveDamage: -0.4
     mangledMultipliers:
@@ -105,15 +93,10 @@
     - BoneDamage
     - VeinsDamage
     - NerveDamage
-    allowedTraumas:
-    - OrganDamage
-    - BoneDamage
-    - VeinsDamage
-    - NerveDamage
     traumasChances:
       Dismemberment: -0.4 # Bullets go THROUGH people
       OrganDamage: 0.24
-      BoneDamage: 0.24
+      BoneDamage: -0.1
       VeinsDamage: -0.4
       NerveDamage: -0.4
   - type: PainInflicter
@@ -134,10 +117,6 @@
     mangleSeverity: Severe
   - type: TraumaInflicter
     severityThreshold: 9
-    allowedTraumas:
-    - Dismemberment
-    - VeinsDamage
-    - NerveDamage
     allowArmourDeduction:
     - Dismemberment # seems rather reasonable. Wear armour, guys
     - VeinsDamage
@@ -166,11 +145,6 @@
     scarWound: BurnScar
   - type: TraumaInflicter
     severityThreshold: 17
-    allowedTraumas:
-    - OrganDamage
-    - BoneDamage
-    - VeinsDamage
-    - NerveDamage
     allowArmourDeduction:
     - OrganDamage
     - BoneDamage
@@ -199,11 +173,6 @@
     scarWound: BurnScar
   - type: TraumaInflicter
     severityThreshold: 17
-    allowedTraumas:
-#    - OrganDamage
-#    - BoneDamage
-    - VeinsDamage
-    - NerveDamage
     allowArmourDeduction:
     - OrganDamage # No matter what ultrasuperduper cool armour you have, while getting fucking boiled alive - YOUR VEINS AND NERVES WILL HURT.
     - BoneDamage
@@ -229,9 +198,6 @@
     scarWound: BurnScar
   - type: TraumaInflicter
     severityThreshold: 12
-    allowedTraumas:
-    - VeinsDamage
-    - NerveDamage
     traumasChances:
       Dismemberment: 0
       OrganDamage: 0
@@ -251,8 +217,6 @@
     woundVisibility: AdvancedScanner
   - type: TraumaInflicter
     severityThreshold: 0
-    allowedTraumas:
-    - NerveDamage
     traumasChances:
       Dismemberment: 0
       OrganDamage: 0
@@ -273,10 +237,6 @@
     scarWound: BurnScar
   - type: TraumaInflicter
     severityThreshold: 9
-    allowedTraumas:
-    - OrganDamage
-    - VeinsDamage
-    - NerveDamage
     traumasChances:
       Dismemberment: 0
       OrganDamage: 0
@@ -298,11 +258,6 @@
     selfHealMultiplier: 0
   - type: TraumaInflicter
     severityThreshold: 0
-    allowedTraumas:
-    - OrganDamage
-    - BoneDamage
-    - VeinsDamage
-    - NerveDamage
     traumasChances:
       Dismemberment: 0
       OrganDamage: 0
@@ -324,9 +279,6 @@
     scarWound: BurnScar
   - type: TraumaInflicter
     severityThreshold: 12
-    allowedTraumas:
-    - VeinsDamage
-    - NerveDamage
     traumasChances:
       Dismemberment: 0
       OrganDamage: 0
@@ -349,10 +301,6 @@
     selfHealMultiplier: 0
   - type: TraumaInflicter
     severityThreshold: 11
-    allowedTraumas:
-    - OrganDamage
-    - VeinsDamage
-    - NerveDamage
     allowArmourDeduction:
     - OrganDamage
     traumasChances:
@@ -375,10 +323,6 @@
     woundVisibility: HandScanner
   - type: TraumaInflicter
     severityThreshold: 7
-    allowedTraumas:
-    - OrganDamage
-    - VeinsDamage
-    - NerveDamage
     traumasChances:
       Dismemberment: 0
       OrganDamage: -0.34
@@ -418,3 +362,18 @@
   components:
   - type: Trauma
     traumaType: Dismemberment
+
+- type: entity
+  id: TraumaShrapnel
+  components:
+  - type: Trauma
+    traumaType: Shrapnel
+  - type: TraumaBloodloss
+    amount: 0.8
+
+- type: entity
+  id: TraumaBraindeath
+  components:
+  - type: Trauma
+    traumaType: Braindeath
+  - type: Braindeath

--- a/Resources/Prototypes/_Shitmed/trauma_types.yml
+++ b/Resources/Prototypes/_Shitmed/trauma_types.yml
@@ -1,0 +1,71 @@
+- type: traumaType
+  id: NerveDamage
+  severityGate: 5
+  target: Woundable
+  traumaEntity: NerveDamage
+  causes:
+  - !type:WoundSeverityCause
+    damageTypes: [ Blunt, Piercing, Slash, Heat, Ion, Cold, Holy, Shock, Cellular, Caustic, Radiation, Poison ]
+    chance: !type:NerveTraumaChance
+
+- type: traumaType
+  id: BoneDamage
+  severityGate: 10
+  blocksHealing: true
+  target: Bone
+  traumaEntity: BoneDamage
+  causes:
+  - !type:WoundSeverityCause
+    damageTypes: [ Blunt, Piercing, Heat, Cellular ]
+    chance: !type:BoneFractureChance
+
+- type: traumaType
+  id: Dismemberment
+  severityGate: 10
+  blocksHealing: true
+  target: ParentWoundable
+  traumaEntity: Dismemberment
+  causes:
+  - !type:WoundSeverityCause
+    damageTypes: [ Blunt, Piercing, Slash ]
+    chance: !type:DismembermentChance
+      damageTypeMultipliers:
+        Piercing: 0.05
+
+- type: traumaType
+  id: OrganDamage
+  severityGate: 15
+  blocksHealing: true
+  target: Organ
+  traumaEntity: OrganDamage
+  causes:
+  - !type:WoundSeverityCause
+    damageTypes: [ Blunt, Piercing, Heat, Shock, Cellular, Radiation, Poison ]
+    chance: !type:OrganTraumaChance
+
+- type: traumaType
+  id: VeinsDamage
+  severityGate: 10
+  target: Woundable
+  traumaEntity: VeinsDamage
+  causes:
+  - !type:WoundSeverityCause
+    damageTypes: [ Blunt, Piercing, Slash, Heat, Ion, Cold, Shock, Cellular, Caustic, Radiation, Poison ]
+
+- type: traumaType
+  id: Shrapnel
+  target: Woundable
+  blocksHealing: true
+  traumaEntity: TraumaShrapnel
+  causes:
+  - !type:ExplosionCause
+    minDamage: 40
+    chance: 0.35
+    scaleWithDamage: true
+  treatment: !type:SurgicalTreatment
+
+- type: traumaType
+  id: Braindeath
+  target: Organ
+  blocksHealing: true
+  traumaEntity: TraumaBraindeath


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
ports the following goobstation fixes for upstream-related woundmed problems:
https://github.com/Goob-Station/Goob-Station/pull/6961
https://github.com/Goob-Station/Goob-Station/pull/6965
https://github.com/Goob-Station/Goob-Station/pull/6978

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
okay, so i know that some things with this aren't working yet. the problem is that i have not a fucking clue why sometimes some surgeries are cooked, but if we don't pull in an interim solution, surgeries and sprays are cooked. if i could get some advice or help with this, that would smack

things that do work:
- the surgery menu
- chems, except specifically cryo chems for non-vital damage (see https://github.com/ProjectOmu/OmuStation/issues/1485)
  - actually, necrosol works fine here. cryox, arcryox and alox are buggered, but cryox restores blood properly now (but not on goob??????)
- sprays and backpack water tanks (though there seems to be some weird desync with them occasionally)
  - ClF3 never worked properly with backpack water tanks: the projectile immediately gets deleted on contact with hull plate or de-tiles whatever you're standing on
- organs getting destroyed at 0% integrity and taking damage more frequently
- organ damage and broken bones prevent TOPICAL healing

things that do not work:
- sometimes, surgery decides to have a conniption when it thinks certain steps are already done. this can be mitigated by opening up, closing up, then re-opening the patient
- most cryo chems (see previous link)
- organ/bone damage does not prevent chemical healing as claimed
- uhh, aghosts can't use topicals on people? whatever i guess
- blood packs do not repeatedly loop themselves after the doafter
- there's some weird edge case where topicals do not abide by organ damage and will continue to heal right until the patient is fully healed, AND it'll get a free use on the last healing (when the "this guy needs surgery" popup shows up), but for the most part they work fine
- uhhhhh, max topical stack size is now 10? everything still spawns topicals with 15 max, but it jumps to 10 when it's updated
- blood does not naturally regenerate
- iron just decides to not add more blood into the bloodstream

## Technical details
<!-- Summary of code changes for easier review. -->
see original PRs
i had only a few merge conflicts and opted to either accept incoming or (in the case of dependencies) accept both

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://youtu.be/imMJVHnnrO8

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- todo Omustation / License CLA here-->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl: Duuckie, Durk, shoebill
- add: Organ damage actually does something now. Organs have much more health but can be destroyed and take damage more often, and brain death kills you and makes you unrevivable until fixed with a fancy new surgery.
- tweak: You can now partially heal wounds topically on parts with organ/bone damage according to how damaged they are. Chems are meant to respect this limit, but as of now they don't.
- fix: Surgery, sprays, and most chems (especially chems that cleanse the bloodstream) should work properly. The changes from Durk patched out a lot of upstream nonsense, but there are still a few smaller issues remaining. Bleeding is kind of severe (plus you don't regenerate blood), and surgery may bug out (open/close/reopen the patient if this happens). Will be fixed when upstreamed.