### PR TITLE
[BOUNTY] Revert roundstart crewsimov

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -440,7 +440,7 @@
     # Once it's in a core it's pretty much an abstract entity at that point.
     visible: false
   - type: SiliconLawProvider
-    laws: OmuCrewsimov # Omu edit. AI uses Omu Crewimov
+    laws: NTDefault # Goobstation - AI/borg law changes - set AI to NTDefault
   - type: IonStormTarget # Goobstation - AI/borg law changes - ion stormable AI
   - type: SiliconLawBound
   - type: ActionGrant


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
This pr makes the roundstart ai laws nt default
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bounty reads as

Lets be real, the laws of NT Default weren't the issue, NT Default never encouraged validhunting nor did it prevent it, as it stands crewsimov actively encourages validhunting and whilst you may have the argument of "each AI interprets laws differently" there's only so much wiggle room with that, Crewsimov as of current encourages the AI to intervene in situations where it is unable to follow its first law, exmples include:
- Trying to bolt nukies into areas to prevent them from getting to crew.
- Separating crew from any hostile threat, including heretics, ninjas or similar
- Preventing access to the armoury to prevent immediate likelyhood of crewharm

These are all examples that have occured in-game, either done by myself or witnessed from other AI players. Those that support crewsimov will say that trying to keep antags and crew separate is a good thing, its not, it completely hinders and ruins the fun of any antag and actively makes the validhunting situation with AI worse, as they're bound by law (you can say they're not, but they are) to keep any crew-identified hostile away from other crew as much as possible, lest they violate their first law of inaction.

NT Default did not encourage this in the same way that Crewsimov does, it allowed crew to be harmed in very specific situations which benefitted the station (allowing sec to fight a dragon for example, for the betterment of the station), and it also gave the AI room to simply observe and watch antags and sec fight, without having to intervene at all.

The issue is not the laws, it is the player, we require additional silicon server rules to prevent unnecessary validhunting which gives no room for interpretation. Changing to Crewsimov roundstart has only made the gameplay of both crew and antags worse, not better

Raincall note: Its kinda weird to have a lawboard called nt default and then not have it be the default on nt stations
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- todo Omustation / License CLA here-->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: raincall
- tweak: Brought back roundstart NT Default laws for AI
