### PR TITLE
Make ipcs and borgs also get hurt by coscult mobs

### DIFF
--- a/Resources/Prototypes/_DV/CosmicCult/Mobs/colossus.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Mobs/colossus.yml
@@ -228,6 +228,7 @@
         Asphyxiation: 10
         Cold: 10
         Structural: 60
+        Ion: 20 # Omu, borgs/ipcs dont take cold or asphyx, so they should take ion instead.
     soundHit:
       path: /Audio/_DV/CosmicCult/cosmicsword_glance.ogg
       params:
@@ -396,3 +397,4 @@
       damage:
         types:
           Cold: 15 # Goobstation - 7 hits to kill instead of 8
+          Ion: 15 # Omu, borgs/ipcs dont take cold, so they should take ion instead.

--- a/Resources/Prototypes/_DV/CosmicCult/Mobs/hostiles.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Mobs/hostiles.yml
@@ -72,6 +72,7 @@
       types:
         Asphyxiation: 5
         Cold: 5
+        Ion: 10 # Omu, borgs/ipcs dont take cold or asphyx, so they should take ion instead.
     soundHit:
       path: /Audio/_DV/CosmicCult/cosmiclance_hit.ogg
       params:


### PR DESCRIPTION
## About the PR
Makes it so IPCs and Borgs also get hurt by coscult mobs (aka, make it in line with coscult's actual melee weapons)

## Why / Balance
Watching borgs and ipcs take 0 damage from coscult mobs is painful.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- tweak: Coscult mobs now deal ion damage alongside their normal damage (ipcs and borgs are no longer immune to them)
