### PR TITLE
Partial revert for the allulalo thirst change

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/allulalo.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/allulalo.yml
@@ -10,7 +10,7 @@
   - type: Hunger
     baseDecayRate: 0.03 # 0.02 # 30% ish more than default # Omu, update for new base rate
   - type: Thirst
-    baseDecayRate: 0.15 # 0.02 # 30% ish more than default # Omu, update for upstream thirst rate (also i'm fairly sure the original "30% ish more" is just flat out wrong)
+    baseDecayRate: 0.02 # 0.02 # 30% ish more than default
   - type: Fixtures
     fixtures: # TODO: This needs a second fixture just for mob collisions.
       fix1:


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
The change to Allulalo thirst made it so the tiny birds could go maybe 10 minutes before becoming parched. This reverts that, as I've also heard word that ethanol isn't being processed correctly, making this problem worse for that species.

## Why / Balance
I was told to by the head admin.

## Technical details
It was one line.

## Media
No need.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

<!-- todo Omustation / License CLA here-->

## Breaking changes
Nothing really.

**Changelog**
:cl: Jerulean
- tweak: Reverted Allulalo thirst rate to prior rate.
