### PR TITLE
Nerf Hunger w/Parity For Non-Goob Species

### DIFF
--- a/Content.Shared/Nutrition/Components/HungerComponent.cs
+++ b/Content.Shared/Nutrition/Components/HungerComponent.cs
@@ -36,7 +36,7 @@ public sealed partial class HungerComponent : Component
     /// </summary>
     /// <remarks>Any time this is modified, <see cref="HungerSystem.SetAuthoritativeHungerValue"/> should be called.</remarks>
     [DataField("baseDecayRate"), ViewVariables(VVAccess.ReadWrite)]
-    public float BaseDecayRate = 0.04166666666f; // Goobstation changed to 150/3600
+    public float BaseDecayRate = 0.025f; // Goobstation changed to 150/3600 // Omu nerf to 90/3600 (originally 60/3600)
 
     /// <summary>
     /// The actual amount at which <see cref="LastAuthoritativeHungerValue"/> decays.

--- a/Resources/Prototypes/Entities/Mobs/NPCs/scurret.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/scurret.yml
@@ -159,7 +159,7 @@
   - type: InventorySlots
   - type: Edible # Why? I'm not sure but I also am afraid of the answer.
   - type: Hunger
-    baseDecayRate: 0.05 # They get a lil' hungy
+    baseDecayRate: 0.075 # 0.05 # They get a lil' hungy # Omu, update for new base rate (3x base)
   - type: BodyEmotes # Grants them clapping and so on.
     soundsId: Scurret
   - type: Deathgasp

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -14,7 +14,7 @@
   - type: HumanoidAppearance
     species: Diona
   - type: Hunger
-    baseDecayRate: 0.020833 # Goobstation base rate changed, 2 times lower than base
+    baseDecayRate: 0.0125 # Goobstation base rate changed, 2 times lower than base # Omu, changed base hunger rate again
   - type: Thirst
     baseDecayRate: 0.0625 # Goobsatation base rate changed, 2 times lower than base
   - type: Icon

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
@@ -12,7 +12,7 @@
     #undergarmentTop:
     #undergarmentBottom: todo marty bottom needs adjusting
   - type: Hunger
-    baseDecayRate: 0.0467 #needs to eat more to survive
+    baseDecayRate: 0.07 # 0.0467 #needs to eat more to survive # Omu, updated for new hunger rate; chitinids get hungry at 2.8x base
   - type: Thirst
   - type: UnpoweredFlashlight
   - type: PointLight

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/rodentia.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/rodentia.yml
@@ -10,7 +10,7 @@
   - type: HumanoidAppearance
     species: Rodentia
   - type: Hunger
-    baseDecayRate: 0.054166 # Goobstation base rate changed, 33% faster than base
+    baseDecayRate: 0.03325 # Goobstation base rate changed, 33% faster than base # Omu, updated for new base rate
   - type: Thirst # // Goob Station //
   - type: Carriable # Carrying system from nyanotrasen.
   - type: Inventory

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/allulalo.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/allulalo.yml
@@ -8,9 +8,9 @@
 #  - type: GoobAbsorbable # Omu, we don't have this
 #    biomassRestored: 1.0
   - type: Hunger
-    baseDecayRate: 0.02 # 30% ish more than default
+    baseDecayRate: 0.03 # 0.02 # 30% ish more than default # Omu, update for new base rate
   - type: Thirst
-    baseDecayRate: 0.02 # 30% ish more than default
+    baseDecayRate: 0.15 # 0.02 # 30% ish more than default # Omu, update for upstream thirst rate (also i'm fairly sure the original "30% ish more" is just flat out wrong)
   - type: Fixtures
     fixtures: # TODO: This needs a second fixture just for mob collisions.
       fix1:

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/avali.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/avali.yml
@@ -33,7 +33,7 @@
         Peckish: 150
         Starving: 100
         Dead: 0
-      baseDecayRate: 0.03
+      baseDecayRate: 0.05 # 0.03 # Omu, update for new base rate
     - type: Thirst
     - type: Icon
       sprite: _Starlight/Mobs/Species/Avali/parts.rsi


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
toned down the hunger rebalance from 150/3600 to 90/3600 hunger per tick (originally 60/3600 pre-upstream)
changed diona, rodentia, chitinid, allulalo, avali, and scurret hunger accordingly
chitinids are only intended to be 1.33x as hungry. for some reason, they are 2.8x as hungry. i am keeping it at 2.8x hunger rate from code, as i play chitinid and i personally know how fast those creatures get hungry

should the proportional hunger rates prove unbelievably sucky for chitinids/scurrets (as they ALREADY got quite hungry pre-upstream) then a second PR can be made to change their hunger rates. i am simply making all species' hunger rates appropriate for this new hunger value

this does not change the hunger value of mobs with set hunger values who are not listed

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
i have heard that the 2.5x increase to hunger rates has literally caused chefs to cry due to how quickly the station empties the kitchen. this is assumedly unideal, so a toning down of hunger rates should be better

we did not account for the hunger change in upstreaming, so i made species with proportional hunger rates share parity with the new hunger rate. should this prove to be Very Bad, Actually, a separate PR can go through to change how hungry that species should be

here's an interesting thing gleaned from https://github.com/Goob-Station/Goob-Station/pull/6704 (the hunger/thirst rebalance PR)
the original intent is to have people experiencing hunger at about 70 minutes in. from what i can tell, chefs are sobbing because people keep eating their shit too quickly
i'm not exactly sure how this works out but that was the intent of the original PR
i believe we have a weaker nutribrick than goob (7.5 nutriment compared to assumedly goob's 10?) which may impact us more

## Technical details
<!-- Summary of code changes for easier review. -->
changed the default `BaseDecayRate` in `Content.Shared/Nutrition/Components/HungerComponent.cs` to be 1.5x pre-upstream hunger rates compared to 2.5x from upstream
accordingly changed diona, chitinid, rodentia, allulalo, avali, and scurret hunger rates. if there wasn't a set proportion listed in the file, then i based the ratio off of the pre-upstream hunger rate compared to the species-specific hunger rate, then i used that ratio with my new hunger rate

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="628" height="284" alt="image" src="https://github.com/user-attachments/assets/3831da65-266f-48c2-a76e-6c73eb04b025" />


<img width="635" height="278" alt="image" src="https://github.com/user-attachments/assets/57ff0cd2-33e4-43b6-bd87-b2c1a46c2aec" />


<img width="631" height="295" alt="image" src="https://github.com/user-attachments/assets/cc7c23d4-40fa-48ee-883d-35289ce5a1a8" />


<img width="646" height="294" alt="image" src="https://github.com/user-attachments/assets/f096fbdb-bad0-417d-9c8b-29ef71a08ccf" />

<img width="641" height="307" alt="image" src="https://github.com/user-attachments/assets/c02bf038-f811-42b9-93f9-fdab6cd5f787" />


<img width="639" height="289" alt="image" src="https://github.com/user-attachments/assets/b2a17d03-a4a9-415d-a1a1-ddf020765fd8" />



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- todo Omustation / License CLA here-->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Duuckie
- tweak: Hunger decreases at 1.5x the pre-upstream rate (compared to 2.5x the pre-upstream rate before this). People should now need to eat less frequently.
- fix: Non-Goobstation species now experience proportionally elevated hunger like the rest of the species. Please report if chitinids starve excessively easily.