### PR TITLE
[Fix] Cryo chems and adding bloodloss back to cryox

### DIFF
--- a/Content.Shared/EntityEffects/Effects/EvenHealthChangeEntityEffectSystem.cs
+++ b/Content.Shared/EntityEffects/Effects/EvenHealthChangeEntityEffectSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Damage.Prototypes;
 using Content.Goobstation.Maths.FixedPoint;
 using Content.Shared._Shitmed.EntityEffects.Effects;
 using Content.Shared._Shitmed.Damage;
+using Content.Shared._Shitmed.Targeting;
 using Content.Shared.Localizations;
 using Content.Shared.Temperature.Components;
 using Robust.Shared.Prototypes;
@@ -44,6 +45,7 @@ public sealed partial class EvenHealthChangeEntityEffectSystem : EntityEffectSys
                     spec,
                     ignoreResistances: args.Effect.IgnoreResistances,
                     interruptsDoAfters: false,
+                    targetPart: args.Effect.UseTargeting ? args.Effect.TargetPart : null, // Omu, needed for full body healing for cryo chems
                     splitDamage: args.Effect.SplitDamage); // Goob
             // </Goob>
         }
@@ -67,6 +69,12 @@ public sealed partial class EvenHealthChange : EntityEffectBase<EvenHealthChange
 
     [DataField]
     public SplitDamageBehavior SplitDamage = SplitDamageBehavior.SplitEnsureAllOrganic; // Goob , need for shitmed
+
+    [DataField]
+    public bool UseTargeting = true; // Omu, needed for full body healing for cryo chems
+
+    [DataField]
+    public TargetBodyPart TargetPart = TargetBodyPart.All; // Omu, needed for full body healing for cryo chems
 
     /// <summary>
     /// Shitmed - How to scale the effect based on the temperature of the target entity.

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -250,6 +250,16 @@
             Brute: -9 # Goob - Cryobuff
             Burn: -9 # Goob - Cryobuff
             Toxin: -6 # Goob - Cryobuff
+        - !type:ModifyBloodLevel
+          conditions:
+          - !type:TemperatureCondition
+            max: 213.0
+          amount: 8
+        - !type:ModifyBleed
+          conditions:
+          - !type:TemperatureCondition
+            max: 213.0
+          amount: -1
         - !type:GenericStatusEffect # Mono edit
           conditions:
             - !type:MetabolizerTypeCondition

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -250,6 +250,7 @@
             Brute: -9 # Goob - Cryobuff
             Burn: -9 # Goob - Cryobuff
             Toxin: -6 # Goob - Cryobuff
+          # Omu Start -- add bloddloss back to cryox
         - !type:ModifyBloodLevel
           conditions:
           - !type:TemperatureCondition
@@ -260,6 +261,7 @@
           - !type:TemperatureCondition
             max: 213.0
           amount: -1
+          #Omu End
         - !type:GenericStatusEffect # Mono edit
           conditions:
             - !type:MetabolizerTypeCondition


### PR DESCRIPTION
## About the PR
Cryo chem fix and adding bloodloss healing back to cryox

## Why / Balance
bug and weird removal of cryox usage
resolves https://github.com/ProjectOmu/OmuStation/issues/1485
resolves https://github.com/Goob-Station/Goob-Station/issues/7051 as well

## Technical details
made targeting similar to Healthchange system

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Cryo chems should heal every body part now rather than just vital part