### PR TITLE
Explosion damage nerf

### DIFF
--- a/Resources/ConfigPresets/_Omu/OmuCore.toml
+++ b/Resources/ConfigPresets/_Omu/OmuCore.toml
@@ -149,3 +149,10 @@ punctuation = true
 
 [ooc]
 enable_during_round = false # Default is false, changed back to default on 31/03/2026 @ 11:35 CDT
+
+[explosion]
+wounding_multiplier = 1f # from 2.5f
+
+[playtest]
+explosion_damage_modifier = 0.65f # from 1f
+

--- a/Resources/ConfigPresets/_Omu/OmuCore.toml
+++ b/Resources/ConfigPresets/_Omu/OmuCore.toml
@@ -151,8 +151,8 @@ punctuation = true
 enable_during_round = false # Default is false, changed back to default on 31/03/2026 @ 11:35 CDT
 
 [explosion]
-wounding_multiplier = 1f # from 2.5f
+wounding_multiplier = 1 # from 2.5
 
 [playtest]
-explosion_damage_modifier = 0.65f # from 1f
+explosion_damage_modifier = 0.65 # from 1
 


### PR DESCRIPTION
## About the PR
Removes the bonus damage explosions get serverside

## Why / Balance
Explosions were far too strong

## Technical details
added ccvar overwrites serverside

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Lowered damage explosions do