### PR TITLE
Reduce Chitinid Hunger Rate

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
@@ -12,7 +12,7 @@
     #undergarmentTop:
     #undergarmentBottom: todo marty bottom needs adjusting
   - type: Hunger
-    baseDecayRate: 0.07 # 0.0467 #needs to eat more to survive # Omu, updated for new hunger rate; chitinids get hungry at 2.8x base
+    baseDecayRate: 0.03325 # 0.0467 #needs to eat more to survive # Omu, updated for new hunger rate; chitinids get hungry at 1.33x base as guidebook says
   - type: Thirst
   - type: UnpoweredFlashlight
   - type: PointLight


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
reduced chitinid hunger rates from 0.07 to 0.03325 (from 2.8x base to 1.33x base)
this is actually below their pre-upstream hunger rate of 0.0467

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
at current rates, chitinids starve at 25 minutes into the shift
this is extremely funny but horrid compared to other species; they do not need to suffer like this

the guidebook says that chitinids should starve 33% faster and i think this is fair (as a chitinid player, i routinely think to myself "got DAMN i starve fast" even pre-upstream)

chitinids were fr living upstream hunger since pre-upstream

## Technical details
<!-- Summary of code changes for easier review. -->
continuation of https://github.com/ProjectOmu/OmuStation/pull/1622 where i nerfed the overall hunger rate (and fucked up and made allulalos 7.5x thirstier than normal)
single line of YAML

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="634" height="286" alt="image" src="https://github.com/user-attachments/assets/3b6f1669-fdd0-4de0-8d41-9c73fdfb1ba2" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- todo Omustation / License CLA here-->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Duuckie
- tweak: Chitinids now starve at 1.33x the base rate instead of 2.8x the base rate. This means that they overall starve less quickly than pre-upstream.