### PR TITLE
Allow projectiles to multiply their speed

### DIFF
--- a/Content.Shared/Projectiles/ProjectileComponent.cs
+++ b/Content.Shared/Projectiles/ProjectileComponent.cs
@@ -127,4 +127,10 @@ public sealed partial class ProjectileComponent : Component
     /// </summary>
     [DataField]
     public FixedPoint2 PenetrationFactor = 1f;
+
+    /// <summary>
+    /// Omu:    A multiplier on projectile speed.
+    /// </summary>
+    [DataField]
+    public FixedPoint2 ProjectileSpeedModifier = 1f;
 }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -514,12 +514,17 @@ public abstract partial class SharedGunSystem : EntitySystem
         var physics = EnsureComp<PhysicsComponent>(uid);
         Physics.SetBodyStatus(uid, physics, BodyStatus.InAir);
 
+        // Omu start - allow the projectile prototype to multiply its speed.
+        var projectile = EnsureComp<ProjectileComponent>(uid);
+        speed = speed * (float) projectile.ProjectileSpeedModifier;
+        // Omu end
+
         var targetMapVelocity = gunVelocity + direction.Normalized() * speed;
         var currentMapVelocity = Physics.GetMapLinearVelocity(uid, physics);
         var finalLinear = physics.LinearVelocity + targetMapVelocity - currentMapVelocity;
         Physics.SetLinearVelocity(uid, finalLinear, body: physics);
 
-        var projectile = EnsureComp<ProjectileComponent>(uid);
+        //var projectile = EnsureComp<ProjectileComponent>(uid); // Omu, move this earlier.
         projectile.Weapon = gunUid;
         var shooter = user ?? gunUid;
         if (shooter != null)


### PR DESCRIPTION
## About the PR
Used on zero projectiles currently, its kinda dumb that projectiles can effect their speed, especially with an ammo type cyg wants to add. so I made it so the bullet can effect its own speed. Go too high and it phases through walls, but I don't really care.

## Why / Balance
There is no balance change here, why? so it can be used in future, since this is easier than telling cyg which lines to change.

## Technical details
Add a field to projectile component called ProjectileSpeedModifier, defaults to 1, bullet speed is multiplied by this.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- add: Added a new field for contribs to use on projectiles, which can multiply its speed, currently does not change any in game projectile.