### PR TITLE
[DOWNSTREAM] Fix BSO Combat Injector 3u/5u Dynamic/Inject-Only Modes

### DIFF
--- a/Resources/Prototypes/Chemistry/injector_modes.yml
+++ b/Resources/Prototypes/Chemistry/injector_modes.yml
@@ -152,3 +152,23 @@
 - type: injectorMode
   parent: [ BaseAdvancedJetInjectorMode, BaseDynamicMode ]
   id: AdvancedJetInjectorDynamicMode
+
+  # Goob start
+  # BSO combat injector's modes
+- type: injectorMode
+  abstract: true
+  id: BaseCombatInjectorMode
+  mobTime: 1 # Attempt to match the previous injector speed
+  transferAmounts:
+  - 3
+  - 5
+
+- type: injectorMode
+  parent: [BaseCombatInjectorMode, BaseDynamicMode]
+  id: CombatInjectorDynamicMode
+
+- type: injectorMode
+  parent: [BaseCombatInjectorMode, BaseInjectMode]
+  id: CombatInjectorInjectMode
+
+  # Goob end

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/blueshield.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/blueshield.yml
@@ -95,10 +95,10 @@
       injector:
         maxVol: 5
   - type: Injector
-    activeModeProtoId: SyringeDrawMode #Goob start
+    activeModeProtoId: CombatInjectorDynamicMode # SyringeDrawMode #Goob start
     allowedModes:
-    - SyringeDrawMode
-    - SyringeInjectMode #Goob end
+    - CombatInjectorDynamicMode # SyringeDrawMode
+    - CombatInjectorInjectMode # SyringeInjectMode #Goob end
   - type: MeleeChemicalInjector
     transferAmount: 5
     solution: injector


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
fixes https://github.com/ProjectOmu/OmuStation/issues/1491
downstreaming of https://github.com/Goob-Station/Goob-Station/pull/7038 (which i made)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
lets the BSO use T4 chems properly again
the combat injector was broken by upstream changes; this more or less fixes them

## Technical details
<!-- Summary of code changes for easier review. -->
see original implementation

as a side note, i'm fairly sure that the "starting injection" popup showing up when you try harm-mode spriteclicking is a secondary kinda bug, but i don't foresee any major ramifications aside from minor unnecessary visual clutter
i don't have the skills or time to figure out exactly why it's doing that, and this implementation should at the very least work for BSOs

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
see original implementation for full overview and funny bug that's out of scope
this is the video taken on omustation: https://youtu.be/PqX-uv9gTR0

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- todo Omustation / License CLA here-->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl: Duuckie
- fix: Blueshield Officers' combat injectors should work how they used to, with fast (1-second normal inject) 3u/5u transfer amounts and dynamic/inject-only modes.