### PR TITLE
[TWEAK] DeltaP Immunity for Reinforced Plasma Windows and nerfing reinforced windows thresholds

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.DeltaPressure.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.DeltaPressure.cs
@@ -181,8 +181,8 @@ public sealed partial class AtmosphereSystem
         float pressure,
         float delta)
     {
-        var aboveMinPressure = pressure > ent.Comp.MinPressure;
-        var aboveMinDeltaPressure = delta > ent.Comp.MinPressureDelta;
+        var aboveMinPressure = pressure > ent.Comp.MinPressure && ent.Comp.MinPressure > 0; // Omu - negative pressure bypass
+        var aboveMinDeltaPressure = delta > ent.Comp.MinPressureDelta && ent.Comp.MinPressureDelta > 0; // Omu - negative pressure bypass
         if (!aboveMinPressure && !aboveMinDeltaPressure)
         {
             SetIsTakingDamageState(ent, false);

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.DeltaPressure.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.DeltaPressure.cs
@@ -181,9 +181,9 @@ public sealed partial class AtmosphereSystem
         float pressure,
         float delta)
     {
-        var aboveMinPressure = pressure > ent.Comp.MinPressure && ent.Comp.MinPressure > 0; // Omu - negative pressure bypass
-        var aboveMinDeltaPressure = delta > ent.Comp.MinPressureDelta && ent.Comp.MinPressureDelta > 0; // Omu - negative pressure bypass
-        if (!aboveMinPressure && !aboveMinDeltaPressure)
+        var aboveMinPressure = pressure > ent.Comp.MinPressure;
+        var aboveMinDeltaPressure = delta > ent.Comp.MinPressureDelta;
+        if (ent.Comp.Bypass || (!aboveMinPressure && !aboveMinDeltaPressure)) // Omu - add bypass
         {
             SetIsTakingDamageState(ent, false);
             return;

--- a/Content.Shared/Atmos/Components/DeltaPressureComponent.cs
+++ b/Content.Shared/Atmos/Components/DeltaPressureComponent.cs
@@ -108,6 +108,14 @@ public sealed partial class DeltaPressureComponent : Component
     /// </summary>
     [DataField]
     public DeltaPressureDamageScalingType ScalingType = DeltaPressureDamageScalingType.Threshold;
+
+    // Omu start
+    /// <summary>
+    /// Whether this entity will ignore all delta pressure damage/enqueue
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool Bypass = false;
+    // Omu end
 }
 
 /// <summary>

--- a/Resources/Prototypes/Atmospherics/Thresholds/deltapressure.yml
+++ b/Resources/Prototypes/Atmospherics/Thresholds/deltapressure.yml
@@ -49,8 +49,8 @@
   id: BaseDeltaPressureReinforcedGlass
   components:
   - type: DeltaPressure
-    minPressure: 15000
-    minPressureDelta: 10000
+    minPressure: 4500
+    minPressureDelta: 2000
     scalingType: Threshold
 
 ## For quarter reinforced glass windows
@@ -60,7 +60,7 @@
   components:
   - type: DeltaPressure
     minPressure: 3750
-    minPressureDelta: 2500
+    minPressureDelta: 1800
 
 ## For glass windows
 - type: entity

--- a/Resources/Prototypes/Atmospherics/Thresholds/deltapressure.yml
+++ b/Resources/Prototypes/Atmospherics/Thresholds/deltapressure.yml
@@ -49,8 +49,8 @@
   id: BaseDeltaPressureReinforcedGlass
   components:
   - type: DeltaPressure
-    minPressure: 4500
-    minPressureDelta: 2000
+    minPressure: 4500 # Omu 
+    minPressureDelta: 2000 # Omu
     scalingType: Threshold
 
 ## For quarter reinforced glass windows
@@ -60,7 +60,7 @@
   components:
   - type: DeltaPressure
     minPressure: 3750
-    minPressureDelta: 1800
+    minPressureDelta: 1800 # Omu
 
 ## For glass windows
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
@@ -3,7 +3,7 @@
 - type: entity
   id: ReinforcedPlasmaWindow
   name: reinforced plasma window
-  parent: [BaseDeltaPressureReinforcedPlasma, WindowRCDResistant]
+  parent: [BaseDeltaPressureImmune, WindowRCDResistant]
   components:
   - type: Sprite
     drawdepth: WallTops
@@ -60,7 +60,7 @@
 
 - type: entity
   id: PlasmaReinforcedWindowDirectional
-  parent: [BaseDeltaPressureReinforcedPlasmaQuarter, WindowDirectionalRCDResistant]
+  parent: [BaseDeltaPressureImmune, WindowDirectionalRCDResistant]
   name: directional reinforced plasma window
   description: Don't smudge up the glass down there.
   placement:

--- a/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
@@ -3,7 +3,7 @@
 - type: entity
   id: ReinforcedPlasmaWindow
   name: reinforced plasma window
-  parent: [BaseDeltaPressureImmune, WindowRCDResistant]
+  parent: [BaseDeltaPressureImmune, WindowRCDResistant] # Omu, make rplasma immune to DeltaP
   components:
   - type: Sprite
     drawdepth: WallTops
@@ -60,7 +60,7 @@
 
 - type: entity
   id: PlasmaReinforcedWindowDirectional
-  parent: [BaseDeltaPressureImmune, WindowDirectionalRCDResistant]
+  parent: [BaseDeltaPressureImmune, WindowDirectionalRCDResistant] # Omu, make rplasma immune to DeltaP
   name: directional reinforced plasma window
   description: Don't smudge up the glass down there.
   placement:

--- a/Resources/Prototypes/_Omu/Atmospherics/Thresholds/deltapressure.yml
+++ b/Resources/Prototypes/_Omu/Atmospherics/Thresholds/deltapressure.yml
@@ -3,5 +3,6 @@
   id: BaseDeltaPressureImmune
   components:
   - type: DeltaPressure
-    minPressure: -1
-    minPressureDelta: -1
+    bypass: true
+    minPressure: 150000
+    minPressureDelta: 100000

--- a/Resources/Prototypes/_Omu/Atmospherics/Thresholds/deltapressure.yml
+++ b/Resources/Prototypes/_Omu/Atmospherics/Thresholds/deltapressure.yml
@@ -1,0 +1,7 @@
+- type: entity
+  abstract: true
+  id: BaseDeltaPressureImmune
+  components:
+  - type: DeltaPressure
+    minPressure: -1
+    minPressureDelta: -1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Reinforced Plasma Windows -> Immune to DeltaPressure damage

Reinforced Windows :
- minPressure -> 4500 kPa
- minPressureDelta -> 2000 kPa

Reinforced Windows Diagonals :
- minPressure -> 3750 kPa
- minPressureDelta -> 1800 kpA

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The current state of DeltaP does not consistently contribute to the round except for blowing up the TEG burn chamber windows. 
Most map design use reinforced windows for mapping, so reducing the threshold for these windows will actually let players see it in a round. 

**_With this change, over pressurizing distro CAN break reinforced windows. Windows to space that see 2000 kPa will take damage._**

## Technical details
<!-- Summary of code changes for easier review. -->
Small change to the DeltaPressure logic to bypass entities with negative thresholds for pressure.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Not needed.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- todo Omustation / License CLA here-->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--

- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Made reinforced plasma windows immune to pressure damage.
- tweak: Lowered normal reinforced windows to take damage at a pressure difference of 2000 kPa!