### PR TITLE
GD tweaks

### DIFF
--- a/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusSystem.cs
+++ b/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusSystem.cs
@@ -93,15 +93,15 @@ public sealed class SecretPlusSystem : GameRuleSystem<SecretPlusComponent>
     protected override void Added(EntityUid uid, SecretPlusComponent scheduler, GameRuleComponent gameRule, GameRuleAddedEvent args)
     {
         // Omu Station - Start
-        // Edited it Initial ChaosScore & Antag Weight, to be based upon the amount of ReadyPlayers to be consistent with round start score.
+        // Edited it Initial ChaosScore & Antag Weight, to be based upon the amount of TotalPlayers to be consistent with round start score.
 
-        var readyPlayers = GameTicker.ReadyPlayerCount();
+        var totalPlayers = GetTotalPlayerCount(_playerManager.Sessions);
         // set up starting chaos score based on ready players
         scheduler.ChaosScore =
-            -_random.NextFloat(scheduler.MinStartingChaos * readyPlayers, scheduler.MaxStartingChaos * readyPlayers) *
+            -_random.NextFloat(scheduler.MinStartingChaos * totalPlayers, scheduler.MaxStartingChaos * totalPlayers) *
             _roundstartChaosScoreMultiplier;
 
-        LogMessage($"Initial chaos score: {scheduler.ChaosScore} (based on {readyPlayers} ready players)");
+        LogMessage($"Initial chaos score: {scheduler.ChaosScore} (based on {totalPlayers} total players)");
         // Omu Station - End
 
         // roll midroundchaos generation variation
@@ -306,6 +306,8 @@ public sealed class SecretPlusSystem : GameRuleSystem<SecretPlusComponent>
                || ruleComp.MinPlayers > count
             )
                 return;
+
+            count = GetTotalPlayerCount(_playerManager.Sessions); // Omu, reset count to totalplayers after we have checked that we are above minplayers
 
                                                 // pick less antags if we have less chaos left
             var effPlayers = (int)MathF.Round(count * scheduler.Comp.ChaosScore / origChaos);


### PR DESCRIPTION
## About the PR
Makes it so GD bases chaos score off totalplayers rather than ready count, alongside resetting the number of players to totalplayers after checking minplayers for gamerules (readycount is now only used when deciding if a rule passes minplayers to prevent GD from breaking).

## Why / Balance
Should hopefully make things more interesting and hopefully have GD behave a little better (more chaos score used up by roundstart rules so it shouldn't go mad midround as much) 

## Requirements
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- tweak: Changed game director to care more about the number of people on the server rather than the number of people ready.
