### PR TITLE
Check all station report papers

### DIFF
--- a/Content.Goobstation.Server/StationReport/StationReportSystem.cs
+++ b/Content.Goobstation.Server/StationReport/StationReportSystem.cs
@@ -25,7 +25,7 @@ public sealed class StationReportSystem : EntitySystem
 
     private void OnRoundEndTextAppend(RoundEndTextAppendEvent args)
     {
-        var reportDefaultFormLoc = ((PaperComponent) _prototypeManager.Index("NanoRepStationReport").Components["Paper"].Component).Content; // Omu: Don't send a report that hasn't been filled in
+        var reportDefaultForm = Loc.GetString(((PaperComponent) _prototypeManager.Index("NanoRepStationReport").Components["Paper"].Component).Content); // Omu: Don't send a report that hasn't been filled in
 
         //locates the first entity with StationReportComponent then stops
         string? stationReportText = null;
@@ -33,7 +33,7 @@ public sealed class StationReportSystem : EntitySystem
         while (query.MoveNext(out var uid, out var tablet))//finds the first entity with stationreport
         {
             if (!TryComp<PaperComponent>(uid, out var paper))
-                return;
+                continue; // Omu: Make sure to check all station reports, just in case there are multiple
 
             stationReportText = paper.Content;
 
@@ -47,10 +47,12 @@ public sealed class StationReportSystem : EntitySystem
                         stationReportText += $"[color={stamp.StampedColor.ToHexNoAlpha()}]⟦{name}⟧[/color] ";
                 }
             }
-            break;
+
+            if (stationReportText != reportDefaultForm) // Omu: Make sure to check all station reports, just in case there are multiple
+                break;
         }
 
-        if(stationReportText != Loc.GetString(reportDefaultFormLoc)) // Omu: Don't send a report that hasn't been filled in
+        if(stationReportText != reportDefaultForm) // Omu: Don't send a report that hasn't been filled in
             BroadcastStationReport(stationReportText);
     }
 


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR

This PR updates the station report system to check all station report papers on the station instead of only the first one.

I'm really not sure but from looking at how the station reports gets assembled it looks like this might be the issue that sometimes the station report doesn't show up in the end of round report?

## Why / Balance

Hopefully a bugfix

## Technical details

Instead of checking only the first station report I've updated the system to check for all station reports and pick the first one where the text isn't the default one.


## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

<!-- todo Omustation / License CLA here-->

**Changelog**
:cl: Quill
- fix: Fixed a bug with station reports not showing up when there are multiple reports on the station.