### PR TITLE
Update CCVars.Playtest.cs

### DIFF
--- a/Content.Shared/CCVar/CCVars.Playtest.cs
+++ b/Content.Shared/CCVar/CCVars.Playtest.cs
@@ -77,7 +77,7 @@ public sealed partial class CCVars
         /// </summary>
         [CVarControl(AdminFlags.VarEdit)]
         public static readonly CVarDef<float> PlaytestExplosionDamageModifier =
-            CVarDef.Create("playtest.explosion_damage_modifier", 1f, CVar.SERVER | CVar.REPLICATED);
+            CVarDef.Create("playtest.explosion_damage_modifier", 0.65f, CVar.SERVER | CVar.REPLICATED);
 
         /// <summary>
         ///     Scales the damage dealt to mobs in the game (i.e. entities with MobStateComponent).


### PR DESCRIPTION
## About the PR
lowered explosive damage

## Why / Balance
Shits too much. Grimbo blow (up) too much.

## Technical details
changed the cvar from 1 to  .65 (pre upstream was .5)

## Media
check the code its a cvar

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.



## Breaking changes
Unfucked the explosions a little, new damage should be more fair

**Changelog**

:cl:
- tweak: Explosions are now somewhat less goida
