### PR TITLE
Remove functionality from the Gnash plush

### DIFF
--- a/Resources/Prototypes/_Omu/Entities/Objects/Fun/plushies.yml
+++ b/Resources/Prototypes/_Omu/Entities/Objects/Fun/plushies.yml
@@ -857,8 +857,6 @@
     wideAnimationRotation: 180
     soundHit:
       path: /Audio/Effects/bite.ogg
-
-
   - type: GasAnalyzer
   - type: ActivatableUI
     inHandsOnly: true

--- a/Resources/Prototypes/_Omu/Entities/Objects/Fun/plushies.yml
+++ b/Resources/Prototypes/_Omu/Entities/Objects/Fun/plushies.yml
@@ -857,30 +857,3 @@
     wideAnimationRotation: 180
     soundHit:
       path: /Audio/Effects/bite.ogg
-  - type: GasAnalyzer
-  - type: ActivatableUI
-    inHandsOnly: true
-    singleUser: true
-    requireActiveHand: false
-    key: enum.GasAnalyzerUiKey.Key
-  - type: UserInterface
-    interfaces:
-      enum.GasAnalyzerUiKey.Key:
-        type: GasAnalyzerBoundUserInterface
-  - type: PointLight # the glow is subtle. It's just enough to make the mantle visible in pitch black lighting, but won't help you see much.
-    radius: 1.45
-    energy: 2
-    offset: 0,0.4
-    color: "#C2FA1F" # this will match the colour of the beast's eyes when worn, this is just a default.
-    mask: /Textures/Effects/LightMasks/cone.png
-    autoRot: true
-    containerOccluded: true # this makes the mantle illuminate itself.
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 5
-        reagents:
-        - ReagentId: Uranium
-          Quantity: 2.5
-        - ReagentId: Radium
-          Quantity: 2.5


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
Removed the gas analyzer functionality, the radioactive glow, and the uranium/radium nutritional content of the Gnash plush

## Why / Balance
Crew plushies having *any* functionality is apparently against some policy that precedes me, but was only told about a few hours ago. 
As a part of this initiative (and budget cuts), the radioactive fuel of these Gnash plushies have been removed, along with the atmospheric vibe readings they once gave.

## Technical details
Just removals in this one.

## Media
Not really required.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

<!-- todo Omustation / License CLA here-->

## Breaking changes
None to be had here

**Changelog**
:cl:
- tweak: The Gnash plush is no longer a gas analyzer. Pure plush friend.
