### PR TITLE
[Fix] Black Screen bug regarding hair displacements

### DIFF
--- a/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
+++ b/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
@@ -344,6 +344,12 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
 
             _sprite.LayerMapRemove(spriteEnt.AsNullable(), layerId);
             _sprite.RemoveLayer(spriteEnt.AsNullable(), index);
+            // If this marking is one that can be displaced, we need to remove the displacement as well; otherwise
+            // altering a marking at runtime can lead to the renderer falling over.
+            // The Vulps must be shaved.
+            // (https://github.com/space-wizards/space-station-14/issues/40135).
+            if (prototype.CanBeDisplaced)
+                _displacement.EnsureDisplacementIsNotOnSprite(spriteEnt, layerId);
         }
     }
 


### PR DESCRIPTION
## About the PR
Fixes strange black screen crash

## Why / Balance
read above

## Technical details
[Goob reverted this fix so we re-add it](https://github.com/space-wizards/space-station-14/pull/40171)

## Error

`[ERRO] ui: Caught exception while trying to draw a UI element: MainWindowRoot (WindowRoot)
[ERRO] runtime: Caught exception in "UserInterfaceManager"
System.Collections.Generic.KeyNotFoundException: The given key 'HumanHairClassicLong3-classiclong3' was not present in the dictionary.
   at Robust.Client.GameObjects.SpriteSystem.HandleShaderLayer(Layer layer, Texture texture, CopyToShaderParameters params) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Render.cs:line 174`

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Black screen bug on displacement issues