### PR TITLE
Fix sleep regression caused by xenobio change

### DIFF
--- a/Content.Shared/Bed/Sleep/SleepingSystem.cs
+++ b/Content.Shared/Bed/Sleep/SleepingSystem.cs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 // Goobstation - start
-using Content.Goobstation.Common.Sleeping; 
+using Content.Goobstation.Common.Sleeping;
 using Content.Shared._Goobstation.Sleep;
 // Goobstation - end
 using Content.Shared.Actions;
@@ -326,7 +326,8 @@ public sealed partial class SleepingSystem : EntitySystem
         var ev = new SleepOverrideEvent();
         RaiseLocalEvent(ent.Owner, ref ev);
 
-        if (ev.MobState != MobState.Alive)
+        // Omu - the only system that subscribes to this event at the time of writing is a xenobio system.
+        if (ev.MobState is MobState.Critical or MobState.Dead)
             return false;
 
         // Goobstation - end


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
This PR makes it so entities can actually fall asleep when knocked out by things that aren't a slime being latched onto them.

## Why / Balance
Sleeping is a core system, with too many interactions to leave in a nonfunctional state.

## Technical details
The xenobio changes from the upstream merge #1535 (specifically with commit [842b03b](https://github.com/Goob-Station/Goob-Station/pull/7049)) introduced a `SleepOverrideEvent` with a possible intent to prevent creatures that are crit or dead from falling asleep. At the time of this PR, the only system that subscribes to the event is in `SlimeLatchSystem`.

The event is raised anytime an attempt to sleep is made, and due to all but one sleep source not subscribing to the event, the event's `MobState` stays at a default value of `Invalid`. This causes all attempts to sleep outside of that one source in xenobio to be rejected.

The change in this PR allows systems that don't subscribe to `SleepOverrideEvent` to still inflict sleep.

## Media
<img width="830" height="555" alt="image" src="https://github.com/user-attachments/assets/ebb1568f-463b-4b9b-8fdb-20dc3333e853" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

<!-- todo Omustation / License CLA here-->

## Breaking changes
None

**Changelog**
:cl: Jerulean
- fix: Fixed the mass insomnia that's gripped the station. Falling asleep and the many ways to snooze work again.

