### PR TITLE
Reverted the adv mop to have the old usage delay again

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -93,7 +93,7 @@
       pickupAmount: 100
       useAbsorberSolution: true
     - type: UseDelay
-      delay: 1.0
+      delay: 0.12 # Omu - Revert goob change
     - type: SolutionRegeneration
       solution: absorbed
       generated:


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR

Default mop has a usage delay of 0.25s.

Advanced mop **had** a usage delay of 0.12s, however for whatever reason it's 1s now, making it unbearably slow to use.

## Why / Balance
It's not fun to clean up with it right now.

## Technical details
Yaml change.

## Media
Currently: 

[Screencast_20260829_203327.webm](https://github.com/user-attachments/assets/43ec5580-a855-4704-b43e-0d65246a8512)

My change which reverts it back to 0.12s:

[Screencast_20260829_203722.webm](https://github.com/user-attachments/assets/ee2bc35b-ea1c-4a72-acff-a6cc3ef2f12d)


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- todo Omustation / License CLA here-->

**Changelog**
:cl: Quill
- tweak: Decreased the advanced mops usage delay.

