### PR TITLE
Remove Obra Dinn Clock from det lockers.

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -204,7 +204,7 @@
     - id: Betty # Goobstation
     - id: BoxTapeRecorder # DeltaV
     - id: PoliceBaton # Goobstation
-    - id: ObraDinnClock # Goobstation
+    #- id: ObraDinnClock # Goobstation # Omu, removed.
 
 - type: entity
   id: ClosetBombFilled

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Security/clock.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Security/clock.yml
@@ -2,6 +2,7 @@
   parent: BaseItem
   id: ObraDinnClock
   name: clock of the insurance evaluator
+  suffix: DO NOT MAP # Omu
   description: an old heirloom that seems to be ticking backwards
   components:
   - type: Sprite


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Removed the "clock of the insurance evaluator" from detective's locker pool, and marked it as DO NOT MAP.

## Why / Balance
This thing is overpowered, heavily encourages unnecessary round removal, and is generally buggy as hell right now. I really don't see a point to keeping it around.

## Technical details
Comments out clock from **Resources/Prototypes/Catalog/Fills/Lockers/security.yml**.
Adds "DO NOT MAP" suffix to clock in **Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Security/clock.yml**.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- todo Omustation / License CLA here-->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: DuskTheSnep
- remove: Clock of the insurance evaluator no longer spawns in the Detective locker.
