### PR TITLE
[Fix] Polymorph chems trigger properly

### DIFF
--- a/Resources/Prototypes/_Omu/Reagents/fun.yml
+++ b/Resources/Prototypes/_Omu/Reagents/fun.yml
@@ -13,13 +13,15 @@
       - !type:Polymorph
         prototype: PolymorphHarpy
         conditions:
-        - !type:ReagentThresholdCondition
+        - !type:ReagentCondition
+          reagent: BirdFlu
           min: 50
       - !type:AdjustReagent
         reagent: BirdFlu
         amount: -40 # Prevents the bug that keeps demorphing and morphing a person keeping them in place when injected with way over the threshold for morphing, once demorphed by knocking into crit.
         conditions:
-        - !type:ReagentThresholdCondition
+        - !type:ReagentCondition
+          reagent: BirdFlu
           min: 50
 
 - type: reagent
@@ -38,13 +40,15 @@
       - !type:Polymorph
         prototype: PolymorphMoth
         conditions:
-        - !type:ReagentThresholdCondition
+        - !type:ReagentCondition
+          reagent: Mothamphetamine
           min: 50
       - !type:AdjustReagent
         reagent: Mothamphetamine
         amount: -40 # Prevents the bug that keeps demorphing and morphing a person keeping them in place when injected with way over the threshold for morphing, once demorphed by knocking into crit.
         conditions:
-        - !type:ReagentThresholdCondition
+        - !type:ReagentCondition
+          reagent: Mothamphetamine
           min: 50
 
 - type: reagent
@@ -62,13 +66,15 @@
       - !type:Polymorph
         prototype: PolymorphSquackroach
         conditions:
-        - !type:ReagentThresholdCondition
+        - !type:ReagentCondition
+          reagent: Cacaphonium
           min: 50
       - !type:AdjustReagent
         reagent: Cacaphonium
         amount: -40 # Prevents the bug that keeps demorphing and morphing a person keeping them in place when injected with way over the threshold for morphing, once demorphed by knocking into crit.
         conditions:
-        - !type:ReagentThresholdCondition
+        - !type:ReagentCondition
+          reagent: Cacaphonium
           min: 50
 
 - type: reagent
@@ -87,13 +93,15 @@
       - !type:Polymorph
         prototype: PolymorphMothroach
         conditions:
-        - !type:ReagentThresholdCondition
+        - !type:ReagentCondition
+          reagent: Chitterzine
           min: 50
       - !type:AdjustReagent
         reagent: Chitterzine
         amount: -40 # Prevents the bug that keeps demorphing and morphing a person keeping them in place when injected with way over the threshold for morphing, once demorphed by knocking into crit.
         conditions:
-        - !type:ReagentThresholdCondition
+        - !type:ReagentCondition
+          reagent: Chitterzine
           min: 50
 
 - type: reagent
@@ -111,13 +119,15 @@
       - !type:Polymorph
         prototype: PolymorphShadowkin
         conditions:
-        - !type:ReagentThresholdCondition
+        - !type:ReagentCondition
+          reagent: Marotine
           min: 50
       - !type:AdjustReagent
         reagent: Marotine
         amount: -40 # Prevents the bug that keeps demorphing and morphing a person keeping them in place when injected with way over the threshold for morphing, once demorphed by knocking into crit.
         conditions:
-        - !type:ReagentThresholdCondition
+        - !type:ReagentCondition
+          reagent: Marotine
           min: 50
 
 - type: reagent
@@ -135,13 +145,15 @@
       - !type:Polymorph
         prototype: PolymorphDwarf
         conditions:
-        - !type:ReagentThresholdCondition
+        - !type:ReagentCondition
+          reagent: Methril
           min: 50
       - !type:AdjustReagent
         reagent: Methril
         amount: -40 # Prevents the bug that keeps demorphing and morphing a person keeping them in place when injected with way over the threshold for morphing, once demorphed by knocking into crit.
         conditions:
-        - !type:ReagentThresholdCondition
+        - !type:ReagentCondition
+          reagent: Methril
           min: 50
 
 - type: reagent
@@ -159,13 +171,15 @@
       - !type:Polymorph
         prototype: PolymorphHarpyPermanent
         conditions:
-        - !type:ReagentThresholdCondition
+        - !type:ReagentCondition
+          reagent: BirdFluConcentrate
           min: 25
       - !type:AdjustReagent
         reagent: BirdFluConcentrate
         amount: -15 # Prevents the bug that keeps demorphing and morphing a person keeping them in place when injected with way over the threshold for morphing, once demorphed by knocking into crit.
         conditions:
-        - !type:ReagentThresholdCondition
+        - !type:ReagentCondition
+          reagent: BirdFluConcentrate
           min: 25
 
 - type: reagent
@@ -184,13 +198,15 @@
       - !type:Polymorph
         prototype: PolymorphMothPermanent
         conditions:
-        - !type:ReagentThresholdCondition
+        - !type:ReagentCondition
+          reagent: MothamphetamineConcentrate
           min: 25
       - !type:AdjustReagent
         reagent: MothamphetamineConcentrate
         amount: -15 # Prevents the bug that keeps demorphing and morphing a person keeping them in place when injected with way over the threshold for morphing, once demorphed by knocking into crit.
         conditions:
-        - !type:ReagentThresholdCondition
+        - !type:ReagentCondition
+          reagent: MothamphetamineConcentrate
           min: 25
 
 - type: reagent


### PR DESCRIPTION
## About the PR
Adjusted polymorph chems to use proper reagent theshhold type

## Why / Balance
After upstream they only needed the bare minimum unit to transform people

## Technical details
Changed typing to the correct one

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Polymorph chems no longer transform at lower than expected values