### PR TITLE
Added the jani keys to command maids

### DIFF
--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Wildcards/command_maid.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Wildcards/command_maid.yml
@@ -40,6 +40,7 @@
     eyes: ClothingEyesGlassesCommand
     belt: ClothingBeltJanitorFilled
     shoes: ClothingShoesBootsJackGaloshes
+    pocket1: KeyRingJanitor # Omu
   inhand:
   - AdvMopItem
 


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
I added the jani keys to command maids

## Why / Balance
Consistency with the jani loadout

## Technical details
Yamlslop

## Media
<img width="1221" height="579" alt="image" src="https://github.com/user-attachments/assets/2d779469-ae2b-4796-921c-8f9c37ec2289" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- todo Omustation / License CLA here-->


**Changelog**
:cl: Quill
- add: Added the janitor's key ring to the command maids starting loadout.
