### PR TITLE
Fixing Thaven/Avali/Allulalo Ethanol Metabolism Rates + Normalizing Allulalo Thirst

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -260,7 +260,7 @@
           - Allulalo # Omu Go fuck yourself you stupid fucking bird motherfucker stealing my time as im upstream merging.
           inverted: true
       - !type:SatiateThirst
-        factor: 4
+        factor: 0.4 # Allulalo metabolize ethanol at 10x, so this is equivalent to water
         conditions:
         - !type:MetabolizerTypeCondition
           type:

--- a/Resources/Prototypes/_Impstation/Body/Organs/thaven.yml
+++ b/Resources/Prototypes/_Impstation/Body/Organs/thaven.yml
@@ -252,7 +252,6 @@
     metabolizerTypes: [Animal, Thaven]
     groups:
     - id: Alcohol
-      rateModifier: 0.1
     - id: Poison
       rateModifier: 0.2
     - id: Narcotic # youuu fekkin druggo

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/allulalo.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/allulalo.yml
@@ -10,7 +10,7 @@
   - type: Hunger
     baseDecayRate: 0.03 # 0.02 # 30% ish more than default # Omu, update for new base rate
   - type: Thirst
-    baseDecayRate: 0.02 # 0.02 # 30% ish more than default
+    baseDecayRate: 0.1625 # 0.02 # 30% ish more than default # Omu, update for new base rate
   - type: Fixtures
     fixtures: # TODO: This needs a second fixture just for mob collisions.
       fix1:

--- a/Resources/Prototypes/_Omu/Body/Organs/allulalo.yml
+++ b/Resources/Prototypes/_Omu/Body/Organs/allulalo.yml
@@ -19,7 +19,7 @@
     metabolizerTypes: [ Allulalo, Animal ]
     groups:
     - id: Alcohol
-      rateModifier: 0.1
+      rateModifier: 10 # This lets allulalo process ethanol at 0.5u/s, which makes it work like water. Yes this causes bacchus's blessing to metabolize fast too
   - type: Liver
   - type: Tag
     tags:

--- a/Resources/Prototypes/_StarLight/Body/Organs/avali.yml
+++ b/Resources/Prototypes/_StarLight/Body/Organs/avali.yml
@@ -46,7 +46,6 @@
       metabolizerTypes: [Avali]
       groups:
         - id: Alcohol
-          rateModifier: 0.1 # removes alcohol very slowly along with the stomach removing it as a drink
 
 - type: entity
   id: OrganAvaliKidneys


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
fixes thaven, avali, and allulalo being unable to process ethanol
allulalo process ethanol 10x faster (at 0.5u/s, the default rate) and are appropriately 130% as thirsty as other species
ethanol restores thirst at an effective rate equal to water, taking 40u to go from totally parched to completely fine

if you start at 350 thirst (the range is from about 310 to 450), normal species will become thirsty at ~6 2/3 minutes shift time and parched (150 or below thirst with 0.75x speed penalty) at ~31 2/3 minutes
allulalo will become thirsty at ~5 minutes and parched at ~24 1/3 minutes
this is just based on the math, but i accounted for the slower rate at which your thirst decreases when you are thirsty (0.8x base rate)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
i fucked up in my first go around of making allulalo abide by upstream thirst
this properly brings allulalo's thirst rate in line with post-upstream species (and tweaks allulalo metabolism rate and ethanol so that ethanol properly acts as an analogue to water)

also fixes avali and thaven not being able to metabolize ethanol, apparently. i didn't hear anything about this before

## Technical details
<!-- Summary of code changes for easier review. -->
builds off the work of https://github.com/Goob-Station/Goob-Station/pull/7086
effectively reverts https://github.com/ProjectOmu/OmuStation/pull/1638

see implementation of https://github.com/Goob-Station/Goob-Station/pull/7086 for thaven/avali ethanol change
when i made the above goobstation PR, i was told to delete the `rateModifier` lines fully instead of commenting them out because full removal of the lines for normal species is the intended solution for all species, downstream or otherwise

changed allulalo thirst from 0.02 (20% of pre-upstream base thirst) to 0.1625 (130% base thirst) in `Resources/Prototypes/_Impstation/Entities/Mobs/Species/allulalo.yml`
changed allulalo ethanol metabolism to 10 times normal speed in `Resources/Prototypes/_Omu/Body/Organs/allulalo.yml`
changed ethanol to restore 1/10 the thirst in `Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml` so that ethanol restores allulalo thirst at the same rate as water (0.4 * 10 from ethanol compared to 4 from water)
it takes 40u of ethanol/water to go from 0 (dead parched) to ~300 (okay, the default state w/no moodle)

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://youtu.be/z3MG-3hmtUk

<img width="674" height="533" alt="image" src="https://github.com/user-attachments/assets/38e4d9d1-36c8-47a3-8ad5-468a78af49d4" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- todo Omustation / License CLA here-->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Duuckie
- fix: Thaven, avali, and allulalo can process ethanol again.
- tweak: Allulalo become thirsty at 130% the base rate (compared to 20% from pre-upstream base) and metabolize ethanol like water (at 0.5u/s and taking 40u to go from parched to not being thirsty at all).