### PR TITLE
Allow Revolvers to be Reloaded From Boxes

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
@@ -9,9 +9,7 @@ using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 using System.Linq;
-using Content.Shared.Actions.Components;
 using Content.Shared.Interaction.Events;
-using Content.Shared.Timing;
 using JetBrains.Annotations;
 
 namespace Content.Shared.Weapons.Ranged.Systems;

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
@@ -168,18 +168,22 @@ public partial class SharedGunSystem
             return true;
         }
 
-        if (HasComp<BallisticAmmoProviderComponent>(insertEnt))
+        if (TryComp<BallisticAmmoProviderComponent>(insertEnt, out var ammoHolder))
         {
-            // Popup("Mar, object definitely holds ammo",ent,user);
-            TryComp<BallisticAmmoProviderComponent>(insertEnt, out var ammoHolder);
+            Popup("Attempting transfer from ammo container to revolver...",ent,user);
 
-            // if (ammoHolder!.MayTransfer)
-            // {
-            //     Popup("Mar, Ammo Holder can transfer contents.",ent,user);
-            // }
-            //
-            // var inWhitelist = _whitelistSystem.IsWhitelistPass(ammoHolder.Whitelist, ent);
-            // Popup($"Mar, inWhitelist is {inWhitelist}",ent,user);
+            // Get simple breaking conditions out of the way first.
+            // Container must allow ammo transfer, and not be empty.
+            if (!ammoHolder.MayTransfer && ammoHolder.Count > 0)
+                return false;
+
+            // Break if the container and the revolver do not fit the same kind of ammo.
+            if (ent.Comp.Whitelist?.Tags is not null && ammoHolder.Whitelist?.Tags is not null
+                && !ent.Comp.Whitelist.Tags.Intersect(ammoHolder.Whitelist.Tags).Any())
+                return false;
+
+            Popup("This container can transfer a bullet.",ent,user);
+            return false;
 
 
         }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
@@ -183,17 +183,44 @@ public partial class SharedGunSystem
                 return false;
 
             Popup("This container can transfer a bullet.",ent,user);
-            return false;
+
+            for (var i = 0; i < ent.Comp.Capacity; i++)
+            {
+                var index = (ent.Comp.CurrentIndex + i) % ent.Comp.Capacity;
+
+                if (ent.Comp.AmmoSlots[index] is not null || ent.Comp.Chambers[index] is not null)
+                    continue;
+
+                // A lot of the code from this point to the return is adapted from how regular Ballistics handle ammo transfer.
+                List<(EntityUid? Entity, IShootable Shootable)> ammo = new();
+                var evTakeAmmo = new TakeAmmoEvent(1, ammo, Transform(ent).Coordinates, user);
+                RaiseLocalEvent(insertEnt, evTakeAmmo);
+
+                foreach (var (bullet, _) in ammo)
+                {
+                    if (bullet is null)
+                        continue;
+
+                    // I have no idea why it spawns 12-to-23 fake bullets
+                    if (IsClientSide(bullet.Value))
+                        Del(bullet.Value);
+                }
+
+                return false;
+
+
+            }
 
 
         }
 
+        // Check to see if the entity does not belong in the revolver.
+        if (_whitelistSystem.IsWhitelistFail(ent.Comp.Whitelist, insertEnt))
+            return false;
+
         // Try to insert the entity directly.
         for (var i = 0; i < ent.Comp.Capacity; i++)
         {
-            if (_whitelistSystem.IsWhitelistFail(ent.Comp.Whitelist, insertEnt))
-                return false; // This cartridge isn't intended for this revolver
-
             var index = (ent.Comp.CurrentIndex + i) % ent.Comp.Capacity;
 
             if (ent.Comp.AmmoSlots[index] != null ||

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
@@ -9,7 +9,9 @@ using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 using System.Linq;
+using Content.Shared.Actions.Components;
 using Content.Shared.Interaction.Events;
+using Content.Shared.Timing;
 using JetBrains.Annotations;
 
 namespace Content.Shared.Weapons.Ranged.Systems;
@@ -95,8 +97,6 @@ public partial class SharedGunSystem
 
     public bool TryRevolverInsert(Entity<RevolverAmmoProviderComponent> ent, EntityUid insertEnt, EntityUid? user)
     {
-        Popup("Mar, attempt was made to insert something into a revolver", ent, user); //debug statement
-
         // If it's a speedloader try to get ammo from it.
         if (HasComp<SpeedLoaderComponent>(insertEnt))
         {
@@ -170,11 +170,15 @@ public partial class SharedGunSystem
 
         if (TryComp<BallisticAmmoProviderComponent>(insertEnt, out var ammoHolder))
         {
-            Popup("Attempting transfer from ammo container to revolver...",ent,user);
-
             // Get simple breaking conditions out of the way first.
             // Container must allow ammo transfer, and not be empty.
             if (!ammoHolder.MayTransfer && ammoHolder.Count > 0)
+                return false;
+
+            // A bit of a hacky way to do it tbh.
+            // To prevent loading revolvers from containers from being always optimal, something has to stop bullets
+            // from being mashed as fast as you can click.
+            if (_useDelay.IsDelayed(ent.Owner))
                 return false;
 
             // Break if the container and the revolver do not fit the same kind of ammo.
@@ -182,7 +186,12 @@ public partial class SharedGunSystem
                 && !ent.Comp.Whitelist.Tags.Intersect(ammoHolder.Whitelist.Tags).Any())
                 return false;
 
-            Popup("This container can transfer a bullet.",ent,user);
+            // Again, kinda hacky.
+            _useDelay.TryGetDelayInfo(ent.Owner, out var defaultDelayInfo);
+            var cycleDelay = defaultDelayInfo?.Length ?? new TimeSpan(0,0,0,0,66);
+            _useDelay.SetLength(ent.Owner, ammoHolder.FillDelay); // multiply by some factor to balance insertion rate?
+            _useDelay.TryResetDelay(ent.Owner);
+            _useDelay.SetLength(ent.Owner, cycleDelay); // reset the time so cycling doesn't have the reload delay on it
 
             for (var i = 0; i < ent.Comp.Capacity; i++)
             {
@@ -201,17 +210,22 @@ public partial class SharedGunSystem
                     if (bullet is null)
                         continue;
 
-                    // I have no idea why it spawns 12-to-23 fake bullets
+                    ent.Comp.AmmoSlots[index] = bullet.Value;
+                    Containers.Insert(bullet.Value, ent.Comp.AmmoContainer);
+                    SetChamber(ent, bullet.Value, index);
+                    Audio.PlayPredicted(ent.Comp.SoundInsert, ent, user);
+                    UpdateRevolverAppearance(ent);
+                    UpdateAmmoCount(ent);
+                    Dirty(ent);
+
+                    // I have no idea why it spawns 12-to-23 fake bullets,
                     if (IsClientSide(bullet.Value))
                         Del(bullet.Value);
                 }
-
-                return false;
-
-
+                return true;
             }
-
-
+            Popup(Loc.GetString("gun-revolver-full"), ent, user);
+            return false;
         }
 
         // Check to see if the entity does not belong in the revolver.

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
@@ -95,12 +95,14 @@ public partial class SharedGunSystem
 
     public bool TryRevolverInsert(Entity<RevolverAmmoProviderComponent> ent, EntityUid insertEnt, EntityUid? user)
     {
-        if (_whitelistSystem.IsWhitelistFail(ent.Comp.Whitelist, insertEnt))
-            return false;
+        Popup("Mar, attempt was made to insert something into a revolver", ent, user); //debug statement
 
         // If it's a speedloader try to get ammo from it.
         if (HasComp<SpeedLoaderComponent>(insertEnt))
         {
+            if (_whitelistSystem.IsWhitelistFail(ent.Comp.Whitelist, insertEnt))
+                return false; // The speedloader isn't intended for this revolver.
+
             var freeSlots = 0;
 
             for (var i = 0; i < ent.Comp.Capacity; i++)
@@ -166,9 +168,28 @@ public partial class SharedGunSystem
             return true;
         }
 
+        if (HasComp<BallisticAmmoProviderComponent>(insertEnt))
+        {
+            // Popup("Mar, object definitely holds ammo",ent,user);
+            TryComp<BallisticAmmoProviderComponent>(insertEnt, out var ammoHolder);
+
+            // if (ammoHolder!.MayTransfer)
+            // {
+            //     Popup("Mar, Ammo Holder can transfer contents.",ent,user);
+            // }
+            //
+            // var inWhitelist = _whitelistSystem.IsWhitelistPass(ammoHolder.Whitelist, ent);
+            // Popup($"Mar, inWhitelist is {inWhitelist}",ent,user);
+
+
+        }
+
         // Try to insert the entity directly.
         for (var i = 0; i < ent.Comp.Capacity; i++)
         {
+            if (_whitelistSystem.IsWhitelistFail(ent.Comp.Whitelist, insertEnt))
+                return false; // This cartridge isn't intended for this revolver
+
             var index = (ent.Comp.CurrentIndex + i) % ent.Comp.Capacity;
 
             if (ent.Comp.AmmoSlots[index] != null ||


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
This PR makes it so revolvers can be loaded directly from things that hold ammo (such as boxes, magazines, drums), as long as the revolver has empty chambers.

## Why / Balance
This was requested by the project lead of OmuStation.

One possible balance tweak could be slapping a multiplier to the time it takes to load each bullet from a box. At the moment, x1 would be 0.5 seconds per bullet for all the ammo holders I looked at.

## Technical details
It's sorta a mix between how revolvers load individual cartridges, and how ballistics handle transferring ammo. Revolvers essentially have 3 cases for interacting with ammo, with "from containers" being the second case (since speedloaders are also ammo containers).

## Media
https://github.com/user-attachments/assets/d59a5fde-1bb8-427f-b1bf-237ea02eec5e

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
No intentional breaking changes have been done.

**Changelog**
:cl:
- add: Revolvers can now be reloaded directly from things that hold ammo.
