### PR TITLE
Eye damage patch

### DIFF
--- a/Content.Server/_Shitmed/Body/Systems/EyesSystem.cs
+++ b/Content.Server/_Shitmed/Body/Systems/EyesSystem.cs
@@ -56,8 +56,10 @@ namespace Content.Server._Shitmed.Body.Systems
                 || organ.IntegrityCap <= 0)
                 return;
 
-            // The expected input is scaled as a number between 12 and 3,
+            
+            // Omu: The expected input is scaled as a number between 12 and 3,
             // such that "blindness" occurs at 25% eye integrity.
+            
             var blindnessSeverity = (int) ((organ.IntegrityCap - organ.OrganIntegrity) / (organ.IntegrityCap / 12)); // Omu
             _blindableSystem.SetEyeDamage((organ.Body.Value, blindable), blindnessSeverity); // Omu
         }

--- a/Content.Server/_Shitmed/Body/Systems/EyesSystem.cs
+++ b/Content.Server/_Shitmed/Body/Systems/EyesSystem.cs
@@ -56,8 +56,10 @@ namespace Content.Server._Shitmed.Body.Systems
                 || organ.IntegrityCap <= 0)
                 return;
 
-            var lost = 1f - (float) (organ.OrganIntegrity / organ.IntegrityCap);
-            _blindableSystem.SetEyeDamage((organ.Body.Value, blindable), (int) (blindable.MaxDamage * lost));
+            // The expected input is scaled as a number between 12 and 3,
+            // such that "blindness" occurs at 25% eye integrity.
+            var blindnessSeverity = (int) ((organ.IntegrityCap - organ.OrganIntegrity) / (organ.IntegrityCap / 12));
+            _blindableSystem.SetEyeDamage((organ.Body.Value, blindable), blindnessSeverity);
         }
 
         private void OnOrganEnabled(EntityUid uid, EyesComponent component, OrganEnabledEvent args)

--- a/Content.Server/_Shitmed/Body/Systems/EyesSystem.cs
+++ b/Content.Server/_Shitmed/Body/Systems/EyesSystem.cs
@@ -58,8 +58,8 @@ namespace Content.Server._Shitmed.Body.Systems
 
             // The expected input is scaled as a number between 12 and 3,
             // such that "blindness" occurs at 25% eye integrity.
-            var blindnessSeverity = (int) ((organ.IntegrityCap - organ.OrganIntegrity) / (organ.IntegrityCap / 12));
-            _blindableSystem.SetEyeDamage((organ.Body.Value, blindable), blindnessSeverity);
+            var blindnessSeverity = (int) ((organ.IntegrityCap - organ.OrganIntegrity) / (organ.IntegrityCap / 12)); // Omu
+            _blindableSystem.SetEyeDamage((organ.Body.Value, blindable), blindnessSeverity); // Omu
         }
 
         private void OnOrganEnabled(EntityUid uid, EyesComponent component, OrganEnabledEvent args)

--- a/Content.Shared/Eye/Blinding/Systems/BlindableSystem.cs
+++ b/Content.Shared/Eye/Blinding/Systems/BlindableSystem.cs
@@ -89,7 +89,7 @@ public sealed class BlindableSystem : EntitySystem
             return;
 
         blindable.Comp.EyeDamage += amount;
-        UpdateEyeDamage(blindable, true);
+        UpdateEyeDamage(blindable, true);    // Eyes have a callback on them that would clobber this update anyway.
         // If the entity has eye organs, then we also damage those.
         if (!TryComp(blindable, out BodyComponent? body)
             || !_body.TryGetBodyOrganEntityComps<EyesComponent>((blindable, body), out var eyes))
@@ -98,8 +98,10 @@ public sealed class BlindableSystem : EntitySystem
         // for now
         foreach (var eye in eyes)
         {
-            if (!_trauma.TryChangeOrganDamageModifier(eye.Owner, amount, blindable.Owner, "BlindableDamage", eye.Comp2))
-                _trauma.TryCreateOrganDamageModifier(eye.Owner, amount, blindable.Owner, "BlindableDamage", eye.Comp2);
+            // Scale the damage done to eye organs proportional to what the cap used to be.
+            var scaledDamage = amount * (eye.Comp2.IntegrityCap / 12);
+            if (!_trauma.TryChangeOrganDamageModifier(eye.Owner, scaledDamage, blindable.Owner, "BlindableDamage", eye.Comp2))
+                _trauma.TryCreateOrganDamageModifier(eye.Owner, scaledDamage, blindable.Owner, "BlindableDamage", eye.Comp2);
         }
     }
 

--- a/Content.Shared/Eye/Blinding/Systems/BlindableSystem.cs
+++ b/Content.Shared/Eye/Blinding/Systems/BlindableSystem.cs
@@ -99,9 +99,11 @@ public sealed class BlindableSystem : EntitySystem
         foreach (var eye in eyes)
         {
             // Scale the damage done to eye organs proportional to what the cap used to be.
+            // Omu start
             var scaledDamage = amount * (eye.Comp2.IntegrityCap / 12);
             if (!_trauma.TryChangeOrganDamageModifier(eye.Owner, scaledDamage, blindable.Owner, "BlindableDamage", eye.Comp2))
                 _trauma.TryCreateOrganDamageModifier(eye.Owner, scaledDamage, blindable.Owner, "BlindableDamage", eye.Comp2);
+            // Omu end
         }
     }
 

--- a/Content.Shared/Eye/Blinding/Systems/BlindableSystem.cs
+++ b/Content.Shared/Eye/Blinding/Systems/BlindableSystem.cs
@@ -89,7 +89,7 @@ public sealed class BlindableSystem : EntitySystem
             return;
 
         blindable.Comp.EyeDamage += amount;
-        UpdateEyeDamage(blindable, true);    // Eyes have a callback on them that would clobber this update anyway.
+        UpdateEyeDamage(blindable, true);
         // If the entity has eye organs, then we also damage those.
         if (!TryComp(blindable, out BodyComponent? body)
             || !_body.TryGetBodyOrganEntityComps<EyesComponent>((blindable, body), out var eyes))
@@ -98,8 +98,8 @@ public sealed class BlindableSystem : EntitySystem
         // for now
         foreach (var eye in eyes)
         {
-            // Scale the damage done to eye organs proportional to what the cap used to be.
             // Omu start
+            // Scale the damage done to eye organs proportional to what the cap used to be.
             var scaledDamage = amount * (eye.Comp2.IntegrityCap / 12);
             if (!_trauma.TryChangeOrganDamageModifier(eye.Owner, scaledDamage, blindable.Owner, "BlindableDamage", eye.Comp2))
                 _trauma.TryCreateOrganDamageModifier(eye.Owner, scaledDamage, blindable.Owner, "BlindableDamage", eye.Comp2);


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
On the player side of things, welding things without proper eye protection now works mostly the way it did before the big upstream merge.

You can no longer explode your eyes just by welding things. You'll go blind before they burst.

This PR also comes with the realization that upstream shadownerfed Oculine - you'll need to use 5 times as much to heal vision damage.

## Why / Balance
I was asked to figure out why welding things without eye protection was being weird.

## Technical details
At some point during the upstream merge, eyes were made to have an `OrganIntegrity` of 60 (was 12), making instances of eye damage that are meant to progress vision problems be 5 times less effective than expected.

I kinda hope the comments are good enough to suffice going into further detail.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
No intentional breaking changes have been done.

**Changelog**
:cl:
- fix: Burning your eyes with a welder now works as expected.

