### PR TITLE
Fix missing common languages for cyborgs and librarians

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -286,6 +286,16 @@
     - Tradeband
     - Schechi
     - NewKinPidgin
+    # Omu start - missing common languages
+    - BieselEckeckyik
+    - Calcic
+    - Eckeckyik
+    - Gruntish
+    - Hydraspeak
+    - Nehina
+    - Qiilour
+    - YowKriol
+    # Omu end
     understands:
     - TauCetiBasic
     - Canilunzt
@@ -307,6 +317,16 @@
     - NewKinPidgin
     - NovuNederic
     - Sign # Omustation end
+    # Omu start - missing common languages
+    - BieselEckeckyik
+    - Calcic
+    - Eckeckyik
+    - Gruntish
+    - Hydraspeak
+    - Nehina
+    - Qiilour
+    - YowKriol
+    # Omu end
   - type: ProtectedFromStepTriggers
   - type: DamageOnInteractProtection
     damageProtection:

--- a/Resources/Prototypes/_Goobstation/Objects/Devices/translator_implants.yml
+++ b/Resources/Prototypes/_Goobstation/Objects/Devices/translator_implants.yml
@@ -35,6 +35,14 @@
       - Schechi
       - ValyrianStandard
       - YowKriol
+      # Omu start - missing common languages
+      - BieselEckeckyik
+      - Calcic
+      - Eckeckyik
+      - Gruntish
+      - Hydraspeak
+      - Qiilour
+      # Omu end
       - Azaziba # Depricated Languages -
       - Delvahii
       - Eldritch
@@ -73,6 +81,14 @@
       - Schechi
       - ValyrianStandard
       - YowKriol
+      # Omu start - missing common languages
+      - BieselEckeckyik
+      - Calcic
+      - Eckeckyik
+      - Gruntish
+      - Hydraspeak
+      - Qiilour
+      # Omu end
       - Azaziba # Depricated Languages -
       - Delvahii
       - Eldritch

--- a/Resources/Prototypes/_Goobstation/Objects/Devices/translator_implants.yml
+++ b/Resources/Prototypes/_Goobstation/Objects/Devices/translator_implants.yml
@@ -37,9 +37,7 @@
       - YowKriol
       # Omu start - missing common languages
       - BieselEckeckyik
-      - Calcic
       - Eckeckyik
-      - Gruntish
       - Hydraspeak
       - Qiilour
       # Omu end
@@ -83,9 +81,7 @@
       - YowKriol
       # Omu start - missing common languages
       - BieselEckeckyik
-      - Calcic
       - Eckeckyik
-      - Gruntish
       - Hydraspeak
       - Qiilour
       # Omu end


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->

Cyborgs and librarians cannot understand nor speak several of the common languages (i.e., the languages that are natively spoken by certain species), even though they ought to be able to. This PR fixes that.

The following languages are missing for both cyborgs and librarians:

- Bieselized Eckeckyik (Thaven)
- Eckeckyik (Thaven)
- Hy'drav'tha (Hydrakin)
- Qiilour (Xelthia)

The following languages are missing only for cyborgs:

- Calcic (Plasmaman)
- Gruntish (Oni)
- Nēhina (Feroxi)
- Yow Kriol (Yowie)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

The languages missing seems like an oversight.
This should not affect balancing.

## Technical details
<!-- Summary of code changes for easier review. -->

Entirely YAML. Elements are added to…

- the `understands` and `speaks` lists of the `LanguageKnowledge` component of `BaseBorgChassisNotIonStormable` (regular playable cyborgs descend from this entity).
- the `understood` and `spoken` lists of the `TranslatorImplant` component of `LibrarianTranslatorImplant`.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="223" height="376" alt="missing_common_languages_cyborg" src="https://github.com/user-attachments/assets/8ae966d2-0d43-4a1e-914a-75dd29e90435" />

<img width="223" height="222" alt="missing_common_languages_librarian" src="https://github.com/user-attachments/assets/56d42aaf-8da7-495f-aa94-7af651403332" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- todo Omustation / License CLA here-->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl: asterisksoda
- fix: Cyborgs and librarians can now speak all common languages; a few were missing.