### PR TITLE
Visually impaired characters listening to whispers fix

### DIFF
--- a/Content.Goobstation.Server/Chat/DeafnessBlindnessSystem.cs
+++ b/Content.Goobstation.Server/Chat/DeafnessBlindnessSystem.cs
@@ -54,6 +54,8 @@ public sealed class DeafnessBlindnessSystem : EntitySystem
     {
         if (!args.RequiresSight)
             return;
-        args.Cancel();
+        if (ent.Comp.Blindness <= 0)
+            args.Cancel();
+        // Signs are completely disabled if the entity is totally blind.
     }
 }

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -720,11 +720,20 @@ public sealed partial class ChatSystem : SharedChatSystem
             if (MessageRangeCheck(session, data, range) != MessageRangeCheckResult.Full)
                 continue; // Won't get logged to chat, and ghosts are too far away to see the pop-up, so we just won't send it to them.
 
+            var evSight = new ChatMessageOverrideInRange(language.SpeechOverride.RequireSpeech, language.SpeechOverride.RequireSight);
+            RaiseLocalEvent(listener, ref evSight);
+            if (evSight.Cancelled) continue;
+            // I'm not familiar enough with the engine to figure out how to pull a property's value from a component through the entity system class
+            // So I had to comment the code below out, and copied the blindness/deafness check from the SendVoiceInRange to this.
+            // So sorry if I had made a sin.
+            
             // Goob edit start
-            if (TryComp<DeafComponent>(listener, out var modifier) && language.SpeechOverride.RequireSpeech)
-                continue; // blocks anyone with the deaf component from hearing.
-            if (HasComp<PermanentBlindnessComponent>(listener) || HasComp<TemporaryBlindnessComponent>(listener))
-                continue; // block blind people from seeing subtle sign language gestures
+            // if (TryComp<DeafComponent>(listener, out var modifier) && language.SpeechOverride.RequireSpeech)
+            //continue; // blocks anyone with the deaf component from hearing
+            
+            // if ((HasComp<PermanentBlindnessComponent>(listener) ||
+            // HasComp<TemporaryBlindnessComponent>(listener)) && language.SpeechOverride.RequireSight)
+            //continue; // block blind people from seeing subtle sign language gestures
             // Goob edit end
 
             // Einstein Engines - Language begin


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Altered a part of the chat system to fix with how characters with impaired visions would view whispers and messages in sign language.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Before this, characters that had vision impairment would be unable to hear any whispers and any characters that doesn't have the 'Blind' trait (mantle beasts or short-sighteds) couldn't see sign language even though it would make sense for them.

## Technical details
<!-- Summary of code changes for easier review. -->
DeafnessBlindnessSystem.cs in Content.Goobstation.Server/Chat has the 'PermanentBlindnessComponent' hooked on OnBlindnessOverrideInRange method altered, checks for 'RequiresSight' then checks if the entity in question is completely blind, if true then it cancels the message on client.

ChatSystem.cs has slight alteration due to how the deafness/blindness check works in 'SendEntityWhisper', it borrows from the method found in 'SendVoiceInRange'... I would've kept the original code but I don't have any experience with the SS14 engine to be able to just extract the 'Blindness' variable from the component and keep the condition, so I had to do an event call.

## Media

Warning for the moving effects from the blurry vision shader intensified by the video compression...

https://github.com/user-attachments/assets/420e22f7-8b68-4d52-8fd9-406abca1d23a

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- todo Omustation / License CLA here-->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fixed blind/visually impaired characters to now hear whispers.
- fix: Fixed visually impaired (not totally blind) characters to see signs.
