### PR TITLE
Squakroachs no longer turn into the sun on spawn in

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/NPCs/animals.yml
@@ -39,7 +39,7 @@
         shape:
           !type:PhysShapeCircle
           radius: 0.2
-        density: 0.007
+        density: 3 # omu edit -- Fix to ensure squackroach's dont combust on spawn -- Was 0.007
         mask:
         - SmallMobMask
         layer:


### PR DESCRIPTION
## About the PR
Change Squakroach density to a reasonable number

## Why / Balance
allows them to exist again

## Technical details
Changed density from `0.007` to `3`

## Media
<img width="105" height="98" alt="image" src="https://github.com/user-attachments/assets/383b24b3-dfa4-466f-be05-51d8ad1d37fd" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Squakroach density fixed so they no longer become hotter than the sun