### PR TITLE
Increased the water amount mops can store

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -46,7 +46,7 @@
   - type: SolutionContainerManager
     solutions:
       absorbed:
-        maxVol: 100
+        maxVol: 200 # Omu - Puddle size revert
   - type: UseDelay
     delay: 0.25
   - type: PhysicalComposition #Goobstation - Recycle update
@@ -99,7 +99,7 @@
       generated:
         reagents:
         - ReagentId: Water
-          Quantity: 5
+          Quantity: 10 # Omu
     - type: SolutionPurge
       solution: absorbed
       preserve:


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
This increases the water amount in mops from 100 to 200 and adjusts the advanced mops regeneration from 5 to 10.

After all of the things Janis needed to go through in the past days (no more water splash melee ground hits, cleanades now being broken) I think this should be a nice little positive change. :)

## Why / Balance
Apparently wizden changed how much units a puddle can store, therefore "nerfing" the mop -> spill action by spawning small puddles instead of a connected big one. This "reverts" the change by effectively "buffing" the mop a bit.

## Technical details
Yamlslop

## Media
### Before Upstream:

[Screencast_20260907_194059.webm](https://github.com/user-attachments/assets/6bb0adbd-faca-474a-9003-ea116a68848e)


### Current:

[Screencast_20260907_193654.webm](https://github.com/user-attachments/assets/5b952727-4735-484f-bdd1-b4a746baf3e4)

### New:

[Screencast_20260907_193406.webm](https://github.com/user-attachments/assets/b9097718-c9ec-41af-8cd1-7e77e52999cb)

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- todo Omustation / License CLA here-->

**Changelog**
:cl: Quill
- tweak: Increased mops water storage to 200u.
