### PR TITLE
Added NanoTask to the AAs PDA

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Devices/pda.yml
@@ -40,5 +40,6 @@
     preinstalled:
       - CrewManifestCartridge
       - NotekeeperCartridge
+      - NanoTaskCartridge # Omu
       - NewsReaderCartridge
       - NanoChatCartridge


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
I added NanoTask to the AAs PDA

## Why / Balance
AA should have access to all the default programs

## Technical details
Yamlslop

## Media
<img width="1097" height="689" alt="image" src="https://github.com/user-attachments/assets/0cc555be-6bd5-4ca3-8fe1-ac58187d9ad8" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- todo Omustation / License CLA here-->

**Changelog**
:cl: Quill
- add: Added NanoTask to the Administrative Assistants PDA.