### PR TITLE
"Unlimited" Vox skin colors

### DIFF
--- a/Resources/Prototypes/Species/skin_colorations.yml
+++ b/Resources/Prototypes/Species/skin_colorations.yml
@@ -12,9 +12,9 @@
 - type: skinColoration
   id: VoxFeathers
   strategy: !type:ClampedHsvColoration
-    hue: [0.081, 0.48]
-    saturation: [0.2, 0.8]
-    value: [0.36, 0.55]
+    hue: [0.0, 1] # Omu - "Unlimited" colors
+    saturation: [0, 0.9] # Omu - "Unlimited" colors
+    value: [0.1, 0.55] # Omu - "Unlimited" colors
 
 - type: skinColoration
   id: HumanToned

--- a/Resources/Prototypes/Species/vox.yml
+++ b/Resources/Prototypes/Species/vox.yml
@@ -8,7 +8,7 @@
   sprites: MobVoxSprites
   markingLimits: MobVoxMarkingLimits
   dollPrototype: MobVoxDummy
-  skinColoration: Hues # Omu - Unlimited colors
+  skinColoration: VoxFeathers
   defaultSkinTone: "#6c741d"
   maleFirstNames: NamesVox
   femaleFirstNames: NamesVox

--- a/Resources/Prototypes/Species/vox.yml
+++ b/Resources/Prototypes/Species/vox.yml
@@ -8,7 +8,7 @@
   sprites: MobVoxSprites
   markingLimits: MobVoxMarkingLimits
   dollPrototype: MobVoxDummy
-  skinColoration: VoxFeathers
+  skinColoration: Hues # Omu - Unlimited colors
   defaultSkinTone: "#6c741d"
   maleFirstNames: NamesVox
   femaleFirstNames: NamesVox


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
"Unrestricted" vox colors, make all the pink, purple, red, whatever else colored voxes you ever wanted.

The only limitation now are brightness and value sliders. Hue is completely unrestricted.

This should be a nice balance to not have "max bright voxes"

## Why / Balance
Screw limitations

## Technical details
Feather color restriction adjustments

## Media

<img width="213" height="336" alt="image" src="https://github.com/user-attachments/assets/f1e8c536-3e9d-4d2c-ba6d-b4762afb62dd" />
<img width="228" height="333" alt="image" src="https://github.com/user-attachments/assets/2c7ce96e-1af0-43ec-bcac-46e0eab0c5e0" />

This would be the min and max slider values:
<img width="1569" height="160" alt="image" src="https://github.com/user-attachments/assets/578f35ad-c2a1-4a15-95d5-ad574593ecd9" />

<img width="1569" height="160" alt="image" src="https://github.com/user-attachments/assets/31d3f1f0-77df-49d1-88f1-4f9685a8a6f1" />



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- todo Omustation / License CLA here-->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: Quill
- tweak: Voxes can now be a lot more colorful.

