### PR TITLE
[BOUNTY] Buff Fresium

### DIFF
--- a/Resources/Prototypes/Chemistry/injector_modes.yml
+++ b/Resources/Prototypes/Chemistry/injector_modes.yml
@@ -152,3 +152,23 @@
 - type: injectorMode
   parent: [ BaseAdvancedJetInjectorMode, BaseDynamicMode ]
   id: AdvancedJetInjectorDynamicMode
+
+  # Goob start
+  # BSO combat injector's modes
+- type: injectorMode
+  abstract: true
+  id: BaseCombatInjectorMode
+  mobTime: 1 # Attempt to match the previous injector speed
+  transferAmounts:
+  - 3
+  - 5
+
+- type: injectorMode
+  parent: [BaseCombatInjectorMode, BaseDynamicMode]
+  id: CombatInjectorDynamicMode
+
+- type: injectorMode
+  parent: [BaseCombatInjectorMode, BaseInjectMode]
+  id: CombatInjectorInjectMode
+
+  # Goob end

--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -256,7 +256,7 @@
         ignoreResistances: false
         damage:
           types:
-            Cold: 0.05
+            Cold: 0.5 # Omu, buff Fresium
       - !type:AdjustTemperature
         conditions:
         - !type:TemperatureCondition
@@ -268,18 +268,18 @@
       - !type:Extinguish # cold
   metabolisms:
     Poison:
-      metabolismRate : 0.45
+      metabolismRate : 0.4 # Omu, buff Fresium
       effects:
       - !type:HealthChange
         damage:
           types:
-             Cold: 0.01 # slightly nips directly, other cold damage comes from the temp change
+             Cold: 0.5 # slightly nips directly, other cold damage comes from the temp change # Omu, buff from 0.01 to 0.5
              Heat: -3 # ghetto burn chem. i don't think anyone would use this intentionally but it's funny
       - !type:PopupMessage
         conditions:
         - !type:ReagentCondition
           reagent: Fresium
-          max: 35
+          max: 20 # 35 # Omu, lower thresholds to account for Fresium buff
         type: Local
         visualType: LargeCaution
         messages: [ "fresium-effect-freeze-insides"]
@@ -288,7 +288,7 @@
         conditions:
         - !type:ReagentCondition
           reagent: Fresium
-          max: 35
+          max: 20 # 35 # Omu, lower thresholds to account for Fresium buff
         type: Local
         visualType: LargeCaution
         messages: [ "fresium-effect-slow"]
@@ -302,21 +302,21 @@
         conditions:
         - !type:ReagentCondition
           reagent: Fresium
-          max: 40 # slows when less than 40
+          max: 25 # 40 # slows when less than 40 # Omu, lowered to 25
         walkSpeedModifier: 0.6
         sprintSpeedModifier: 0.6
       - !type:MovementSpeedModifier
         conditions:
         - !type:ReagentCondition
           reagent: Fresium
-          min: 40 # your legs stop working when above 40
+          min: 25 # 40 # your legs stop working when above 40 # Omu, lowered to 25
         walkSpeedModifier: 0.00
         sprintSpeedModifier: 0.00
       - !type:PopupMessage
         conditions:
         - !type:ReagentCondition
           reagent: Fresium
-          min: 40
+          min: 25 # 40 # Omu, lowered to 25
         type: Local
         visualType: LargeCaution
         messages: [ "fresium-effect-frozen"]

--- a/Resources/Prototypes/Recipes/Reactions/fun.yml
+++ b/Resources/Prototypes/Recipes/Reactions/fun.yml
@@ -90,35 +90,39 @@
       amount: 1
     Water:
       amount: 1
-  effects:
-  - !type:CreateGas
-    gas: Frezon
+  # effects: # Omu start; comment out the creation of frezon due to Fresium not being made with frezon
+  # - !type:CreateGas
+  #   gas: Frezon # Omu end
   products:
     Ice: 5
 
 - type: reaction
   id: Fresium
   priority: 20
-  maxTemp: 300
+  maxTemp: 100 # 300 # Omu start; change the recipe of Fresium to be more accessible (maxTemp lowered to make people use cryostylane)
   reactants:
-    Frezon:
-      amount: 3
+    # Frezon:
+    #   amount: 3
+    Cryostylane:
+      amount: 1
     Plasma:
       amount: 1
-      catalyst: true
+      # catalyst: true
     Nitrogen:
-      amount: 2
+      amount: 1 # 2
     Cryoxadone:
-      amount: 0.22
-    TableSalt:
-      amount: 0.08
+      amount: 1 # 0.22
+    # TableSalt:
+    #   amount: 0.08
     Water:
-      amount: 1.5
+      amount: 1 # 1.5
+    Phenol:
+      amount: 1
   effects:
   - !type:CreateGas
     gas: Nitrogen
   products:
-    Fresium: 5
+    Fresium: 6 # 5 # Omu end; change the recipe of Fresium to be more accessible
 
 - type: reaction
   id: FiberBreakdown

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/blueshield.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/blueshield.yml
@@ -95,10 +95,10 @@
       injector:
         maxVol: 5
   - type: Injector
-    activeModeProtoId: SyringeDrawMode #Goob start
+    activeModeProtoId: CombatInjectorDynamicMode # SyringeDrawMode #Goob start
     allowedModes:
-    - SyringeDrawMode
-    - SyringeInjectMode #Goob end
+    - CombatInjectorDynamicMode # SyringeDrawMode
+    - CombatInjectorInjectMode # SyringeInjectMode #Goob end
   - type: MeleeChemicalInjector
     transferAmount: 5
     solution: injector


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Fresium is now substantially easier to get, no longer requiring frezon and having a much less convoluted recipe
Fresium also requires less of it (40u --> 25u) to cause total freezing (setting movement to 0x speed)
Fresium does not produce frezon when freezing water into ice

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bountied
Fresium is so unbelievably underutilized. i have never in my life seen or heard of anyone attempting to make this. this will put Fresium back on the menu for making ice and uh, you know. the usual chemistry war crimes they do

## Technical details
<!-- Summary of code changes for easier review. -->
altered `Resources\Prototypes\Reagents\fun.yml` for Fresium's stat changes
altered `Resources\Prototypes\Recipes\Reactions\fun.yml` for Fresium's recipe change

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1342" height="674" alt="image" src="https://github.com/user-attachments/assets/9cd511b0-3b20-48a3-9016-6a76bdecb9d6" />
<img width="632" height="668" alt="image" src="https://github.com/user-attachments/assets/4d99d2eb-a8f5-4e46-81b0-4a20b11cf82f" />

here's the Fresium + ice reaction (i spilled a bunch out of the beaker)
note that i did NOT get frezon nuked and die
[1 Fresium + 1 Water] (Makes 5 Ice)
<img width="643" height="698" alt="image" src="https://github.com/user-attachments/assets/7ce10fa8-19d2-4c37-b674-5b30cf83b71e" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- todo Omustation / License CLA here-->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl: Duuckie
- tweak: Fresium is now more potent and substantially easier to get, no longer requiring frezon to make. As a result, Fresium no longer produces frezon when turning water into ice.