### PR TITLE
Fix missing species languages on librarian translator implant

### DIFF
--- a/Resources/Prototypes/_Goobstation/Objects/Devices/translator_implants.yml
+++ b/Resources/Prototypes/_Goobstation/Objects/Devices/translator_implants.yml
@@ -17,16 +17,21 @@
       - Tradeband
       - Sign
       - SpaceItalian # Job Specific -
-      - Bubblish # Species Languages -
+      # Species Languages -
+      - BieselEckeckyik # Omu
+      - Bubblish
       - Calcic
       - Canilunzt
       - Chittin
+      - Eckeckyik # Omu
       - Gruntish
+      - Hydraspeak # Omu
       - NewKinPidgin # = Ka'rakk
       - Marish
       - Moffic
       - Nehina
       - Nekomimetic
+      - Qiilour # Omu
       - RakkProper # Omu
       - RobotTalk
       - RootSpeak
@@ -55,16 +60,21 @@
       - Tradeband
       - Sign
       - SpaceItalian # Job Specific -
-      - Bubblish # Species Languages -
+      # Species Languages -
+      - BieselEckeckyik # Omu
+      - Bubblish
       - Calcic
       - Canilunzt
       - Chittin
+      - Eckeckyik # Omu
       - Gruntish
+      - Hydraspeak # Omu
       - NewKinPidgin # = Ka'rakk
       - Marish
       - Moffic
       - Nehina
       - Nekomimetic
+      - Qiilour # Omu
       - RakkProper # Omu
       - RobotTalk
       - RootSpeak


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->

Allows librarians to understand and speak Bieselized Eckeckyik, Eckeckyik, Hy'drav'tha, and Qiilour.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Librarians are supposed to be able to understand all crew languages. They do not.

This is technically a minor buff to librarians.

## Technical details
<!-- Summary of code changes for easier review. -->

Entirely YAML; entries are added to the `understood` and `spoken` lists of the `TranslatorImplant` component of the librarian translator implant.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="388" height="246" alt="missing_languages_for_librarians_1" src="https://github.com/user-attachments/assets/a5d89d42-fa87-4cdb-bcb6-08c00b7c5989" />
<img width="393" height="244" alt="missing_languages_for_librarians_2" src="https://github.com/user-attachments/assets/6c64e3aa-3dd3-4dc2-b4be-c055920b82a7" />
<img width="387" height="247" alt="missing_languages_for_librarians_3" src="https://github.com/user-attachments/assets/84d731b9-7d96-4b06-9f66-47c22985e32f" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- todo Omustation / License CLA here-->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl: asterisksoda
- fix: Librarians can now speak and understand all crew languages; Bieselized Eckeckyik, Eckeckyik, Hy'drav'tha, and Qiilour were previously missing.