### PR TITLE
Removed all the old silo links

### DIFF
--- a/Resources/Maps/_Omu/bagel.yml
+++ b/Resources/Maps/_Omu/bagel.yml
@@ -50122,7 +50122,7 @@ entities:
       pos: 46.5,5.5
       parent: 2
     - type: OreSiloClient
-      silo: 12376
+      silo: null
 - proto: Carpet
   entities:
   - uid: 7445
@@ -113495,7 +113495,7 @@ entities:
       pos: 45.5,4.5
       parent: 2
     - type: OreSiloClient
-      silo: 12376
+      silo: null
     - type: MaterialStorage
       materialWhiteList:
       - Steel

--- a/Resources/Maps/_Omu/box.yml
+++ b/Resources/Maps/_Omu/box.yml
@@ -56542,7 +56542,7 @@ entities:
       pos: -28.5,-24.5
       parent: 2
     - type: OreSiloClient
-      silo: 10979
+      silo: null
 - proto: Carpet
   entities:
   - uid: 9245
@@ -124817,7 +124817,7 @@ entities:
       pos: -24.5,-28.5
       parent: 2
     - type: OreSiloClient
-      silo: 10979
+      silo: null
     - type: MaterialStorage
       materialWhiteList:
       - Steel

--- a/Resources/Maps/_Omu/cluster.yml
+++ b/Resources/Maps/_Omu/cluster.yml
@@ -23682,7 +23682,7 @@ entities:
       pos: 13.5,-20.5
       parent: 2
     - type: OreSiloClient
-      silo: 504
+      silo: null
 - proto: Carpet
   entities:
   - uid: 3347
@@ -60329,7 +60329,7 @@ entities:
       pos: 17.5,-23.5
       parent: 2
     - type: OreSiloClient
-      silo: 504
+      silo: null
 - proto: OreProcessorMachineCircuitboard
   entities:
   - uid: 8696

--- a/Resources/Maps/_Omu/crystal.yml
+++ b/Resources/Maps/_Omu/crystal.yml
@@ -11882,7 +11882,7 @@ entities:
       pos: 48.5,14.5
       parent: 2
     - type: OreSiloClient
-      silo: 1958
+      silo: null
     - type: TechnologyDatabase
       supportedDisciplines:
       - Industrial
@@ -11895,7 +11895,7 @@ entities:
       pos: 16.5,20.5
       parent: 2
     - type: OreSiloClient
-      silo: 1958
+      silo: null
     - type: TechnologyDatabase
       supportedDisciplines:
       - Industrial
@@ -33986,7 +33986,7 @@ entities:
       pos: 36.5,11.5
       parent: 2
     - type: OreSiloClient
-      silo: 1958
+      silo: null
     - type: TechnologyDatabase
       supportedDisciplines:
       - Industrial
@@ -37606,7 +37606,7 @@ entities:
       pos: 30.5,-10.5
       parent: 2
     - type: OreSiloClient
-      silo: 1958
+      silo: null
     - type: TechnologyDatabase
       supportedDisciplines:
       - Industrial
@@ -46245,7 +46245,7 @@ entities:
       pos: 16.5,22.5
       parent: 2
     - type: OreSiloClient
-      silo: 1958
+      silo: null
     - type: TechnologyDatabase
       supportedDisciplines:
       - Industrial
@@ -46260,7 +46260,7 @@ entities:
       pos: 44.5,-10.5
       parent: 2
     - type: OreSiloClient
-      silo: 1958
+      silo: null
     - type: TechnologyDatabase
       supportedDisciplines:
       - Industrial
@@ -83196,7 +83196,7 @@ entities:
       pos: -6.5,-34.5
       parent: 2
     - type: OreSiloClient
-      silo: 1958
+      silo: null
 - proto: MedkitAdvancedFilled
   entities:
   - uid: 2587
@@ -89621,7 +89621,7 @@ entities:
       pos: 31.5,-10.5
       parent: 2
     - type: OreSiloClient
-      silo: 1958
+      silo: null
     - type: TechnologyDatabase
       supportedDisciplines:
       - Industrial
@@ -95651,7 +95651,7 @@ entities:
       - Experimental
       - CivilianServices
     - type: OreSiloClient
-      silo: 1958
+      silo: null
 - proto: SciFlash
   entities:
   - uid: 9245
@@ -95983,7 +95983,7 @@ entities:
       - Experimental
       - CivilianServices
     - type: OreSiloClient
-      silo: 1958
+      silo: null
 - proto: SeedExtractor
   entities:
   - uid: 1495
@@ -96018,7 +96018,7 @@ entities:
       - Experimental
       - CivilianServices
     - type: OreSiloClient
-      silo: 1958
+      silo: null
 - proto: ShardCrystalGreen
   entities:
   - uid: 6242
@@ -105674,7 +105674,7 @@ entities:
       - Experimental
       - CivilianServices
     - type: OreSiloClient
-      silo: 1958
+      silo: null
 - proto: UniformShortsRed
   entities:
   - uid: 14756

--- a/Resources/Maps/_Omu/delta.yml
+++ b/Resources/Maps/_Omu/delta.yml
@@ -99650,7 +99650,7 @@ entities:
       pos: 7.5,33.5
       parent: 2
     - type: OreSiloClient
-      silo: 25116
+      silo: null
 - proto: Carpet
   entities:
   - uid: 12499
@@ -192410,7 +192410,7 @@ entities:
       pos: 33.5,27.5
       parent: 2
     - type: OreSiloClient
-      silo: 25116
+      silo: null
 - proto: OrganDionaStomach
   entities:
   - uid: 25410

--- a/Resources/Maps/_Omu/glacier.yml
+++ b/Resources/Maps/_Omu/glacier.yml
@@ -103134,7 +103134,7 @@ entities:
       - Experimental
       - CivilianServices
     - type: OreSiloClient
-      silo: 11920
+      silo: null
 - proto: SeedExtractor
   entities:
   - uid: 15291

--- a/Resources/Maps/_Omu/leonid.yml
+++ b/Resources/Maps/_Omu/leonid.yml
@@ -100077,7 +100077,7 @@ entities:
       pos: -57.5,-49.5
       parent: 2
     - type: OreSiloClient
-      silo: 24372
+      silo: null
 - proto: CleanerDispenser
   entities:
   - uid: 16141
@@ -114943,7 +114943,7 @@ entities:
       pos: -67.5,-49.5
       parent: 2
     - type: OreSiloClient
-      silo: 24372
+      silo: null
 - proto: ExtendedEmergencyNitrogenTankFilled
   entities:
   - uid: 21
@@ -161771,7 +161771,7 @@ entities:
       pos: -61.5,-23.5
       parent: 2
     - type: OreSiloClient
-      silo: 24372
+      silo: null
 - proto: MedkitAdvancedFilled
   entities:
   - uid: 24394
@@ -185853,7 +185853,7 @@ entities:
       - Experimental
       - CivilianServices
     - type: OreSiloClient
-      silo: 24372
+      silo: null
 - proto: SeedExtractor
   entities:
   - uid: 28397

--- a/Resources/Maps/_Omu/loop.yml
+++ b/Resources/Maps/_Omu/loop.yml
@@ -35407,7 +35407,7 @@ entities:
       pos: 5.5,62.5
       parent: 2
     - type: OreSiloClient
-      silo: 15199
+      silo: null
 - proto: Carpet
   entities:
   - uid: 5387
@@ -81172,7 +81172,7 @@ entities:
       pos: 8.5,66.5
       parent: 2
     - type: OreSiloClient
-      silo: 15199
+      silo: null
 - proto: OxygenCanister
   entities:
   - uid: 11909

--- a/Resources/Maps/_Omu/meta.yml
+++ b/Resources/Maps/_Omu/meta.yml
@@ -52468,7 +52468,7 @@ entities:
       pos: -33.5,18.5
       parent: 2
     - type: OreSiloClient
-      silo: 10167
+      silo: null
 - proto: Carpet
   entities:
   - uid: 8100
@@ -126035,7 +126035,7 @@ entities:
       angularDamping: 0
       linearDamping: 0
     - type: OreSiloClient
-      silo: 10167
+      silo: null
     - type: Conveyed
 - proto: OxygenCanister
   entities:

--- a/Resources/Maps/_Omu/saltern.yml
+++ b/Resources/Maps/_Omu/saltern.yml
@@ -24129,7 +24129,7 @@ entities:
       pos: 12.5,9.5
       parent: 2
     - type: OreSiloClient
-      silo: 8502
+      silo: null
 - proto: Carpet
   entities:
   - uid: 3767
@@ -55131,7 +55131,7 @@ entities:
       pos: 18.5,13.5
       parent: 2
     - type: OreSiloClient
-      silo: 8502
+      silo: null
 - proto: OxygenCanister
   entities:
   - uid: 8561


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
New silo feature bugged out when a "single global silo" was configured, setting all the links to null fixes that.

## Why / Balance
Marty requested a bugfix.

## Technical details
Map yaml editing

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- todo Omustation / License CLA here-->

**Changelog**
:cl: Quill
- fix: On most maps, unlinked the old non existent global silo.

