### PR TITLE
Positronics suffer braindeath rather than braindelete

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
@@ -121,6 +121,15 @@
       job: Borg
     - type: Organ
       slotId: posbrain
+      intCap: 200 # Omu start
+      integrity: 200
+      integrityThresholds:
+        Normal: 200
+        Damaged: 100
+        Destroyed: 0
+      indestructible: true
+    - type: OrganDeathTrauma
+      trauma: Braindeath # Omu end
     - type: Brain
     - type: BlockMovement
     - type: Examiner

--- a/Resources/Prototypes/_Shitmed/Entities/Surgery/surgeries.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Surgery/surgeries.yml
@@ -229,6 +229,26 @@
   - type: SurgeryTraumaPresentCondition
     trauma: Braindeath
 
+# Omu start - IPC parity is good
+- type: entity
+  parent: BasePartSurgery
+  id: SurgeryRepairPositronicDamage
+  name: Repair Positronic Damage
+  components:
+  - type: Surgery
+    requirement: SurgeryOpenIncision
+    steps:
+    - SurgeryStepSawBones
+    - SurgeryStepClampInternalBleeders
+    - SurgeryStepRepairBrain
+  - type: SurgeryPartCondition
+    parts: [ Chest ]
+  - type: SurgeryBleedsPresentCondition
+    inverted: true
+  - type: SurgeryTraumaPresentCondition
+    trauma: Braindeath
+# Omu end
+
 # I fucking hate hardcoding all of this shit to accomodate for surgery BUI.
 # If anyone can give me pointers on how to make it better I'd be incredibly grateful.
 


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
New upstream mechanic didn't involve IPCs, and it could *theoretically* put one in an absolutely unrevivable state by deleting the brain due to organ damage. Now they get to suffer slightly less!

## Why / Balance
I was asked to!

## Technical details
Pure YAML - the surgery was adapted from `SurgeryRepairBrainDamage`, and the integrity numbers for positronics was grabbed from the human brain template all other brains copy from.

## Media
https://github.com/user-attachments/assets/54b4e8d4-2062-417d-b2b7-28b8c001a1e0

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

<!-- todo Omustation / License CLA here-->

## Breaking changes
No breaking changes, only additions in this PR!

**Changelog**
:cl: Jerulean
- fix: Positronic brains are no longer deleted by maxing out organ damage.
- add: Surgery to repair destroyed positronic brains.

